### PR TITLE
fix(indieweb): block dangerous URL schemes in webmention render (XSS)

### DIFF
--- a/template/worker/site-entry.js
+++ b/template/worker/site-entry.js
@@ -304,21 +304,41 @@ class WebmentionInjector {
   }
 }
 
-function renderMention(m) {
+export function renderMention(m) {
   const name = escapeHtml(m.author_name || m.author_url || "Someone");
-  const photo = m.author_photo
-    ? `<img class="u-photo" src="${escapeHtml(m.author_photo)}" alt="" width="48" height="48" />`
+  // Webmention fields come from arbitrary external sites. escapeHtml() blocks
+  // tag injection but NOT dangerous URL schemes — a `javascript:`/`data:` value
+  // in an href/src is executable. Only http/https URLs may reach an attribute.
+  const photoUrl = safeUrl(m.author_photo);
+  const authorUrl = safeUrl(m.author_url);
+  const url = safeUrl(m.url);
+  const photo = photoUrl
+    ? `<img class="u-photo" src="${escapeHtml(photoUrl)}" alt="" width="48" height="48" />`
     : "";
-  const author = m.author_url
-    ? `<a class="p-author h-card u-url" href="${escapeHtml(m.author_url)}">${name}</a>`
+  const author = authorUrl
+    ? `<a class="p-author h-card u-url" rel="nofollow ugc noopener" href="${escapeHtml(authorUrl)}">${name}</a>`
     : `<span class="p-author">${name}</span>`;
   const content = m.content
     ? `<div class="p-content">${escapeHtml(m.content)}</div>`
     : "";
-  const permalink = m.url
-    ? `<a class="u-url" href="${escapeHtml(m.url)}">permalink</a>`
+  const permalink = url
+    ? `<a class="u-url" rel="nofollow ugc noopener" href="${escapeHtml(url)}">permalink</a>`
     : "";
   return `<li class="h-cite">${photo}${author}${content}${permalink}</li>`;
+}
+
+// Return the URL only if it parses to an http(s) URL, else null. Blocks
+// javascript:/data:/vbscript:/mailto: and any other scheme from reaching an
+// href/src attribute. Relative URLs are rejected (no base to resolve against
+// here); webmention author/permalink URLs are absolute in practice.
+export function safeUrl(value) {
+  if (!value) return null;
+  try {
+    const u = new URL(String(value).trim());
+    return u.protocol === "http:" || u.protocol === "https:" ? u.href : null;
+  } catch {
+    return null;
+  }
 }
 
 function escapeHtml(value) {

--- a/template/worker/site-entry.js
+++ b/template/worker/site-entry.js
@@ -316,13 +316,13 @@ export function renderMention(m) {
     ? `<img class="u-photo" src="${escapeHtml(photoUrl)}" alt="" width="48" height="48" />`
     : "";
   const author = authorUrl
-    ? `<a class="p-author h-card u-url" rel="nofollow ugc noopener" href="${escapeHtml(authorUrl)}">${name}</a>`
+    ? `<a class="p-author h-card u-url" rel="nofollow ugc noopener noreferrer" href="${escapeHtml(authorUrl)}">${name}</a>`
     : `<span class="p-author">${name}</span>`;
   const content = m.content
     ? `<div class="p-content">${escapeHtml(m.content)}</div>`
     : "";
   const permalink = url
-    ? `<a class="u-url" rel="nofollow ugc noopener" href="${escapeHtml(url)}">permalink</a>`
+    ? `<a class="u-url" rel="nofollow ugc noopener noreferrer" href="${escapeHtml(url)}">permalink</a>`
     : "";
   return `<li class="h-cite">${photo}${author}${content}${permalink}</li>`;
 }

--- a/tests/indieweb-render-safety.test.ts
+++ b/tests/indieweb-render-safety.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Webmention edge-render output safety (Anglesite/anglesite#363, problem 3).
+ *
+ * `renderMention()` interpolates externally-sourced webmention fields
+ * (author_url, author_photo, url) into `href`/`src`. Escaping the value is not
+ * enough: a verified mention whose URL is `javascript:…` or `data:…` renders an
+ * executable link/`src` — stored XSS, since webmention data comes from arbitrary
+ * external sites. Only http/https URLs may reach an attribute.
+ */
+import { describe, it, expect } from "vitest";
+import { renderMention } from "../template/worker/site-entry.js";
+
+const HOSTILE = [
+  "javascript:alert(1)",
+  "JavaScript:alert(1)",
+  " javascript:alert(1)",
+  "data:text/html,<script>alert(1)</script>",
+  "vbscript:msgbox(1)",
+  "javascript:alert(1)",
+];
+
+describe("renderMention URL-scheme safety", () => {
+  it("never emits a javascript:/data:/vbscript: href for author_url", () => {
+    for (const url of HOSTILE) {
+      const html = renderMention({ author_name: "X", author_url: url });
+      expect(html, url).not.toMatch(/href="[^"]*(javascript|data|vbscript):/i);
+      // The name still renders, just not as a link.
+      expect(html).toContain("X");
+    }
+  });
+
+  it("never emits a hostile src for author_photo", () => {
+    for (const url of HOSTILE) {
+      const html = renderMention({ author_name: "X", author_photo: url });
+      expect(html, url).not.toMatch(/src="[^"]*(javascript|data|vbscript):/i);
+    }
+  });
+
+  it("never emits a hostile permalink href for url", () => {
+    for (const url of HOSTILE) {
+      const html = renderMention({ author_name: "X", url });
+      expect(html, url).not.toMatch(/href="[^"]*(javascript|data|vbscript):/i);
+    }
+  });
+
+  it("renders http/https URLs as links with rel hardening", () => {
+    const html = renderMention({
+      author_name: "Alice",
+      author_url: "https://alice.example/",
+      author_photo: "https://alice.example/me.jpg",
+      content: "Nice!",
+      url: "https://alice.example/reply/1",
+    });
+    expect(html).toContain('href="https://alice.example/"');
+    expect(html).toContain('src="https://alice.example/me.jpg"');
+    expect(html).toContain('href="https://alice.example/reply/1"');
+    // External, user-generated content: don't pass link equity or window handle.
+    expect(html).toMatch(/rel="[^"]*nofollow[^"]*"/);
+    expect(html).toMatch(/rel="[^"]*ugc[^"]*"/);
+    expect(html).toMatch(/rel="[^"]*noopener[^"]*"/);
+  });
+
+  it("still escapes HTML metacharacters in text fields", () => {
+    const html = renderMention({
+      author_name: '<img src=x onerror=alert(1)>',
+      content: "<b>hi</b>",
+    });
+    expect(html).not.toContain("<img src=x");
+    expect(html).not.toContain("<b>hi</b>");
+    expect(html).toContain("&lt;");
+  });
+});

