### PR TITLE
fix(server): lazy-load sharp so a missing native dep can't crash boot (#361)

### DIFF
--- a/server/optimize-images.mjs
+++ b/server/optimize-images.mjs
@@ -8,20 +8,28 @@ import { join, basename, extname } from "node:path";
  * path. Loading it on first use keeps the server alive and fails only the
  * image-optimization tool — at call time, with an actionable message (#361).
  *
+ * Caches the import Promise (not the resolved value) so concurrent callers
+ * share one load, and resets on failure so a retry can succeed after a later
+ * `npm install` without restarting the server. The original failure is kept on
+ * `.cause` — a load can fail for reasons other than absence (ABI mismatch,
+ * wrong Node version, corrupted install), and discarding it would be misleading.
+ *
  * @returns {Promise<import("sharp").default>}
  */
-let _sharp;
-async function loadSharp() {
-  if (!_sharp) {
-    try {
-      _sharp = (await import("sharp")).default;
-    } catch {
-      throw new Error(
-        "image optimization requires the 'sharp' package — run `npm install` (or `npm install sharp`)",
-      );
-    }
+let _sharpPromise;
+function loadSharp() {
+  if (!_sharpPromise) {
+    _sharpPromise = import("sharp")
+      .then((m) => m.default)
+      .catch((cause) => {
+        _sharpPromise = undefined;
+        throw new Error(
+          "image optimization requires the 'sharp' package — run `npm install` (or `npm install sharp`)",
+          { cause },
+        );
+      });
   }
-  return _sharp;
+  return _sharpPromise;
 }
 
 /**

--- a/server/optimize-images.mjs
+++ b/server/optimize-images.mjs
@@ -1,6 +1,28 @@
 import { mkdirSync, copyFileSync, existsSync } from "node:fs";
 import { join, basename, extname } from "node:path";
-import sharp from "sharp";
+
+/**
+ * Lazily resolve `sharp`. It's an optional native dependency: importing it at
+ * module top level would crash the whole MCP server at boot when it's absent
+ * (stale/partial node_modules), because this module sits on the apply_edit boot
+ * path. Loading it on first use keeps the server alive and fails only the
+ * image-optimization tool — at call time, with an actionable message (#361).
+ *
+ * @returns {Promise<import("sharp").default>}
+ */
+let _sharp;
+async function loadSharp() {
+  if (!_sharp) {
+    try {
+      _sharp = (await import("sharp")).default;
+    } catch {
+      throw new Error(
+        "image optimization requires the 'sharp' package — run `npm install` (or `npm install sharp`)",
+      );
+    }
+  }
+  return _sharp;
+}
 
 /**
  * Optimize a single image: write a primary WebP plus responsive variants,
@@ -18,6 +40,7 @@ import sharp from "sharp";
  * }>}
  */
 export async function optimizeImage(inputFile, options) {
+  const sharp = await loadSharp();
   const widths = options.widths ?? [480, 768, 1024, 1920];
   const outputDir = options.outputDir;
   if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });

--- a/template/server/optimize-images.mjs
+++ b/template/server/optimize-images.mjs
@@ -8,20 +8,28 @@ import { join, basename, extname } from "node:path";
  * path. Loading it on first use keeps the server alive and fails only the
  * image-optimization tool — at call time, with an actionable message (#361).
  *
+ * Caches the import Promise (not the resolved value) so concurrent callers
+ * share one load, and resets on failure so a retry can succeed after a later
+ * `npm install` without restarting the server. The original failure is kept on
+ * `.cause` — a load can fail for reasons other than absence (ABI mismatch,
+ * wrong Node version, corrupted install), and discarding it would be misleading.
+ *
  * @returns {Promise<import("sharp").default>}
  */
-let _sharp;
-async function loadSharp() {
-  if (!_sharp) {
-    try {
-      _sharp = (await import("sharp")).default;
-    } catch {
-      throw new Error(
-        "image optimization requires the 'sharp' package — run `npm install` (or `npm install sharp`)",
-      );
-    }
+let _sharpPromise;
+function loadSharp() {
+  if (!_sharpPromise) {
+    _sharpPromise = import("sharp")
+      .then((m) => m.default)
+      .catch((cause) => {
+        _sharpPromise = undefined;
+        throw new Error(
+          "image optimization requires the 'sharp' package — run `npm install` (or `npm install sharp`)",
+          { cause },
+        );
+      });
   }
-  return _sharp;
+  return _sharpPromise;
 }
 
 /**

--- a/template/server/optimize-images.mjs
+++ b/template/server/optimize-images.mjs
@@ -1,6 +1,28 @@
 import { mkdirSync, copyFileSync, existsSync } from "node:fs";
 import { join, basename, extname } from "node:path";
-import sharp from "sharp";
+
+/**
+ * Lazily resolve `sharp`. It's an optional native dependency: importing it at
+ * module top level would crash the whole MCP server at boot when it's absent
+ * (stale/partial node_modules), because this module sits on the apply_edit boot
+ * path. Loading it on first use keeps the server alive and fails only the
+ * image-optimization tool — at call time, with an actionable message (#361).
+ *
+ * @returns {Promise<import("sharp").default>}
+ */
+let _sharp;
+async function loadSharp() {
+  if (!_sharp) {
+    try {
+      _sharp = (await import("sharp")).default;
+    } catch {
+      throw new Error(
+        "image optimization requires the 'sharp' package — run `npm install` (or `npm install sharp`)",
+      );
+    }
+  }
+  return _sharp;
+}
 
 /**
  * Optimize a single image: write a primary WebP plus responsive variants,
@@ -18,6 +40,7 @@ import sharp from "sharp";
  * }>}
  */
 export async function optimizeImage(inputFile, options) {
+  const sharp = await loadSharp();
   const widths = options.widths ?? [480, 768, 1024, 1920];
   const outputDir = options.outputDir;
   if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });

--- a/test/fixtures/sharp-absent/hooks.mjs
+++ b/test/fixtures/sharp-absent/hooks.mjs
@@ -3,9 +3,9 @@
 // Used via `node --import ./register.mjs <probe>` in optimize-images-sharp-optional.test.js.
 export async function resolve(specifier, context, nextResolve) {
   if (specifier === "sharp") {
-    const err = new Error(
-      "Cannot find package 'sharp' imported from optimize-images.mjs (simulated absent)",
-    );
+    // The hook intercepts any `import "sharp"` in the process, so the message
+    // stays attribution-free rather than naming a specific importer.
+    const err = new Error("Cannot find package 'sharp' (simulated absent for testing #361)");
     err.code = "ERR_MODULE_NOT_FOUND";
     throw err;
   }

--- a/test/fixtures/sharp-absent/hooks.mjs
+++ b/test/fixtures/sharp-absent/hooks.mjs
@@ -1,0 +1,13 @@
+// ESM resolution hook that simulates `sharp` being absent from node_modules,
+// reproducing the ERR_MODULE_NOT_FOUND a stale/partial checkout hits (#361).
+// Used via `node --import ./register.mjs <probe>` in optimize-images-sharp-optional.test.js.
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === "sharp") {
+    const err = new Error(
+      "Cannot find package 'sharp' imported from optimize-images.mjs (simulated absent)",
+    );
+    err.code = "ERR_MODULE_NOT_FOUND";
+    throw err;
+  }
+  return nextResolve(specifier, context);
+}

--- a/test/fixtures/sharp-absent/register.mjs
+++ b/test/fixtures/sharp-absent/register.mjs
@@ -1,0 +1,2 @@
+import { register } from "node:module";
+register("./hooks.mjs", import.meta.url);

--- a/test/optimize-images-sharp-optional.test.js
+++ b/test/optimize-images-sharp-optional.test.js
@@ -26,11 +26,17 @@ const OPTIMIZE = join(REPO_ROOT, "server", "optimize-images.mjs");
 
 /** Run a snippet in a subprocess with `sharp` made unresolvable. Returns stdout. */
 function runWithoutSharp(snippet) {
-  return execFileSync(
-    process.execPath,
-    ["--import", REGISTER, "--input-type=module", "-e", snippet],
-    { cwd: REPO_ROOT, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] },
-  );
+  try {
+    return execFileSync(
+      process.execPath,
+      ["--import", REGISTER, "--input-type=module", "-e", snippet],
+      { cwd: REPO_ROOT, encoding: "utf-8" },
+    );
+  } catch (e) {
+    // execFileSync only surfaces "Command failed" on a non-zero exit; pull the
+    // real stderr/stdout forward so a CI failure here is diagnosable.
+    throw new Error(`subprocess failed:\n${e.stderr ?? ""}\n${e.stdout ?? ""}`, { cause: e });
+  }
 }
 
 describe("sharp is optional (#361)", () => {

--- a/test/optimize-images-sharp-optional.test.js
+++ b/test/optimize-images-sharp-optional.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ---------------------------------------------------------------------------
+// sharp is an OPTIONAL native dep (#361)
+//
+// The MCP server's boot graph reaches optimize-images.mjs via
+// apply-edit-dispatcher.mjs. A top-level `import sharp` there means a missing
+// `sharp` (stale/partial node_modules) throws ERR_MODULE_NOT_FOUND during graph
+// load and takes down the whole server before it ever listens. sharp must load
+// lazily so only the image-optimization tool fails — at call time, with a clear
+// message — when it's absent.
+//
+// We simulate sharp's absence with an ESM resolution hook (fixtures/sharp-absent)
+// run in a subprocess, so the test is faithful even though sharp is installed in
+// the dev/CI environment.
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const REGISTER = join(__dirname, "fixtures", "sharp-absent", "register.mjs");
+const DISPATCHER = join(REPO_ROOT, "server", "apply-edit-dispatcher.mjs");
+const OPTIMIZE = join(REPO_ROOT, "server", "optimize-images.mjs");
+
+/** Run a snippet in a subprocess with `sharp` made unresolvable. Returns stdout. */
+function runWithoutSharp(snippet) {
+  return execFileSync(
+    process.execPath,
+    ["--import", REGISTER, "--input-type=module", "-e", snippet],
+    { cwd: REPO_ROOT, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+}
+
+describe("sharp is optional (#361)", () => {
+  it("loads the apply_edit boot module graph when sharp is absent", () => {
+    const out = runWithoutSharp(
+      `import(${JSON.stringify(DISPATCHER)})` +
+        `.then((m) => console.log(typeof m.applyEdit === "function" ? "BOOT_OK" : "BOOT_BAD"))`,
+    );
+    expect(out).toContain("BOOT_OK");
+  });
+
+  it("fails image optimization at call time with an actionable sharp error", () => {
+    const out = runWithoutSharp(
+      `const { optimizeImage } = await import(${JSON.stringify(OPTIMIZE)});` +
+        `try { await optimizeImage("/nonexistent.jpg", { outputDir: "/tmp" }); console.log("NO_THROW"); }` +
+        `catch (e) { console.log("ERR:" + e.message); }`,
+    );
+    expect(out).toContain("ERR:");
+    expect(out.toLowerCase()).toContain("sharp");
+    expect(out).not.toContain("NO_THROW");
+  });
+});


### PR DESCRIPTION
Closes #361.

## Problem

`server/optimize-images.mjs` sits on the MCP server's `apply_edit` boot path:

```
index.mjs → index-tools.mjs → apply-edit-dispatcher.mjs → optimize-images.mjs
```

Its top-level `import sharp from "sharp"` meant a missing/partial `sharp` (stale or incomplete `node_modules`) threw `ERR_MODULE_NOT_FOUND` during module-graph load — **crashing the whole server before it ever listened**. CI installs deps fresh so it's masked there; it bites stale local checkouts. Downstream this looked like a "MCP cold-start timing flake" (Anglesite-app#221 / #231) — the server was dead, not slow.

## Fix

Resolve `sharp` lazily through a cached `loadSharp()` helper called inside `optimizeImage`:

- The server boots normally without `sharp`.
- `apply_edit` and every other tool work unaffected.
- Only the image-optimization tool fails — **at call time**, with an actionable `"image optimization requires the 'sharp' package — run npm install"` message instead of a process crash.
- Behavior is identical when `sharp` is present.

Mirrored byte-identically into `template/server/optimize-images.mjs` (the packaging guard enforces this). Audited the rest of `server/` for the same eager-native-import pattern (the issue flagged `satori`) — **`optimize-images.mjs` was the only one**.

## Acceptance criteria

- [x] `node server/index.mjs` starts and serves with `sharp` absent
- [x] The image-optimization tool returns a clear, actionable error (not a crash) when `sharp` is missing
- [x] With `sharp` present, image optimization behaves exactly as today
- [x] Audited other server modules for the same pattern

## Tests

New `test/optimize-images-sharp-optional.test.js` simulates `sharp`'s absence with an ESM resolution hook (`test/fixtures/sharp-absent/`) run in a subprocess — faithful even though `sharp` is installed in CI. It asserts:

1. the `apply_edit` boot module graph loads when `sharp` is absent, and
2. optimization fails at call time with a clear `sharp` error.

Full suite: **2646 passed**. The one failing test (`optimize-images-packaging.test.js` scaffold e2e) is pre-existing — it fails identically on `main` because the scaffolded sandbox isn't `npm install`ed, so `sharp` isn't resolvable there. Not a regression from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)