--- a/tests/indieweb-render-safety.test.ts
+++ b/tests/indieweb-render-safety.test.ts
@@ -16,7 +16,11 @@ const HOSTILE = [
   " javascript:alert(1)",
   "data:text/html,<script>alert(1)</script>",
   "vbscript:msgbox(1)",
-  "javascript:alert(1)",
+  "mailto:me@example.com",
+  "file:///etc/passwd",
+  // Unicode-confusable scheme: U+FF4A FULLWIDTH LATIN SMALL LETTER J. The WHATWG
+  // URL parser rejects a non-ASCII scheme start, so safeUrl drops it via catch.
+  "ｊavascript:alert(1)",
 ];
 
 describe("renderMention URL-scheme safety", () => {
@@ -54,10 +58,22 @@ describe("renderMention URL-scheme safety", () => {
     expect(html).toContain('href="https://alice.example/"');
     expect(html).toContain('src="https://alice.example/me.jpg"');
     expect(html).toContain('href="https://alice.example/reply/1"');
-    // External, user-generated content: don't pass link equity or window handle.
+    // External, user-generated content: don't pass link equity, a window handle,
+    // or a Referer signal that this URL appeared as a webmention here.
     expect(html).toMatch(/rel="[^"]*nofollow[^"]*"/);
     expect(html).toMatch(/rel="[^"]*ugc[^"]*"/);
     expect(html).toMatch(/rel="[^"]*noopener[^"]*"/);
+    expect(html).toMatch(/rel="[^"]*noreferrer[^"]*"/);
+  });
+
+  it("never lets a hostile author_url reach an attribute via the name fallback", () => {
+    // With author_name absent, the visible text falls back to author_url. A
+    // hostile scheme must render only as escaped text, never inside href/src.
+    const html = renderMention({ author_url: "javascript:alert(1)" });
+    expect(html).not.toMatch(/href="[^"]*javascript:/i);
+    expect(html).not.toMatch(/src="[^"]*javascript:/i);
+    // It appears as escaped text in the fallback span instead.
+    expect(html).toContain('<span class="p-author">javascript:alert(1)</span>');
   });
 
   it("still escapes HTML metacharacters in text fields", () => {


### PR DESCRIPTION
## Problem (HIGH — stored XSS)

`renderMention()` in `template/worker/site-entry.js` interpolates externally-sourced webmention fields (`author_url`, `author_photo`, `url`) into `href`/`src` with only `escapeHtml()`. Escaping blocks tag injection but **not dangerous URL schemes** — a verified webmention whose `author_url`/`url` is `javascript:…` (or `data:…`) rendered an executable link/`src`. Webmention data originates from arbitrary external sites, so this is stored XSS on any page with mentions once Webmention is enabled.

## Fix

- `safeUrl(value)` — parse and allow through only `http:`/`https:`; otherwise drop the attribute. The author name still renders, just not as a link.
- Add `rel="nofollow ugc noopener"` to mention anchors (external, user-generated content shouldn't pass link equity or a window handle).

## Tests (TDD)

`tests/indieweb-render-safety.test.ts` — written failing first, then fixed:
- `javascript:` / `JavaScript:` / ` javascript:` / `data:` / `vbscript:` are dropped from `href` and `src`
- `http`/`https` pass through, with `nofollow`/`ugc`/`noopener` present
- text fields remain HTML-escaped

26/26 pass (render-safety + existing dispatch suite). Scoped to this fix only; does not touch the in-flight #361 sharp work or the broader #363 API-alignment effort.

Addresses problem 3 of #363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)