### PR TITLE
feat(indieweb): passkey-backed IndieAuth — spec, plan & implementation (#363)

### DIFF
--- a/docs/decisions/0022-passkey-indieauth.md
+++ b/docs/decisions/0022-passkey-indieauth.md
@@ -1,0 +1,57 @@
+---
+status: accepted
+date: 2026-06-21
+decision-makers: [Anglesite maintainers]
+---
+
+# Authenticate the IndieAuth owner with passkeys (`@dwk/webauthn`)
+
+## Context and Problem Statement
+
+ADR-0020 chose to compose `@dwk/indieauth` into `site-entry.js` for self-owned
+IndieAuth. That package deliberately leaves **authentication and consent** to the
+deployer via a required `approveAuthorization` hook — it mints no token until the
+deployer proves the owner's identity and obtains consent. Anglesite had no such
+mechanism, so the endpoint could not even construct. We need a way for a
+non-technical owner to prove they are the owner, with no third-party identity
+provider (ADR-0011).
+
+## Decision
+
+Authenticate the owner with **passkeys** via `@dwk/webauthn`, plus printable
+single-use backup codes, all served from the owner's own Worker:
+
+- `approveAuthorization` returns the consent page (a `Response`) until the
+  request carries a signed owner-session cookie **and** a consent token bound to
+  that exact authorization request; then it returns the `AuthorizationApproval`.
+- A passkey assertion (or a backup code) at `POST /auth/consent` establishes the
+  session and mints the request-bound consent token, which blocks consent-screen-
+  skip deep links.
+- `@dwk/webauthn`'s `/register/*` enrols any passkey, so the **first** enrolment
+  is gated on a one-time `INDIEWEB_REG_TOKEN`; later ones on an owner session.
+- Recovery has three layers: ≥2 passkeys, 10 single-use backup codes (SHA-256
+  hashes in `OWNER_AUTH_DB`), and redeploy-root reset (rotate the token).
+
+### Bindings added
+
+`WEBAUTHN` (the first Durable Object in the template, with a `migrations` block),
+`OWNER_AUTH_DB` (D1, backup-code hashes), and the `INDIEAUTH_SESSION_KEY` /
+`INDIEWEB_REG_TOKEN` secrets (the deploy scan rejects them if committed).
+
+## Consequences
+
+- Good: identity and credentials stay entirely on the owner's Cloudflare account;
+  no password to store; phishing-resistant.
+- Good: the consent-token binding makes the OAuth consent step CSRF-safe.
+- Bad: introduces the template's first Durable Object and a multi-step owner
+  setup (enrol passkeys, save backup codes).
+- Neutral: built on `@dwk/webauthn`, the least-mature package in the cohort
+  ("exploratory, lowest priority") — acceptable because the owner controls the
+  whole stack and can reset auth.
+
+## More Information
+
+Design: `docs/superpowers/specs/2026-06-21-passkey-indieauth-design.md`.
+Plan: `docs/superpowers/plans/2026-06-21-passkey-indieauth.md`. Tracking:
+Anglesite issue #363 (problem 2, IndieAuth slice). Micropub realignment (#2c)
+depends on this and is tracked separately.

--- a/docs/platforms/dwk-workers.md
+++ b/docs/platforms/dwk-workers.md
@@ -45,6 +45,10 @@ The composed Worker's `Env` is the union of the mounted packages' fragments; a m
 | Binding | Type | Package | Purpose |
 |---|---|---|---|
 | `AUTH_DB` | D1 | indieauth | Authorization codes + issued tokens (strongly-consistent; never KV) |
+| `WEBAUTHN` | Durable Object | webauthn | Passkey challenge state + credential records (owner authentication) |
+| `OWNER_AUTH_DB` | D1 | (anglesite) | Single-use backup-code hashes (owner recovery) |
+| `INDIEAUTH_SESSION_KEY` | secret | (anglesite) | Signs the owner-session cookie after a passkey/backup-code sign-in |
+| `INDIEWEB_REG_TOKEN` | secret | (anglesite) | One-time gate for the first passkey enrolment |
 | `MICROPUB_DB` | D1 | micropub | Published post records (mf2 source) + DPoP `jti` replay store |
 | `WEBMENTION_INBOX` | D1 | webmention | Verified-mention inbox (stores `{ source, target, verified_at }` only — no author/content) |
 | `MEDIA` | R2 | micropub | Media-endpoint blob storage |

--- a/docs/superpowers/plans/2026-06-21-passkey-indieauth.md
+++ b/docs/superpowers/plans/2026-06-21-passkey-indieauth.md
@@ -1,0 +1,548 @@
+# Passkey-backed IndieAuth Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire `@dwk/indieauth`'s `approveAuthorization` hook to a passkey
+(`@dwk/webauthn`) owner-authentication + consent flow, with printable single-use
+backup codes, so a site owner can sign in to IndieWeb services with their own
+domain.
+
+**Architecture:** All endpoints mount under `/auth` in `site-entry.js`, gated on
+`env.AUTH_DB`. `approveAuthorization` returns the consent page (`Response`) until
+a signed owner-session cookie + a request-bound consent token exist, then returns
+`AuthorizationApproval`. Owner identity is proven by a passkey assertion (or a
+backup code) against a `WEBAUTHN` Durable Object. Owner-side state (session keys,
+consent tokens, backup-code hashes) lives in helpers we own, never in
+`@dwk/indieauth`'s `AUTH_DB`.
+
+**Tech Stack:** Cloudflare Workers (ESM), `@dwk/indieauth` + `@dwk/webauthn`
+(`0.1.0-beta.3`), Durable Objects (SQLite), D1, WebCrypto (`crypto.subtle`
+HMAC-SHA-256), Vitest with aliased package stubs.
+
+## Global Constraints
+
+- **Module system:** ESM only (`import`/`export`).
+- **Worker files** live in `template/worker/*.js`; tests in `tests/*.test.ts`
+  using the vitest aliases in `vitest.config.ts`.
+- **No real `@dwk/*` at test time:** vitest aliases `@dwk/indieauth` and
+  `@dwk/webauthn` to `tests/__stubs__/dwk-*.ts`. The stub IS the substitute.
+- **Per-`env` memoized construction** (the `webmentionFor` pattern already in
+  `site-entry.js`) — factories need config derived from `env.SITE_URL`.
+- **Secrets never committed:** `INDIEAUTH_SESSION_KEY`, `INDIEWEB_REG_TOKEN` are
+  wrangler secrets; the deploy scan asserts this.
+- **Custom domain required** (skill preflight already enforces it) — passkeys are
+  domain-bound.
+- Reuse the existing HMAC cookie pattern (`verifyMembershipCookie` in
+  `site-entry.js`) for the owner session.
+
+## File Structure
+
+- Create `template/worker/owner-auth.js` — owner session cookie
+  (issue/verify), consent token (mint/verify), backup-code hash/redeem. Pure
+  WebCrypto; no package deps. The testable security core.
+- Create `template/worker/auth-pages.js` — `renderConsentPage()` and
+  `renderRegisterPage()` returning HTML strings (inline JS drives the WebAuthn
+  ceremonies). No logic beyond templating.
+- Modify `template/worker/site-entry.js` — import `createIndieAuth` /
+  `createWebAuthn`, re-export `WebAuthnObject`, add `/auth/*` dispatch +
+  `approveAuthorization`.
+- Modify `template/wrangler.jsonc` — `durable_objects` + `migrations` +
+  `OWNER_AUTH_DB`.
+- Create `tests/__stubs__/dwk-webauthn.ts`; rewrite `tests/__stubs__/dwk-indieauth.ts`.
+- Create `tests/indieauth-session.test.ts`, `tests/indieauth-approve.test.ts`,
+  `tests/indieauth-backup-codes.test.ts`, `tests/indieauth-dispatch.test.ts`.
+- Modify `skills/indieweb/SKILL.md`, `scripts/pre-deploy-check.sh`,
+  `docs/platforms/dwk-workers.md`; create `docs/decisions/0022-passkey-indieauth.md`.
+
+---
+
+### Task 1: `@dwk/webauthn` stub + DO binding + ceremonies reachable
+
+**Files:**
+- Create: `tests/__stubs__/dwk-webauthn.ts`
+- Modify: `vitest.config.ts` (alias), `template/worker/site-entry.js`, `template/wrangler.jsonc`
+- Test: `tests/indieauth-dispatch.test.ts`
+
+**Interfaces:**
+- Produces: `createWebAuthn(config) => (req,env,ctx)=>Response` and re-export
+  `WebAuthnObject`; `webauthnFor(env)` memoized bundle `{ handler }`.
+
+- [ ] **Step 1: Stub.** Create `tests/__stubs__/dwk-webauthn.ts`:
+
+```ts
+export const webauthnCalls = { fetch: 0 };
+export function resetWebauthnCalls() { webauthnCalls.fetch = 0; }
+export class WebAuthnObject {} // bound as a DO class; never instantiated in tests
+export function createWebAuthn(_config?: unknown) {
+  return (req: Request, _env: unknown, _ctx: unknown) => {
+    webauthnCalls.fetch++;
+    const path = new URL(req.url).pathname;
+    return new Response("webauthn", {
+      headers: { "x-handler": "webauthn", "x-webauthn-path": path },
+    });
+  };
+}
+```
+
+- [ ] **Step 2: Alias.** In `vitest.config.ts` `alias`, add:
+  `"@dwk/webauthn": resolve(__dirname, "tests/__stubs__/dwk-webauthn.ts"),`
+
+- [ ] **Step 3: Failing test.** `tests/indieauth-dispatch.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import worker from "../template/worker/site-entry.js";
+const ctx = () => ({ waitUntil: vi.fn(), passThroughOnException: vi.fn() });
+const env = (o = {}) => ({ ASSETS: { fetch: vi.fn(async () => new Response("a")) }, SITE_URL: "https://example.com", ...o } as any);
+const req = (p: string) => new Request(`https://example.com${p}`, { method: "POST" });
+
+describe("WebAuthn ceremony dispatch", () => {
+  it("routes /auth/webauthn/* to the WebAuthn handler when AUTH_DB is bound", async () => {
+    const res = await worker.fetch(req("/auth/webauthn/authenticate/options"), env({ AUTH_DB: {}, WEBAUTHN: {} }), ctx());
+    expect(res.headers.get("x-handler")).toBe("webauthn");
+  });
+  it("falls through /auth/webauthn/* to ASSETS when AUTH_DB absent", async () => {
+    const e = env();
+    await worker.fetch(req("/auth/webauthn/authenticate/options"), e, ctx());
+    expect(e.ASSETS.fetch).toHaveBeenCalledOnce();
+  });
+});
+```
+
+- [ ] **Step 4: Run, expect FAIL** (`createWebAuthn` not imported): `npx vitest run tests/indieauth-dispatch.test.ts`
+
+- [ ] **Step 5: Implement.** In `site-entry.js`: add `import { createWebAuthn, WebAuthnObject } from "@dwk/webauthn";` and `import { createIndieAuth } from "@dwk/indieauth";` (replace the `createHandler as createIndieAuth` line). Add a memoized bundle:
+
+```js
+const authByEnv = new WeakMap();
+function authFor(env) {
+  let b = authByEnv.get(env);
+  if (!b) {
+    const origin = env.SITE_URL;
+    const rpId = origin ? new URL(origin).host : undefined;
+    b = {
+      webauthn: createWebAuthn({ rpId, rpName: rpId ?? "site", origin }),
+    };
+    authByEnv.set(env, b);
+  }
+  return b;
+}
+export { WebAuthnObject };
+```
+
+In the IndieWeb dispatch block, before the existing `/auth` route, add:
+
+```js
+if (env.AUTH_DB && p.startsWith("/auth/webauthn/"))
+  return authFor(env).webauthn(request, env, ctx);
+```
+
+- [ ] **Step 6: Run, expect PASS.** Then `wrangler.jsonc`: add after `d1_databases`:
+
+```jsonc
+"durable_objects": {
+  "bindings": [{ "name": "WEBAUTHN", "class_name": "WebAuthnObject" }]
+},
+"migrations": [{ "tag": "v1", "new_sqlite_classes": ["WebAuthnObject"] }],
+```
+
+- [ ] **Step 7: Commit** `feat(indieauth): mount @dwk/webauthn ceremonies + WEBAUTHN DO binding`.
+
+---
+
+### Task 2: Owner session cookie (`owner-auth.js`)
+
+**Files:** Create `template/worker/owner-auth.js`; Test `tests/indieauth-session.test.ts`.
+
+**Interfaces:**
+- Produces: `issueOwnerSession(signingKeyHex, ttlSeconds?) => Promise<string>` (cookie value `payloadB64.sigHex`); `verifyOwnerSession(cookieValue, signingKeyHex) => Promise<{sub,exp}|null>`; `OWNER_COOKIE = "__anglesite_owner"`; `readCookie(header, name)`.
+
+- [ ] **Step 1: Failing test** `tests/indieauth-session.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { issueOwnerSession, verifyOwnerSession } from "../template/worker/owner-auth.js";
+const KEY = "00112233445566778899aabbccddeeff";
+
+describe("owner session cookie", () => {
+  it("round-trips a valid session", async () => {
+    const v = await issueOwnerSession(KEY, 900);
+    const p = await verifyOwnerSession(v, KEY);
+    expect(p?.sub).toBe("owner");
+    expect(p?.exp).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+  it("rejects a tampered payload", async () => {
+    const v = await issueOwnerSession(KEY, 900);
+    const [, sig] = v.split(".");
+    expect(await verifyOwnerSession("ZXZpbA." + sig, KEY)).toBeNull();
+  });
+  it("rejects an expired session", async () => {
+    const v = await issueOwnerSession(KEY, -1);
+    expect(await verifyOwnerSession(v, KEY)).toBeNull();
+  });
+  it("rejects under a different key", async () => {
+    const v = await issueOwnerSession(KEY, 900);
+    expect(await verifyOwnerSession(v, "ffffffffffffffffffffffffffffffff")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL.** `npx vitest run tests/indieauth-session.test.ts`
+
+- [ ] **Step 3: Implement** `template/worker/owner-auth.js`. Mirror the membership HMAC helpers; `now` injectable via param default for the expiry test:
+
+```js
+export const OWNER_COOKIE = "__anglesite_owner";
+
+function hexToBytes(hex) {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.substr(i * 2, 2), 16);
+  return out;
+}
+function bytesToHex(buf) {
+  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+function b64urlEncode(bytes) {
+  let s = btoa(String.fromCharCode(...bytes));
+  return s.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+function b64urlDecode(str) {
+  const pad = str.length % 4 ? "=".repeat(4 - (str.length % 4)) : "";
+  const bin = atob(str.replace(/-/g, "+").replace(/_/g, "/") + pad);
+  return new Uint8Array([...bin].map((c) => c.charCodeAt(0)));
+}
+async function hmacKey(hex, usages) {
+  return crypto.subtle.importKey("raw", hexToBytes(hex), { name: "HMAC", hash: "SHA-256" }, false, usages);
+}
+
+export async function issueOwnerSession(signingKeyHex, ttlSeconds = 900) {
+  const exp = Math.floor(Date.now() / 1000) + ttlSeconds;
+  const payload = new TextEncoder().encode(JSON.stringify({ sub: "owner", exp }));
+  const key = await hmacKey(signingKeyHex, ["sign"]);
+  const sig = await crypto.subtle.sign("HMAC", key, payload);
+  return `${b64urlEncode(payload)}.${bytesToHex(sig)}`;
+}
+
+export async function verifyOwnerSession(value, signingKeyHex) {
+  if (!value || !signingKeyHex) return null;
+  const dot = value.indexOf(".");
+  if (dot < 0) return null;
+  const payloadB64 = value.slice(0, dot);
+  const sigHex = value.slice(dot + 1);
+  if (!/^[0-9a-f]+$/i.test(sigHex)) return null;
+  let payloadBytes;
+  try { payloadBytes = b64urlDecode(payloadB64); } catch { return null; }
+  const key = await hmacKey(signingKeyHex, ["verify"]);
+  const ok = await crypto.subtle.verify("HMAC", key, hexToBytes(sigHex), payloadBytes);
+  if (!ok) return null;
+  let payload;
+  try { payload = JSON.parse(new TextDecoder().decode(payloadBytes)); } catch { return null; }
+  if (payload?.sub !== "owner" || typeof payload.exp !== "number") return null;
+  if (payload.exp * 1000 < Date.now()) return null;
+  return payload;
+}
+
+export function readCookie(cookieHeader, name) {
+  for (const piece of (cookieHeader ?? "").split(";")) {
+    const t = piece.trim();
+    const eq = t.indexOf("=");
+    if (eq > 0 && t.slice(0, eq) === name) return t.slice(eq + 1);
+  }
+  return null;
+}
+```
+
+- [ ] **Step 4: Run, expect PASS.**
+- [ ] **Step 5: Commit** `feat(indieauth): owner session cookie helpers`.
+
+---
+
+### Task 3: Request-bound consent token
+
+**Files:** Modify `template/worker/owner-auth.js`; Test `tests/indieauth-approve.test.ts` (consent-token block).
+
+**Interfaces:**
+- Produces: `mintConsentToken(keyHex, {clientId, redirectUri, scope}, ttlSeconds?) => Promise<string>`; `verifyConsentToken(token, keyHex, {clientId, redirectUri, scope}) => Promise<boolean>` — HMAC over a canonical `clientId|redirectUri|scope|exp` string; mismatch on any field or expiry ⇒ false.
+
+- [ ] **Step 1: Failing test** (new file `tests/indieauth-approve.test.ts`, first describe):
+
+```ts
+import { describe, it, expect } from "vitest";
+import { mintConsentToken, verifyConsentToken } from "../template/worker/owner-auth.js";
+const KEY = "00112233445566778899aabbccddeeff";
+const REQ = { clientId: "https://app.example", redirectUri: "https://app.example/cb", scope: "create" };
+
+describe("consent token", () => {
+  it("verifies a token bound to the same request", async () => {
+    const t = await mintConsentToken(KEY, REQ, 300);
+    expect(await verifyConsentToken(t, KEY, REQ)).toBe(true);
+  });
+  it("rejects when a bound field differs", async () => {
+    const t = await mintConsentToken(KEY, REQ, 300);
+    expect(await verifyConsentToken(t, KEY, { ...REQ, scope: "create media" })).toBe(false);
+    expect(await verifyConsentToken(t, KEY, { ...REQ, redirectUri: "https://evil.example/cb" })).toBe(false);
+  });
+  it("rejects an expired token", async () => {
+    const t = await mintConsentToken(KEY, REQ, -1);
+    expect(await verifyConsentToken(t, KEY, REQ)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+- [ ] **Step 3: Implement** (append to `owner-auth.js`):
+
+```js
+function consentMessage({ clientId, redirectUri, scope }, exp) {
+  return new TextEncoder().encode(
+    [clientId, redirectUri, scope ?? "", exp].join("|"),
+  );
+}
+export async function mintConsentToken(keyHex, req, ttlSeconds = 300) {
+  const exp = Math.floor(Date.now() / 1000) + ttlSeconds;
+  const key = await hmacKey(keyHex, ["sign"]);
+  const sig = await crypto.subtle.sign("HMAC", key, consentMessage(req, exp));
+  return `${exp}.${bytesToHex(sig)}`;
+}
+export async function verifyConsentToken(token, keyHex, req) {
+  if (!token) return false;
+  const dot = token.indexOf(".");
+  if (dot < 0) return false;
+  const exp = Number(token.slice(0, dot));
+  const sigHex = token.slice(dot + 1);
+  if (!Number.isFinite(exp) || exp * 1000 < Date.now()) return false;
+  if (!/^[0-9a-f]+$/i.test(sigHex)) return false;
+  const key = await hmacKey(keyHex, ["verify"]);
+  return crypto.subtle.verify("HMAC", key, hexToBytes(sigHex), consentMessage(req, exp));
+}
+```
+
+- [ ] **Step 4: Run, expect PASS.**
+- [ ] **Step 5: Commit** `feat(indieauth): request-bound consent token`.
+
+---
+
+### Task 4: Backup codes (`OWNER_AUTH_DB`)
+
+**Files:** Modify `template/worker/owner-auth.js`; Test `tests/indieauth-backup-codes.test.ts`.
+
+**Interfaces:**
+- Produces: `generateBackupCodes(db, n?) => Promise<string[]>` (returns plaintext once, stores SHA-256 hashes); `redeemBackupCode(db, code) => Promise<boolean>` (single-use; constant-time host compare via hash equality). `db` is a D1 binding; the helper issues `CREATE TABLE IF NOT EXISTS owner_backup_codes (...)`.
+
+- [ ] **Step 1: Failing test** with an in-memory fake D1 (`prepare/bind/run/first/all`):
+
+```ts
+import { describe, it, expect } from "vitest";
+import { generateBackupCodes, redeemBackupCode } from "../template/worker/owner-auth.js";
+
+function fakeD1() {
+  const rows: any[] = [];
+  const db = {
+    prepare(sql: string) {
+      return {
+        _sql: sql, _args: [] as any[],
+        bind(...a: any[]) { this._args = a; return this; },
+        async run() {
+          if (/INSERT/.test(sql)) rows.push({ code_hash: this._args[0], used_at: null });
+          if (/UPDATE/.test(sql)) { const r = rows.find((x) => x.code_hash === this._args[0] && !x.used_at); if (r) r.used_at = 1; }
+          return { success: true };
+        },
+        async first() {
+          if (/SELECT/.test(sql)) return rows.find((x) => x.code_hash === this._args[0] && !x.used_at) ?? null;
+          return null;
+        },
+        async all() { return { results: rows }; },
+      };
+    },
+  };
+  return db as any;
+}
+
+describe("backup codes", () => {
+  it("generates N codes and redeems each once", async () => {
+    const db = fakeD1();
+    const codes = await generateBackupCodes(db, 10);
+    expect(codes).toHaveLength(10);
+    expect(new Set(codes).size).toBe(10);
+    expect(await redeemBackupCode(db, codes[0])).toBe(true);
+    expect(await redeemBackupCode(db, codes[0])).toBe(false); // single-use
+    expect(await redeemBackupCode(db, "not-a-real-code")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+- [ ] **Step 3: Implement** (append to `owner-auth.js`):
+
+```js
+async function sha256Hex(s) {
+  const d = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(s));
+  return bytesToHex(d);
+}
+function randomCode() {
+  const b = new Uint8Array(10);
+  crypto.getRandomValues(b);
+  // Crockford-ish base32, grouped: xxxxx-xxxxx
+  const A = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+  const s = [...b].map((x) => A[x % 32]).join("");
+  return `${s.slice(0, 5)}-${s.slice(5, 10)}`;
+}
+async function ensureBackupTable(db) {
+  await db.prepare(
+    `CREATE TABLE IF NOT EXISTS owner_backup_codes (code_hash TEXT PRIMARY KEY, created_at INTEGER, used_at INTEGER)`,
+  ).run();
+}
+export async function generateBackupCodes(db, n = 10) {
+  await ensureBackupTable(db);
+  const codes = [];
+  for (let i = 0; i < n; i++) {
+    const code = randomCode();
+    codes.push(code);
+    await db.prepare(
+      `INSERT INTO owner_backup_codes (code_hash, created_at, used_at) VALUES (?1, ?2, NULL)`,
+    ).bind(await sha256Hex(code), Math.floor(Date.now() / 1000)).run();
+  }
+  return codes;
+}
+export async function redeemBackupCode(db, code) {
+  if (!code) return false;
+  const hash = await sha256Hex(String(code).trim().toUpperCase());
+  const row = await db.prepare(
+    `SELECT code_hash FROM owner_backup_codes WHERE code_hash = ?1 AND used_at IS NULL`,
+  ).bind(hash).first();
+  if (!row) return false;
+  await db.prepare(
+    `UPDATE owner_backup_codes SET used_at = ?2 WHERE code_hash = ?1 AND used_at IS NULL`,
+  ).bind(hash, Math.floor(Date.now() / 1000)).run();
+  return true;
+}
+```
+
+(Note: `generateBackupCodes` must uppercase before hashing to match `redeemBackupCode`; codes are emitted uppercase already.)
+
+- [ ] **Step 4: Run, expect PASS.**
+- [ ] **Step 5: Commit** `feat(indieauth): single-use backup codes in OWNER_AUTH_DB`.
+
+---
+
+### Task 5: `approveAuthorization` + consent dispatch
+
+**Files:** Modify `template/worker/site-entry.js`; create `template/worker/auth-pages.js`; Test `tests/indieauth-approve.test.ts` (second describe).
+
+**Interfaces:**
+- Consumes: `verifyOwnerSession`, `verifyConsentToken`, `OWNER_COOKIE`, `readCookie` (Task 2/3); `renderConsentPage({request})` (new).
+- Produces: `makeApproveAuthorization(env)` returning the `ApproveAuthorization` hook; dispatch for `POST /auth/consent`.
+
+- [ ] **Step 1: Failing test** (`tests/indieauth-approve.test.ts`, append). Drive `worker.fetch` against `/auth` with the indieauth stub configured so the stub *calls* `config.approveAuthorization` and surfaces its result (see Task 7 stub). Assert: no session ⇒ response body is the consent page (status 200, contains `id="passkey-signin"`); valid session cookie + valid `_consent` ⇒ stub reports an `AuthorizationApproval` with `me === env.SITE_URL`.
+
+```ts
+// (uses helpers from Task 7's dwk-indieauth stub: it echoes the approval as JSON
+// on header x-approval, or returns the Response verbatim)
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+- [ ] **Step 3: Implement.** `auth-pages.js` → `renderConsentPage({ request, authenticated })` returns an HTML string with: a `<button id="passkey-signin">`, inline JS that POSTs to `/auth/webauthn/authenticate/options`, calls `navigator.credentials.get`, POSTs the assertion to `/auth/consent` along with the original query string, and a "Use a backup code" `<form>` posting to `/auth/consent`. In `site-entry.js`:
+
+```js
+import { OWNER_COOKIE, readCookie, verifyOwnerSession, verifyConsentToken } from "./owner-auth.js";
+import { renderConsentPage } from "./auth-pages.js";
+
+function makeApproveAuthorization(env) {
+  return async (authReq, httpRequest) => {
+    const sessionKey = env.INDIEAUTH_SESSION_KEY;
+    const cookie = readCookie(httpRequest.headers.get("Cookie") ?? "", OWNER_COOKIE);
+    const session = await verifyOwnerSession(cookie, sessionKey);
+    const url = new URL(httpRequest.url);
+    const consent = url.searchParams.get("_consent");
+    const bound = { clientId: authReq.clientId, redirectUri: authReq.redirectUri, scope: authReq.scope };
+    if (session && consent && (await verifyConsentToken(consent, sessionKey, bound))) {
+      return { me: env.SITE_URL, scopes: authReq.scopes, profile: { url: env.SITE_URL } };
+    }
+    return new Response(renderConsentPage({ request: httpRequest, authenticated: !!session }), {
+      status: 200, headers: { "content-type": "text/html; charset=utf-8" },
+    });
+  };
+}
+```
+
+Wire the indieauth handler in `authFor(env)`: `indieauth: createIndieAuth({ baseUrl: env.SITE_URL, approveAuthorization: makeApproveAuthorization(env) })`. (The `/auth/consent` POST handler is Task 6.)
+
+- [ ] **Step 4: Run, expect PASS.**
+- [ ] **Step 5: Commit** `feat(indieauth): approveAuthorization consent gate`.
+
+---
+
+### Task 6: `/auth/consent` POST — passkey/backup → session + consent token
+
+**Files:** Modify `template/worker/site-entry.js`; Test `tests/indieauth-approve.test.ts` (consent endpoint block).
+
+**Interfaces:**
+- Consumes: `authFor(env).webauthn` (verify assertion), `issueOwnerSession`, `mintConsentToken`, `redeemBackupCode`.
+- Produces: dispatch `POST /auth/consent` → on a verified passkey assertion *or* a redeemed backup code, set `Set-Cookie: __anglesite_owner=...` and 302 to `/auth?<original>&_consent=<token>`.
+
+- [ ] **Step 1: Failing test:** POST `/auth/consent` with a body flagged `{ backupCode }` against a fake `OWNER_AUTH_DB` containing that code ⇒ 302, `Location` carries `_consent=`, and a `__anglesite_owner` Set-Cookie. A bad backup code ⇒ 401, no cookie.
+- [ ] **Step 2: Run, expect FAIL.**
+- [ ] **Step 3: Implement** `POST /auth/consent` in `site-entry.js`: parse the form/JSON body; if `backupCode` present, `redeemBackupCode(env.OWNER_AUTH_DB, code)`; else forward the assertion to `authFor(env).webauthn` (`/authenticate/verify`) and require a 200. On success: `issueOwnerSession`, `mintConsentToken` over the original `client_id/redirect_uri/scope`, build the `Location` back to `/auth` with the original params plus `_consent`, return 302 with the Set-Cookie. On failure: 401.
+- [ ] **Step 4: Run, expect PASS.**
+- [ ] **Step 5: Commit** `feat(indieauth): /auth/consent passkey + backup-code redemption`.
+
+---
+
+### Task 7: Rewrite `dwk-indieauth` stub + full `/auth` dispatch
+
+**Files:** Rewrite `tests/__stubs__/dwk-indieauth.ts`; Modify `template/worker/site-entry.js` (dispatch order); Test: existing `tests/indieweb-dispatch.test.ts` updates.
+
+**Interfaces:**
+- Produces stub `createIndieAuth(config) => handler`. The handler, on `GET /auth`, calls `config.approveAuthorization(parsedReq, request)` and: if it returns a `Response`, returns it; if it returns an approval object, returns `new Response(JSON.stringify(approval), { headers: { "x-handler": "indieauth", "x-approval": "1" } })`. This lets tests observe both arms.
+
+- [ ] **Step 1:** Rewrite the stub to `createIndieAuth` with the approval-surfacing behavior above; parse `client_id`,`redirect_uri`,`state`,`scope`,`code_challenge` from the query into the `AuthorizationRequest` shape (`clientId`,`redirectUri`,`scope`,`scopes`).
+- [ ] **Step 2:** Update `tests/indieweb-dispatch.test.ts`: the IndieAuth dispatch test now expects `x-handler: indieauth` for `/auth` only when `AUTH_DB` bound, and `/auth/webauthn/*` / `/auth/consent` are handled before the generic `/auth` route. Run, expect FAIL where the old `createHandler` import is referenced.
+- [ ] **Step 3:** In `site-entry.js` ensure dispatch order: `/auth/webauthn/*` → `/auth/consent` → `/auth` (generic). Implement.
+- [ ] **Step 4:** Run the full IndieWeb suite, expect PASS.
+- [ ] **Step 5: Commit** `feat(indieauth): wire createIndieAuth with real API + dispatch order`.
+
+---
+
+### Task 8: Registration gating + `/auth/register` page
+
+**Files:** Modify `template/worker/site-entry.js`, `template/worker/auth-pages.js`; Test `tests/indieauth-dispatch.test.ts` (registration block).
+
+**Interfaces:**
+- Consumes: `verifyOwnerSession`, `env.INDIEWEB_REG_TOKEN`.
+- Produces: gate on `/auth/webauthn/register/*` (403 unless `?token=` matches `INDIEWEB_REG_TOKEN` **or** a valid owner session); `GET /auth/register` → `renderRegisterPage()`.
+
+- [ ] **Step 1: Failing tests:** `/auth/webauthn/register/options` with no token and no session ⇒ 403; with `?token=<INDIEWEB_REG_TOKEN>` ⇒ reaches the webauthn handler (`x-handler: webauthn`); with a valid owner session cookie ⇒ reaches it too.
+- [ ] **Step 2: Run, expect FAIL.**
+- [ ] **Step 3: Implement** the gate in `site-entry.js` immediately before the `/auth/webauthn/` route: for paths starting `/auth/webauthn/register/`, require token-or-session else `return new Response("Forbidden", { status: 403 })`. Add `GET /auth/register` → `renderRegisterPage()` (HTML driving `/auth/webauthn/register/*`, carrying the `token` param into its fetches).
+- [ ] **Step 4: Run, expect PASS.**
+- [ ] **Step 5: Commit** `feat(indieauth): owner-only passkey registration gating + page`.
+
+---
+
+### Task 9: Skill, wrangler secrets, deploy-scan, docs, ADR
+
+**Files:** Modify `skills/indieweb/SKILL.md`, `template/wrangler.jsonc`, `scripts/pre-deploy-check.sh`, `docs/platforms/dwk-workers.md`; Create `docs/decisions/0022-passkey-indieauth.md`; Test `tests/pre-deploy-scan.test.ts` (new secret-name cases).
+
+- [ ] **Step 1:** SKILL Step 3: provision `OWNER_AUTH_DB` (D1) + the `WEBAUTHN` DO (no resource to create — it's code-defined; just the wrangler binding/migration) + generate `INDIEAUTH_SESSION_KEY` (`openssl rand -hex 32`) and `INDIEWEB_REG_TOKEN` as wrangler secrets; show the owner the one-time `/auth/register?token=…` link and the 10 backup codes once. Document `--reset-auth`.
+- [ ] **Step 2:** `wrangler.jsonc`: add the `OWNER_AUTH_DB` D1 binding (empty id, skill-filled). DO binding + migrations already added in Task 1.
+- [ ] **Step 3:** `pre-deploy-check.sh`: add `INDIEAUTH_SESSION_KEY` and `INDIEWEB_REG_TOKEN` to the secret-scan patterns (must be secret bindings, never committed). Add a failing test in `tests/pre-deploy-scan.test.ts` (a committed `INDIEAUTH_SESSION_KEY=...` value trips the scan), run FAIL, implement, run PASS.
+- [ ] **Step 4:** `docs/platforms/dwk-workers.md`: add the `WEBAUTHN` DO, `OWNER_AUTH_DB`, `INDIEAUTH_SESSION_KEY`, `INDIEWEB_REG_TOKEN` rows + a short "passkey owner-auth flow" subsection. Create `docs/decisions/0022-passkey-indieauth.md` (terse ADR pointing at this spec/plan).
+- [ ] **Step 5:** Run the full suite (`npm test`); commit `feat(indieweb): provision passkey IndieAuth (skill, secrets, deploy-scan, docs, ADR-0022)`.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** approveAuthorization (T5), consent token (T3), session (T2),
+  registration gating + bootstrap token (T8), backup codes (T4), DO binding +
+  migrations (T1), createIndieAuth wiring (T7), skill/secrets/deploy-scan/docs/ADR
+  (T9), recovery `--reset-auth` (T9). Backup-code recovery + ≥2 passkeys: T4 + T8
+  page copy. All spec sections map to a task.
+- **Out of scope (correctly absent):** Micropub realignment (#2c).
+- **Type consistency:** `authFor(env)` exposes `{ webauthn, indieauth }`;
+  `owner-auth.js` exports `OWNER_COOKIE`, `readCookie`, `issueOwnerSession`,
+  `verifyOwnerSession`, `mintConsentToken`, `verifyConsentToken`,
+  `generateBackupCodes`, `redeemBackupCode` — names used identically in T5/T6/T8.
+- **Note for executor:** `@dwk/*` packages don't load in plain Node until
+  `beta.3` is published; tests rely on the vitest stubs, so the suite is green
+  regardless. A real deploy bundles via wrangler/esbuild.

--- a/docs/superpowers/specs/2026-06-21-passkey-indieauth-design.md
+++ b/docs/superpowers/specs/2026-06-21-passkey-indieauth-design.md
@@ -1,0 +1,255 @@
+# Passkey-backed IndieAuth (`approveAuthorization`)
+
+**Date:** 2026-06-21 · **Issue:** Anglesite/anglesite#363 (problem 2, IndieAuth slice) · **Status:** draft — awaiting review
+
+Successor to `2026-06-09-active-indieweb-design.md` and ADR-0020. Sibling of the
+Webmention realignment (shipped, #370). Micropub realignment is a separate spec
+(#2c) that depends on this one.
+
+## Problem
+
+`@dwk/indieauth` owns all IndieAuth protocol mechanics (PKCE, code/token
+issuance, metadata) but **deliberately delegates authentication and consent to
+the deployer**:
+
+```ts
+readonly approveAuthorization: ApproveAuthorization; // required config
+type ApproveAuthorization =
+  (request: AuthorizationRequest, httpRequest: Request)
+    => Promise<AuthorizationApproval | Response>;
+```
+
+The current template calls `createIndieAuth()` with no config — it cannot even
+construct, and there is no mechanism for the owner to prove they are the owner
+before a token is minted. We need to build that mechanism. Per brainstorming
+(2026-06-21) the chosen mechanism is **passkeys via `@dwk/webauthn`**.
+
+## The contract we build against
+
+`approveAuthorization` returns one of two things:
+
+- **`AuthorizationApproval { me, scopes?, profile? }`** — the library mints a code
+  and redirects to the client. Return this only when the current request carries
+  a valid owner session **and** a consent token bound to this exact request.
+- **`Response`** — the library returns it verbatim, handing us the exchange. This
+  is the escape hatch for interactive auth: we return the login/consent page.
+
+This single seam is the whole integration point. Everything else is the page,
+the session, and the credential store behind it.
+
+## What `@dwk/webauthn` gives us (and what it doesn't)
+
+`createWebAuthn({ rpId, rpName, origin })` → a `fetch` handler exposing four
+ceremony endpoints, backed by a **`WEBAUTHN` Durable Object namespace**
+(`WebAuthnObject`, exported by the package) that holds challenge state +
+credential records (strongly consistent):
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /register/options` | issue creation options + challenge |
+| `POST /register/verify` | verify attestation, **store the credential** |
+| `POST /authenticate/options` | issue request options + challenge |
+| `POST /authenticate/verify` | verify assertion, advance the counter |
+
+**Critical gap:** the package is a generic relying party. Its `/register/*`
+endpoints will enrol **any** passkey that completes the ceremony — it has no
+notion of "the owner." Gating registration so only the owner can enrol the first
+credential is **our** responsibility. This is the load-bearing design decision
+(see Open decisions §1).
+
+> Caveat to record: `@dwk/webauthn` is self-described "exploratory, lowest
+> priority" — the least-mature package in the set. We are putting the owner's
+> primary identity on it. Acceptable given the owner controls the whole stack and
+> can reset auth (§ Recovery), but worth stating plainly.
+
+## Architecture
+
+Everything mounts under `/auth` in `site-entry.js`, ahead of the `ASSETS`
+fallthrough, gated on `env.AUTH_DB` (as today):
+
+```
+/auth                       → @dwk/indieauth authorization + token + metadata
+/auth/webauthn/register/*    → @dwk/webauthn (owner-only gated, see §1)
+/auth/webauthn/authenticate/* → @dwk/webauthn (open — proves possession only)
+/auth/register               → owner-only registration page (HTML)
+/auth/consent                → POST target: validate session, mint consent token
+```
+
+Per-request construction, memoized per `env` (the `webmentionFor` pattern from
+#370), because `createIndieAuth`/`createWebAuthn` need config (`baseUrl`,
+`rpId`, `origin`) that derives from `env.SITE_URL`.
+
+### The flow
+
+```
+1. Client → GET /auth?response_type=code&client_id&redirect_uri&state
+            &code_challenge&code_challenge_method=S256&scope&me
+2. @dwk/indieauth validates → approveAuthorization(request, httpRequest)
+3. our hook reads the signed __anglesite_owner session cookie:
+   a. no/expired session →
+        return Response: consent page (HTML). The page:
+          - runs a WebAuthn assertion via /auth/webauthn/authenticate/*
+            (navigator.credentials.get)
+          - on success POSTs to /auth/consent with the assertion result +
+            the original authorization params
+          - /auth/consent verifies the assertion server-side, sets the
+            __anglesite_owner session cookie, mints a per-request consent
+            token (HMAC over client_id|redirect_uri|scope|nonce|exp), and
+            302-redirects back to /auth?...original...&_consent=<token>
+   b. session present + valid _consent token for THIS request →
+        return AuthorizationApproval { me: SITE_URL, scopes, profile }
+   c. session present, no consent token →
+        return Response: consent page in "already authenticated" mode
+        (skip the passkey step, just show client+scopes, Approve → mint token)
+4. @dwk/indieauth mints the code, redirects to redirect_uri with code+state
+```
+
+The consent token is what prevents a malicious client from deep-linking
+`/auth?...&_consent=…` to skip the visible consent screen: the token is an HMAC
+the owner's browser only receives after POSTing through `/auth/consent`, bound to
+the specific request parameters and short-lived.
+
+### Session
+
+A signed cookie `__anglesite_owner`, reusing the existing membership HMAC helper
+shape in `site-entry.js` (`verifyMembershipCookie`/`crypto.subtle` HMAC-SHA-256).
+Payload `{ sub: "owner", iat, exp }`, `exp` ~15 min, `HttpOnly; Secure; SameSite=Lax`.
+A fresh passkey assertion re-issues it. Signing key: a new
+`INDIEAUTH_SESSION_KEY` secret (or reuse `INDIEAUTH_SIGNING_KEY`).
+
+### Registration
+
+The owner enrols a passkey at `/auth/register` (HTML page driving
+`/auth/webauthn/register/*`). Gated owner-only (§1). The page encourages
+enrolling **two** credentials (e.g. phone + laptop, or a hardware key) so a lost
+device isn't a lockout. Once authenticated, the same page (reached with a valid
+session) lets the owner add or remove credentials.
+
+### Backup codes
+
+A second recovery factor alongside multiple passkeys and the redeploy root. At
+setup (and regenerable from an authenticated session), the worker generates **10
+single-use backup codes**, shows them once for the owner to print/save, and
+stores only their hashes. The consent page offers "Use a backup code instead of a
+passkey"; a submitted code is hashed and matched against an unused stored hash —
+on match it establishes the owner session and the code is marked consumed. A used
+or unknown code returns the consent page unchanged (no oracle).
+
+- **Storage:** a small owned table (`owner_backup_codes`: `code_hash`,
+  `created_at`, `used_at`) in a dedicated `OWNER_AUTH_DB` D1 binding — *not* in
+  `AUTH_DB`, whose schema belongs to `@dwk/indieauth`. Single-use is enforced by
+  `used_at`, which a Worker secret could not provide (secrets are read-only at
+  runtime).
+- **Hashing:** SHA-256 of the code (codes are high-entropy, so a fast hash is
+  fine); compare in constant time.
+- **Rate limit:** cap backup-code attempts per session/IP to blunt guessing,
+  even against high-entropy codes.
+
+## Bindings & wrangler
+
+| Binding | Type | Source |
+|---|---|---|
+| `AUTH_DB` | D1 | already declared (indieauth codes/tokens) |
+| `WEBAUTHN` | **Durable Object namespace** → `WebAuthnObject` | **new** |
+| `SITE_URL` | var | already added (#370); also drives `rpId`/`origin` |
+| `INDIEAUTH_SIGNING_KEY` | secret | already (token signing) |
+| `INDIEAUTH_SESSION_KEY` | secret | **new** (owner session cookie) — or reuse above |
+| `INDIEWEB_REG_TOKEN` | secret | **new** (registration bootstrap, §1) |
+| `OWNER_AUTH_DB` | D1 | **new** (single-use backup-code hashes) |
+
+The `WEBAUTHN` DO is the **first Durable Object in the Anglesite template**. It
+needs a `durable_objects.bindings` entry **and** a `migrations` block in
+`wrangler.jsonc`:
+
+```jsonc
+"durable_objects": {
+  "bindings": [{ "name": "WEBAUTHN", "class_name": "WebAuthnObject" }]
+},
+"migrations": [{ "tag": "v1", "new_sqlite_classes": ["WebAuthnObject"] }]
+```
+
+`site-entry.js` must re-export the class: `export { WebAuthnObject } from "@dwk/webauthn";`.
+SQLite-backed Durable Objects are available on the Workers **free** plan, so this
+adds no cost. (Confirm at build time against the current Cloudflare limits.)
+
+## Resolved decisions
+
+1. **Registration bootstrap — how does the owner enrol the *first* passkey so a
+   stranger can't claim the identity?** **Resolved:** a one-time
+   `INDIEWEB_REG_TOKEN` secret the skill generates and shows the owner once as a
+   setup link (`/auth/register?token=…`). `/auth/webauthn/register/*` is gated on
+   *either* that token *or* a valid owner session (for adding later credentials).
+   After the first credential exists, the bare-token path can be disabled (the
+   skill rotates/clears the token). Alternatives considered: "first registration
+   wins in a time window" (racy — a bot could win; rejected); GitHub/Cloudflare
+   OAuth as the bootstrap root (heavier; the token *is* effectively that root
+   since only the deployer can set the secret).
+
+2. **Recovery if all passkeys are lost.** **Resolved:** three layers — encourage
+   ≥2 passkeys at setup; **printable single-use backup codes** (see § Backup
+   codes); and the redeploy root (`/anglesite:indieweb --reset-auth` rotates
+   `INDIEWEB_REG_TOKEN` and re-opens registration) as the ultimate fallback for
+   the owner who controls the Cloudflare account + GitHub repo.
+
+3. **Session signing key.** **Resolved:** a separate new `INDIEAUTH_SESSION_KEY`
+   (rotating the session key doesn't invalidate issued IndieAuth tokens, and vice
+   versa).
+
+4. **Profile (`me`/h-card) returned to clients.** **Resolved:** `me = SITE_URL`;
+   `profile.name` from `OWNER_NAME` (collected on-demand per the PII policy),
+   `profile.photo` from the site logo if present.
+
+## Security considerations
+
+- **rpId / origin** derive from `SITE_URL`; passkeys are domain-bound, so an
+  endpoint served from `*.workers.dev` can't impersonate the custom domain (the
+  skill already requires a custom domain).
+- **Consent token** is HMAC-bound to `client_id|redirect_uri|scope|nonce|exp` and
+  delivered only via the POST-through, blocking consent-screen-skip deep links.
+- **`user_verification: "required"`** so a stolen unlocked device still needs the
+  biometric/PIN gate.
+- The deploy scan already treats `/auth*` as intentional public routes and
+  asserts `INDIEAUTH_*` keys are secret bindings; extend it to `INDIEAUTH_SESSION_KEY`
+  and `INDIEWEB_REG_TOKEN`.
+- Registration endpoints must fail closed: no token and no session → 403.
+
+## Testing (TDD)
+
+Plugin-side, against `@dwk/webauthn`/`@dwk/indieauth` stubs (the established
+pattern), each behavior failing-first:
+
+- `approveAuthorization`: no session → returns a `Response` (the consent page),
+  not an approval; never mints on an unauthenticated request.
+- valid session + matching consent token → returns `AuthorizationApproval` with
+  `me === SITE_URL` and the requested scopes.
+- forged/missing/mismatched `_consent` token with a valid session → still returns
+  the consent page, never an approval (deep-link-skip blocked).
+- `/auth/webauthn/register/*` with neither token nor session → 403.
+- backup code: an unused code establishes a session and is marked `used_at`; the
+  same code a second time fails; an unknown code returns the consent page
+  unchanged (no oracle); attempts are rate-limited.
+- session cookie verify mirrors the membership-cookie tests (tamper, expiry).
+- dispatch: `/auth/*` routes only when `AUTH_DB` is bound; `WEBAUTHN`-less env
+  fails closed with a clear error.
+
+## Out of scope
+
+- **Micropub realignment (#2c)** — `createMicropub({ baseUrl, me })`; its auth is
+  the IndieAuth *token*, so it depends on this shipping but needs no passkey work.
+- IndieAuth client features (signing *into* other sites) beyond what
+  `@dwk/indieauth` already provides.
+- Multi-user / delegated identity — one owner per site.
+
+## Build sequence (for the implementation plan)
+
+1. DO binding + `migrations` + `WebAuthnObject` re-export; `createWebAuthn` wired,
+   ceremonies reachable (no gating yet) — prove the DO boots.
+2. Owner session cookie (issue/verify), mirroring membership helpers.
+3. Registration gating (§1) + `/auth/register` page; enrol a credential E2E.
+4. `approveAuthorization` + consent page + `/auth/consent` + consent token.
+5. Backup codes: `OWNER_AUTH_DB` table, generation/display, single-use redemption
+   on the consent page, regeneration from an authenticated session.
+6. `createIndieAuth({ baseUrl, approveAuthorization })` wired into dispatch.
+7. Skill (`/anglesite:indieweb`) provisions the DO, `OWNER_AUTH_DB`, secrets, the
+   one-time registration link, and shows the backup codes once; deploy-scan
+   extensions; docs + ADR-0022.

--- a/scripts/pre-deploy-check.sh
+++ b/scripts/pre-deploy-check.sh
@@ -81,12 +81,13 @@ if grep -rE 'pat[A-Za-z0-9]{14}\.[A-Za-z0-9]{32,}|sk-[A-Za-z0-9]{20,}|gh[pousr]_
   REASONS+=("API token pattern found in source or build output")
 fi
 
-# 2b. IndieWeb secret bindings (INDIEAUTH_SIGNING_KEY, GITHUB_TOKEN) committed
-# as literals. Name-only references never match — env.GITHUB_TOKEN,
-# ${{ secrets.GITHUB_TOKEN }}, and `wrangler secret put INDIEAUTH_SIGNING_KEY`
-# all lack a credential-shaped value after = or :
-if grep -rE '(INDIEAUTH_SIGNING_KEY|GITHUB_TOKEN)["'\'']?[[:space:]]*[:=][[:space:]]*["'\'']?[A-Za-z0-9+/_-]{16,}' "${TOKEN_SCAN_PATHS[@]}" 2>/dev/null | grep -q .; then
-  REASONS+=("INDIEAUTH_SIGNING_KEY or GITHUB_TOKEN committed in source — rotate it and store it with 'wrangler secret put'")
+# 2b. IndieWeb secret bindings (INDIEAUTH_SIGNING_KEY, INDIEAUTH_SESSION_KEY,
+# INDIEWEB_REG_TOKEN, GITHUB_TOKEN) committed as literals. Name-only references
+# never match — env.GITHUB_TOKEN, ${{ secrets.GITHUB_TOKEN }}, and
+# `wrangler secret put INDIEAUTH_SIGNING_KEY` all lack a credential-shaped value
+# after = or :
+if grep -rE '(INDIEAUTH_SIGNING_KEY|INDIEAUTH_SESSION_KEY|INDIEWEB_REG_TOKEN|GITHUB_TOKEN)["'\'']?[[:space:]]*[:=][[:space:]]*["'\'']?[A-Za-z0-9+/_-]{16,}' "${TOKEN_SCAN_PATHS[@]}" 2>/dev/null | grep -q .; then
+  REASONS+=("An IndieWeb secret (INDIEAUTH_SIGNING_KEY / INDIEAUTH_SESSION_KEY / INDIEWEB_REG_TOKEN / GITHUB_TOKEN) is committed in source — rotate it and store it with 'wrangler secret put'")
 fi
 
 # 3. Third-party scripts — unauthorized external JS (allowlist driven by .site-config)

--- a/skills/indieweb/SKILL.md
+++ b/skills/indieweb/SKILL.md
@@ -80,6 +80,7 @@ Each endpoint stores data in its own D1 database. Create only the databases for 
 | Endpoint | D1 database name | Binding name | `.site-config` key |
 |---|---|---|---|
 | IndieAuth | `indieauth` | `AUTH_DB` | `INDIEWEB_AUTH_DB_ID` |
+| IndieAuth (owner auth) | `owner-auth` | `OWNER_AUTH_DB` | `INDIEWEB_OWNER_AUTH_DB_ID` |
 | Micropub | `micropub` | `MICROPUB_DB` | `INDIEWEB_MICROPUB_DB_ID` |
 | Webmention | `webmention` | `WEBMENTION_INBOX` | `INDIEWEB_WEBMENTION_DB_ID` |
 
@@ -198,6 +199,56 @@ npx wrangler secret put INDIEAUTH_SIGNING_KEY --name <CF_PROJECT_NAME>
 ```
 
 Tell the owner to paste the generated key when prompted. The key never appears in source code or `.site-config` — it lives only in Cloudflare's secret store.
+
+### 5c — Passkey owner authentication (if IndieAuth selected)
+
+IndieAuth signs the owner in to other sites with their domain, so the owner must
+prove they are the owner before a token is minted. Anglesite uses **passkeys**
+(`@dwk/webauthn`, served from the `WEBAUTHN` Durable Object — already declared in
+`wrangler.jsonc`, no resource to create) plus printable backup codes.
+
+1. **Session + registration secrets.** Generate and store both:
+
+   ```sh
+   openssl rand -hex 32
+   ```
+
+   ```sh
+   npx wrangler secret put INDIEAUTH_SESSION_KEY --name <CF_PROJECT_NAME>
+   ```
+
+   ```sh
+   openssl rand -hex 24
+   ```
+
+   ```sh
+   npx wrangler secret put INDIEWEB_REG_TOKEN --name <CF_PROJECT_NAME>
+   ```
+
+   `INDIEAUTH_SESSION_KEY` signs the owner-session cookie; `INDIEWEB_REG_TOKEN`
+   is the one-time gate for the first passkey enrolment. Both live only in the
+   secret store — the deploy scan fails the build if either is committed.
+
+2. **Enrol the first passkey.** After the next deploy, give the owner the
+   one-time link (substitute the token value just set):
+
+   `https://<SITE_DOMAIN>/auth/register?token=<INDIEWEB_REG_TOKEN>`
+
+   Tell them to open it on each device they want to sign in from and **register
+   at least two passkeys** (e.g. phone + laptop) so a lost device isn't a
+   lockout. Once a passkey exists, they can add more from a signed-in session at
+   `/auth/register`.
+
+3. **Backup codes.** Have the owner generate 10 single-use backup codes from
+   `/auth/register` and **print or save them now**. A code can stand in for a
+   passkey on the sign-in screen if every device is unavailable. Only hashes are
+   stored; the plaintext is shown once.
+
+4. **Recovery.** Three layers: multiple passkeys, the backup codes, and — as the
+   ultimate root — redeploy access. If the owner loses everything, re-run
+   `/anglesite:indieweb` and choose "reset owner auth", which rotates
+   `INDIEWEB_REG_TOKEN` and re-opens registration (only someone who controls the
+   Cloudflare account can do this).
 
 ### 5b — GitHub token (if Micropub selected)
 

--- a/template/scripts/pre-deploy-check.ts
+++ b/template/scripts/pre-deploy-check.ts
@@ -82,7 +82,7 @@ export const githubTokenPattern = /\bgh[pousr]_[A-Za-z0-9]{36,}\b|\bgithub_pat_[
  * `<`, and `.` so env interpolations, doc placeholders, and property accesses
  * never match.
  */
-export const committedSecretPattern = /\b(?:INDIEAUTH_SIGNING_KEY|GITHUB_TOKEN)["']?\s*[:=]\s*["']?[A-Za-z0-9+/_-]{16,}/;
+export const committedSecretPattern = /\b(?:INDIEAUTH_SIGNING_KEY|INDIEAUTH_SESSION_KEY|INDIEWEB_REG_TOKEN|GITHUB_TOKEN)["']?\s*[:=]\s*["']?[A-Za-z0-9+/_-]{16,}/;
 
 /**
  * IndieWeb endpoints served by the site Worker (`worker/site-entry.js`), set

--- a/template/worker/auth-pages.js
+++ b/template/worker/auth-pages.js
@@ -1,0 +1,163 @@
+/**
+ * Server-rendered HTML for the passkey IndieAuth owner-auth flow (no build step,
+ * no framework). Two pages:
+ *
+ *   - renderConsentPage: shown by approveAuthorization when the owner must sign
+ *     in (passkey or backup code) and approve a client's authorization request.
+ *   - renderRegisterPage: the owner-only passkey enrolment page.
+ *
+ * Client/scope values come from the (attacker-controlled) query string, so every
+ * interpolated value is HTML-escaped.
+ */
+
+function escapeHtml(value) {
+  return String(value).replace(
+    /[&<>"']/g,
+    (c) =>
+      ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      })[c],
+  );
+}
+
+const SHELL = (title, body) =>
+  `<!doctype html><html lang="en"><head><meta charset="utf-8">` +
+  `<meta name="viewport" content="width=device-width, initial-scale=1">` +
+  `<meta name="robots" content="noindex">` +
+  `<title>${escapeHtml(title)}</title>` +
+  `<style>body{font-family:system-ui,sans-serif;max-width:32rem;margin:4rem auto;padding:0 1rem;line-height:1.5}` +
+  `button{font:inherit;padding:.6rem 1rem;cursor:pointer}details{margin-top:1.5rem}` +
+  `.client{font-weight:600}.scopes{font-family:ui-monospace,monospace}</style></head>` +
+  `<body>${body}</body></html>`;
+
+/**
+ * @param request  the inbound /auth request (its query string carries the
+ *                 authorization params we echo back to /auth/consent).
+ * @param authenticated  true when a valid owner session already exists (skip the
+ *                 passkey step; just show Approve/Deny).
+ */
+export function renderConsentPage({ request, authenticated = false }) {
+  const url = new URL(request.url);
+  const query = url.searchParams.toString();
+  const clientId = url.searchParams.get("client_id") ?? "";
+  const scope = url.searchParams.get("scope") ?? "";
+
+  const signIn = authenticated
+    ? ""
+    : `<p>Sign in as the site owner to continue.</p>
+       <button id="passkey-signin" type="button">Sign in with a passkey</button>
+       <details><summary>Use a backup code instead</summary>
+         <form id="backup-form" method="POST" action="/auth/consent">
+           <input type="hidden" name="query" value="${escapeHtml(query)}">
+           <label>Backup code <input name="backupCode" autocomplete="one-time-code" required></label>
+           <button type="submit">Use code</button>
+         </form>
+       </details>`;
+
+  const approve = authenticated
+    ? `<form method="POST" action="/auth/consent">
+         <input type="hidden" name="query" value="${escapeHtml(query)}">
+         <input type="hidden" name="approve" value="1">
+         <button type="submit">Approve</button>
+       </form>`
+    : "";
+
+  const body =
+    `<h1>Authorize sign-in</h1>` +
+    `<p><span class="client">${escapeHtml(clientId || "An application")}</span> wants to sign in as you` +
+    (scope ? ` and request <span class="scopes">${escapeHtml(scope)}</span>` : "") +
+    `.</p>` +
+    signIn +
+    approve +
+    `<script type="module">
+      const QUERY = ${JSON.stringify(query)};
+      const btn = document.getElementById("passkey-signin");
+      function b64urlToBytes(s){s=s.replace(/-/g,"+").replace(/_/g,"/");const p=s.length%4?"=".repeat(4-s.length%4):"";const b=atob(s+p);return Uint8Array.from(b,c=>c.charCodeAt(0));}
+      function bytesToB64url(buf){let s=btoa(String.fromCharCode(...new Uint8Array(buf)));return s.replace(/\\+/g,"-").replace(/\\//g,"_").replace(/=+$/,"");}
+      btn && btn.addEventListener("click", async () => {
+        btn.disabled = true;
+        try {
+          const optRes = await fetch("/auth/webauthn/authenticate/options", { method: "POST" });
+          const opts = await optRes.json();
+          const pk = opts.publicKey ?? opts;
+          pk.challenge = b64urlToBytes(pk.challenge);
+          (pk.allowCredentials||[]).forEach(c => c.id = b64urlToBytes(c.id));
+          const cred = await navigator.credentials.get({ publicKey: pk });
+          const assertion = {
+            id: cred.id,
+            rawId: bytesToB64url(cred.rawId),
+            type: cred.type,
+            response: {
+              clientDataJSON: bytesToB64url(cred.response.clientDataJSON),
+              authenticatorData: bytesToB64url(cred.response.authenticatorData),
+              signature: bytesToB64url(cred.response.signature),
+              userHandle: cred.response.userHandle ? bytesToB64url(cred.response.userHandle) : null,
+            },
+          };
+          const res = await fetch("/auth/consent", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ assertion, query: QUERY }),
+          });
+          if (res.redirected) { location.href = res.url; }
+          else { btn.disabled = false; alert("Sign-in failed."); }
+        } catch (e) { btn.disabled = false; alert("Sign-in failed."); }
+      });
+    </script>`;
+
+  return SHELL("Authorize sign-in", body);
+}
+
+/**
+ * Owner-only passkey enrolment page. `token` (when present) is the one-time
+ * registration token threaded into the ceremony fetches so the worker gate
+ * accepts an otherwise-unauthenticated enrolment.
+ */
+export function renderRegisterPage({ token = "" } = {}) {
+  const body =
+    `<h1>Register a passkey</h1>` +
+    `<p>Add a passkey for your phone or laptop. Register at least two so a lost ` +
+    `device doesn't lock you out.</p>` +
+    `<button id="passkey-register" type="button">Register a passkey</button>` +
+    `<script type="module">
+      const TOKEN = ${JSON.stringify(token)};
+      const qs = TOKEN ? ("?token=" + encodeURIComponent(TOKEN)) : "";
+      function b64urlToBytes(s){s=s.replace(/-/g,"+").replace(/_/g,"/");const p=s.length%4?"=".repeat(4-s.length%4):"";const b=atob(s+p);return Uint8Array.from(b,c=>c.charCodeAt(0));}
+      function bytesToB64url(buf){let s=btoa(String.fromCharCode(...new Uint8Array(buf)));return s.replace(/\\+/g,"-").replace(/\\//g,"_").replace(/=+$/,"");}
+      const btn = document.getElementById("passkey-register");
+      btn.addEventListener("click", async () => {
+        btn.disabled = true;
+        try {
+          const optRes = await fetch("/auth/webauthn/register/options" + qs, { method: "POST" });
+          const opts = await optRes.json();
+          const pk = opts.publicKey ?? opts;
+          pk.challenge = b64urlToBytes(pk.challenge);
+          pk.user.id = b64urlToBytes(pk.user.id);
+          (pk.excludeCredentials||[]).forEach(c => c.id = b64urlToBytes(c.id));
+          const cred = await navigator.credentials.create({ publicKey: pk });
+          const attestation = {
+            id: cred.id,
+            rawId: bytesToB64url(cred.rawId),
+            type: cred.type,
+            response: {
+              clientDataJSON: bytesToB64url(cred.response.clientDataJSON),
+              attestationObject: bytesToB64url(cred.response.attestationObject),
+            },
+          };
+          const res = await fetch("/auth/webauthn/register/verify" + qs, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(attestation),
+          });
+          alert(res.ok ? "Passkey registered." : "Registration failed.");
+          btn.disabled = false;
+        } catch (e) { btn.disabled = false; alert("Registration failed."); }
+      });
+    </script>`;
+
+  return SHELL("Register a passkey", body);
+}

--- a/template/worker/auth-pages.js
+++ b/template/worker/auth-pages.js
@@ -10,6 +10,19 @@
  * interpolated value is HTML-escaped.
  */
 
+// Serialize a value for safe interpolation into an inline <script>. JSON.stringify
+// alone does NOT escape `</script>` (or the U+2028/U+2029 line separators that
+// break JS string literals), so a `</script>` in attacker-controlled input would
+// terminate the element. Escaping `<`,`>`,`&` to \uXXXX keeps it inert.
+function jsonForScript(value) {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003C")
+    .replace(/>/g, "\\u003E")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
 function escapeHtml(value) {
   return String(value).replace(
     /[&<>"']/g,
@@ -74,7 +87,7 @@ export function renderConsentPage({ request, authenticated = false }) {
     signIn +
     approve +
     `<script type="module">
-      const QUERY = ${JSON.stringify(query)};
+      const QUERY = ${jsonForScript(query)};
       const btn = document.getElementById("passkey-signin");
       function b64urlToBytes(s){s=s.replace(/-/g,"+").replace(/_/g,"/");const p=s.length%4?"=".repeat(4-s.length%4):"";const b=atob(s+p);return Uint8Array.from(b,c=>c.charCodeAt(0));}
       function bytesToB64url(buf){let s=btoa(String.fromCharCode(...new Uint8Array(buf)));return s.replace(/\\+/g,"-").replace(/\\//g,"_").replace(/=+$/,"");}
@@ -124,7 +137,7 @@ export function renderRegisterPage({ token = "" } = {}) {
     `device doesn't lock you out.</p>` +
     `<button id="passkey-register" type="button">Register a passkey</button>` +
     `<script type="module">
-      const TOKEN = ${JSON.stringify(token)};
+      const TOKEN = ${jsonForScript(token)};
       const qs = TOKEN ? ("?token=" + encodeURIComponent(TOKEN)) : "";
       function b64urlToBytes(s){s=s.replace(/-/g,"+").replace(/_/g,"/");const p=s.length%4?"=".repeat(4-s.length%4):"";const b=atob(s+p);return Uint8Array.from(b,c=>c.charCodeAt(0));}
       function bytesToB64url(buf){let s=btoa(String.fromCharCode(...new Uint8Array(buf)));return s.replace(/\\+/g,"-").replace(/\\//g,"_").replace(/=+$/,"");}

--- a/template/worker/owner-auth.js
+++ b/template/worker/owner-auth.js
@@ -135,3 +135,69 @@ export async function verifyConsentToken(token, keyHex, req) {
     consentMessage(req, exp),
   );
 }
+
+// --- single-use backup codes (OWNER_AUTH_DB) -------------------------------
+
+async function sha256Hex(s) {
+  const d = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(s));
+  return bytesToHex(d);
+}
+
+// Codes are high-entropy (10 bytes → 50 bits over a 32-symbol alphabet), emitted
+// uppercase and grouped `XXXXX-XXXXX` for legibility on a printed sheet.
+function randomCode() {
+  const bytes = new Uint8Array(10);
+  crypto.getRandomValues(bytes);
+  const A = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"; // Crockford base32 (no I L O U)
+  const s = [...bytes].map((x) => A[x % 32]).join("");
+  return `${s.slice(0, 5)}-${s.slice(5, 10)}`;
+}
+
+async function ensureBackupTable(db) {
+  await db
+    .prepare(
+      `CREATE TABLE IF NOT EXISTS owner_backup_codes (` +
+        `code_hash TEXT PRIMARY KEY, created_at INTEGER, used_at INTEGER)`,
+    )
+    .run();
+}
+
+// Generate `n` codes, store only their hashes, and return the plaintext ONCE for
+// the owner to print. Callers must never persist the returned plaintext.
+export async function generateBackupCodes(db, n = 10) {
+  await ensureBackupTable(db);
+  const now = Math.floor(Date.now() / 1000);
+  const codes = [];
+  for (let i = 0; i < n; i++) {
+    const code = randomCode();
+    codes.push(code);
+    await db
+      .prepare(
+        `INSERT INTO owner_backup_codes (code_hash, created_at, used_at) VALUES (?1, ?2, NULL)`,
+      )
+      .bind(await sha256Hex(code), now)
+      .run();
+  }
+  return codes;
+}
+
+// Redeem a code: true on a first, valid redemption; false for unknown, already
+// used, or empty. Normalizes case/whitespace to match the emitted form.
+export async function redeemBackupCode(db, code) {
+  if (!code) return false;
+  const hash = await sha256Hex(String(code).trim().toUpperCase());
+  const row = await db
+    .prepare(
+      `SELECT code_hash FROM owner_backup_codes WHERE code_hash = ?1 AND used_at IS NULL`,
+    )
+    .bind(hash)
+    .first();
+  if (!row) return false;
+  await db
+    .prepare(
+      `UPDATE owner_backup_codes SET used_at = ?2 WHERE code_hash = ?1 AND used_at IS NULL`,
+    )
+    .bind(hash, Math.floor(Date.now() / 1000))
+    .run();
+  return true;
+}

--- a/template/worker/owner-auth.js
+++ b/template/worker/owner-auth.js
@@ -1,0 +1,102 @@
+/**
+ * Owner-side authentication helpers for the passkey-backed IndieAuth flow
+ * (configured by /anglesite:indieweb). These are the state @dwk/indieauth
+ * deliberately leaves to the deployer:
+ *
+ *   - the signed owner-session cookie (proof the owner authenticated), and
+ *   - the request-bound consent token (proof the owner approved THIS request),
+ *   - single-use printable backup codes (a recovery factor).
+ *
+ * All crypto is WebCrypto HMAC-SHA-256 / SHA-256 — no package dependencies. The
+ * session cookie mirrors the membership-cookie pattern in site-entry.js.
+ */
+
+export const OWNER_COOKIE = "__anglesite_owner";
+
+// --- byte/encoding helpers -------------------------------------------------
+
+function hexToBytes(hex) {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.substr(i * 2, 2), 16);
+  }
+  return out;
+}
+
+function bytesToHex(buf) {
+  return [...new Uint8Array(buf)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function b64urlEncode(bytes) {
+  const s = btoa(String.fromCharCode(...bytes));
+  return s.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function b64urlDecode(str) {
+  const pad = str.length % 4 ? "=".repeat(4 - (str.length % 4)) : "";
+  const bin = atob(str.replace(/-/g, "+").replace(/_/g, "/") + pad);
+  return new Uint8Array([...bin].map((c) => c.charCodeAt(0)));
+}
+
+async function hmacKey(hex, usages) {
+  return crypto.subtle.importKey(
+    "raw",
+    hexToBytes(hex),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    usages,
+  );
+}
+
+// --- owner session cookie --------------------------------------------------
+
+export async function issueOwnerSession(signingKeyHex, ttlSeconds = 900) {
+  const exp = Math.floor(Date.now() / 1000) + ttlSeconds;
+  const payload = new TextEncoder().encode(JSON.stringify({ sub: "owner", exp }));
+  const key = await hmacKey(signingKeyHex, ["sign"]);
+  const sig = await crypto.subtle.sign("HMAC", key, payload);
+  return `${b64urlEncode(payload)}.${bytesToHex(sig)}`;
+}
+
+export async function verifyOwnerSession(value, signingKeyHex) {
+  if (!value || !signingKeyHex) return null;
+  const dot = value.indexOf(".");
+  if (dot < 0) return null;
+  const payloadB64 = value.slice(0, dot);
+  const sigHex = value.slice(dot + 1);
+  if (!/^[0-9a-f]+$/i.test(sigHex)) return null;
+  let payloadBytes;
+  try {
+    payloadBytes = b64urlDecode(payloadB64);
+  } catch {
+    return null;
+  }
+  const key = await hmacKey(signingKeyHex, ["verify"]);
+  const ok = await crypto.subtle.verify(
+    "HMAC",
+    key,
+    hexToBytes(sigHex),
+    payloadBytes,
+  );
+  if (!ok) return null;
+  let payload;
+  try {
+    payload = JSON.parse(new TextDecoder().decode(payloadBytes));
+  } catch {
+    return null;
+  }
+  if (payload?.sub !== "owner" || typeof payload.exp !== "number") return null;
+  if (payload.exp * 1000 < Date.now()) return null;
+  return payload;
+}
+
+export function readCookie(cookieHeader, name) {
+  for (const piece of (cookieHeader ?? "").split(";")) {
+    const t = piece.trim();
+    const eq = t.indexOf("=");
+    if (eq > 0 && t.slice(0, eq) === name) return t.slice(eq + 1);
+  }
+  return null;
+}

--- a/template/worker/owner-auth.js
+++ b/template/worker/owner-auth.js
@@ -100,3 +100,38 @@ export function readCookie(cookieHeader, name) {
   }
   return null;
 }
+
+// --- request-bound consent token -------------------------------------------
+
+// HMAC over a canonical client_id|redirect_uri|scope|exp string. The token is
+// delivered to the owner's browser only after it POSTs through /auth/consent, so
+// a client can't pre-fabricate `&_consent=…` to skip the visible consent screen.
+function consentMessage({ clientId, redirectUri, scope }, exp) {
+  return new TextEncoder().encode(
+    [clientId, redirectUri, scope ?? "", exp].join("|"),
+  );
+}
+
+export async function mintConsentToken(keyHex, req, ttlSeconds = 300) {
+  const exp = Math.floor(Date.now() / 1000) + ttlSeconds;
+  const key = await hmacKey(keyHex, ["sign"]);
+  const sig = await crypto.subtle.sign("HMAC", key, consentMessage(req, exp));
+  return `${exp}.${bytesToHex(sig)}`;
+}
+
+export async function verifyConsentToken(token, keyHex, req) {
+  if (!token) return false;
+  const dot = token.indexOf(".");
+  if (dot < 0) return false;
+  const exp = Number(token.slice(0, dot));
+  const sigHex = token.slice(dot + 1);
+  if (!Number.isFinite(exp) || exp * 1000 < Date.now()) return false;
+  if (!/^[0-9a-f]+$/i.test(sigHex)) return false;
+  const key = await hmacKey(keyHex, ["verify"]);
+  return crypto.subtle.verify(
+    "HMAC",
+    key,
+    hexToBytes(sigHex),
+    consentMessage(req, exp),
+  );
+}

--- a/template/worker/site-entry.js
+++ b/template/worker/site-entry.js
@@ -72,7 +72,7 @@ import {
   mintConsentToken,
   redeemBackupCode,
 } from "./owner-auth.js";
-import { renderConsentPage } from "./auth-pages.js";
+import { renderConsentPage, renderRegisterPage } from "./auth-pages.js";
 
 // @dwk/webauthn is bound as a Durable Object namespace (WEBAUTHN); the Worker
 // must re-export the class so wrangler can instantiate it.
@@ -292,6 +292,26 @@ const worker = {
 
     // 4. IndieWeb endpoints — each gated on its D1 binding being present.
     const p = url.pathname;
+    if (env.AUTH_DB && p === "/auth/register" && request.method === "GET")
+      return new Response(
+        renderRegisterPage({ token: url.searchParams.get("token") ?? "" }),
+        { status: 200, headers: { "content-type": "text/html; charset=utf-8" } },
+      );
+    // Owner-only gate: the package's /register/* enrols any passkey, so the
+    // first enrolment must carry the one-time INDIEWEB_REG_TOKEN, and later ones
+    // a valid owner session. /authenticate/* stays open (it only proves
+    // possession of an already-registered credential).
+    if (env.AUTH_DB && p.startsWith("/auth/webauthn/register/")) {
+      const tokenOk =
+        env.INDIEWEB_REG_TOKEN &&
+        url.searchParams.get("token") === env.INDIEWEB_REG_TOKEN;
+      const session = await verifyOwnerSession(
+        readCookie(request.headers.get("Cookie") ?? "", OWNER_COOKIE),
+        env.INDIEAUTH_SESSION_KEY,
+      );
+      if (!tokenOk && !session)
+        return new Response("Forbidden", { status: 403 });
+    }
     if (env.AUTH_DB && p.startsWith("/auth/webauthn/"))
       return authFor(env).webauthn(request, env, ctx);
     if (env.AUTH_DB && p === "/auth/consent" && request.method === "POST")

--- a/template/worker/site-entry.js
+++ b/template/worker/site-entry.js
@@ -61,7 +61,12 @@ import {
   createWebmentionQueueConsumer,
   createD1Inbox,
 } from "@dwk/webmention";
+import { createWebAuthn, WebAuthnObject } from "@dwk/webauthn";
 import { sync as syncMicropubBridge } from "./indieweb-bridge.js";
+
+// @dwk/webauthn is bound as a Durable Object namespace (WEBAUTHN); the Worker
+// must re-export the class so wrangler can instantiate it.
+export { WebAuthnObject };
 
 const COOKIE_NAME = "__anglesite_member";
 
@@ -96,6 +101,22 @@ function webmentionFor(env) {
       inbox: env.WEBMENTION_INBOX ? createD1Inbox(env.WEBMENTION_INBOX) : null,
     };
     webmentionByEnv.set(env, bundle);
+  }
+  return bundle;
+}
+
+// IndieAuth + WebAuthn factories also need config (origin/rpId) derived from
+// env.SITE_URL, available only at request time. Build once per env and memoize.
+const authByEnv = new WeakMap();
+function authFor(env) {
+  let bundle = authByEnv.get(env);
+  if (!bundle) {
+    const origin = env.SITE_URL;
+    const rpId = origin ? new URL(origin).host : undefined;
+    bundle = {
+      webauthn: createWebAuthn({ rpId, rpName: rpId ?? "site", origin }),
+    };
+    authByEnv.set(env, bundle);
   }
   return bundle;
 }
@@ -170,6 +191,8 @@ const worker = {
 
     // 4. IndieWeb endpoints — each gated on its D1 binding being present.
     const p = url.pathname;
+    if (env.AUTH_DB && p.startsWith("/auth/webauthn/"))
+      return authFor(env).webauthn(request, env, ctx);
     if (env.AUTH_DB && p.startsWith("/auth"))
       return indieauth(request, env, ctx);
     if (env.MICROPUB_DB && (p === "/micropub" || p === "/media"))

--- a/template/worker/site-entry.js
+++ b/template/worker/site-entry.js
@@ -54,7 +54,7 @@
  */
 
 import premiumRoutes from "./_premium-routes.json";
-import { createHandler as createIndieAuth } from "@dwk/indieauth";
+import { createIndieAuth } from "@dwk/indieauth";
 import { createHandler as createMicropub } from "@dwk/micropub";
 import {
   createWebmention,
@@ -63,6 +63,13 @@ import {
 } from "@dwk/webmention";
 import { createWebAuthn, WebAuthnObject } from "@dwk/webauthn";
 import { sync as syncMicropubBridge } from "./indieweb-bridge.js";
+import {
+  OWNER_COOKIE,
+  readCookie,
+  verifyOwnerSession,
+  verifyConsentToken,
+} from "./owner-auth.js";
+import { renderConsentPage } from "./auth-pages.js";
 
 // @dwk/webauthn is bound as a Durable Object namespace (WEBAUTHN); the Worker
 // must re-export the class so wrangler can instantiate it.
@@ -70,10 +77,42 @@ export { WebAuthnObject };
 
 const COOKIE_NAME = "__anglesite_member";
 
-const indieauth = createIndieAuth();
 const micropub = createMicropub({
   generatePostUrl: (slug) => `/notes/${slug}/`,
 });
+
+// The IndieAuth authentication + consent hook. @dwk/indieauth owns the protocol;
+// proving the owner's identity (passkey/backup code) and obtaining consent is
+// ours. Returns an AuthorizationApproval only when the request carries a valid
+// owner-session cookie AND a consent token bound to this exact request;
+// otherwise returns the consent page (the library forwards it verbatim).
+function makeApproveAuthorization(env) {
+  return async (authReq, httpRequest) => {
+    const sessionKey = env.INDIEAUTH_SESSION_KEY;
+    const cookie = readCookie(
+      httpRequest.headers.get("Cookie") ?? "",
+      OWNER_COOKIE,
+    );
+    const session = await verifyOwnerSession(cookie, sessionKey);
+    const consent = new URL(httpRequest.url).searchParams.get("_consent");
+    const bound = {
+      clientId: authReq.clientId,
+      redirectUri: authReq.redirectUri,
+      scope: authReq.scope,
+    };
+    if (session && consent && (await verifyConsentToken(consent, sessionKey, bound))) {
+      return {
+        me: env.SITE_URL,
+        scopes: authReq.scopes,
+        profile: { url: env.SITE_URL },
+      };
+    }
+    return new Response(
+      renderConsentPage({ request: httpRequest, authenticated: !!session }),
+      { status: 200, headers: { "content-type": "text/html; charset=utf-8" } },
+    );
+  };
+}
 
 // @dwk/webmention's factories take config (baseUrl) at construction, but the
 // Worker only has `env` at request/queue time — and the queue consumer has no
@@ -114,6 +153,10 @@ function authFor(env) {
     const origin = env.SITE_URL;
     const rpId = origin ? new URL(origin).host : undefined;
     bundle = {
+      indieauth: createIndieAuth({
+        baseUrl: origin,
+        approveAuthorization: makeApproveAuthorization(env),
+      }),
       webauthn: createWebAuthn({ rpId, rpName: rpId ?? "site", origin }),
     };
     authByEnv.set(env, bundle);
@@ -194,7 +237,7 @@ const worker = {
     if (env.AUTH_DB && p.startsWith("/auth/webauthn/"))
       return authFor(env).webauthn(request, env, ctx);
     if (env.AUTH_DB && p.startsWith("/auth"))
-      return indieauth(request, env, ctx);
+      return authFor(env).indieauth(request, env, ctx);
     if (env.MICROPUB_DB && (p === "/micropub" || p === "/media"))
       return micropub(request, env, ctx);
     if (env.WEBMENTION_INBOX && p === "/webmention")

--- a/template/worker/site-entry.js
+++ b/template/worker/site-entry.js
@@ -68,6 +68,9 @@ import {
   readCookie,
   verifyOwnerSession,
   verifyConsentToken,
+  issueOwnerSession,
+  mintConsentToken,
+  redeemBackupCode,
 } from "./owner-auth.js";
 import { renderConsentPage } from "./auth-pages.js";
 
@@ -112,6 +115,61 @@ function makeApproveAuthorization(env) {
       { status: 200, headers: { "content-type": "text/html; charset=utf-8" } },
     );
   };
+}
+
+// POST /auth/consent — prove ownership (passkey assertion, backup code, or an
+// existing session's explicit Approve), then 302 back to /auth carrying a fresh
+// owner-session cookie and a request-bound consent token so approveAuthorization
+// completes. 401 on any failed proof.
+async function handleConsent(request, env, ctx) {
+  const sessionKey = env.INDIEAUTH_SESSION_KEY;
+  let body = {};
+  const contentType = request.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    body = await request.json().catch(() => ({}));
+  } else {
+    const form = await request.formData().catch(() => null);
+    if (form) body = Object.fromEntries(form);
+  }
+  const query = String(body.query ?? "");
+
+  let ok = false;
+  if (body.backupCode && env.OWNER_AUTH_DB) {
+    ok = await redeemBackupCode(env.OWNER_AUTH_DB, String(body.backupCode));
+  } else if (body.assertion) {
+    const verifyReq = new Request(
+      new URL("/auth/webauthn/authenticate/verify", request.url),
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body.assertion),
+      },
+    );
+    const verifyRes = await authFor(env).webauthn(verifyReq, env, ctx);
+    ok = verifyRes.ok;
+  } else if (body.approve) {
+    const cookie = readCookie(request.headers.get("Cookie") ?? "", OWNER_COOKIE);
+    ok = !!(await verifyOwnerSession(cookie, sessionKey));
+  }
+  if (!ok) return new Response("Unauthorized", { status: 401 });
+
+  const params = new URLSearchParams(query);
+  const bound = {
+    clientId: params.get("client_id") ?? "",
+    redirectUri: params.get("redirect_uri") ?? "",
+    scope: params.get("scope") ?? "",
+  };
+  const session = await issueOwnerSession(sessionKey, 900);
+  const consent = await mintConsentToken(sessionKey, bound, 300);
+  params.set("_consent", consent);
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: `/auth?${params.toString()}`,
+      "Set-Cookie": `${OWNER_COOKIE}=${session}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=900`,
+      "Cache-Control": "no-store",
+    },
+  });
 }
 
 // @dwk/webmention's factories take config (baseUrl) at construction, but the
@@ -236,6 +294,8 @@ const worker = {
     const p = url.pathname;
     if (env.AUTH_DB && p.startsWith("/auth/webauthn/"))
       return authFor(env).webauthn(request, env, ctx);
+    if (env.AUTH_DB && p === "/auth/consent" && request.method === "POST")
+      return handleConsent(request, env, ctx);
     if (env.AUTH_DB && p.startsWith("/auth"))
       return authFor(env).indieauth(request, env, ctx);
     if (env.MICROPUB_DB && (p === "/micropub" || p === "/media"))

--- a/template/wrangler.jsonc
+++ b/template/wrangler.jsonc
@@ -31,7 +31,8 @@
   "d1_databases": [
     { "binding": "AUTH_DB",          "database_name": "indieauth",   "database_id": "" },
     { "binding": "MICROPUB_DB",      "database_name": "micropub",    "database_id": "" },
-    { "binding": "WEBMENTION_INBOX", "database_name": "webmention",  "database_id": "" }
+    { "binding": "WEBMENTION_INBOX", "database_name": "webmention",  "database_id": "" },
+    { "binding": "OWNER_AUTH_DB",    "database_name": "owner-auth",  "database_id": "" }
   ],
   // Passkey owner-auth (IndieAuth) — provisioned by /anglesite:indieweb.
   // WebAuthnObject (from @dwk/webauthn, re-exported by worker/site-entry.js) owns

--- a/template/wrangler.jsonc
+++ b/template/wrangler.jsonc
@@ -33,6 +33,15 @@
     { "binding": "MICROPUB_DB",      "database_name": "micropub",    "database_id": "" },
     { "binding": "WEBMENTION_INBOX", "database_name": "webmention",  "database_id": "" }
   ],
+  // Passkey owner-auth (IndieAuth) — provisioned by /anglesite:indieweb.
+  // WebAuthnObject (from @dwk/webauthn, re-exported by worker/site-entry.js) owns
+  // challenge state + credential records. First Durable Object in the template.
+  "durable_objects": {
+    "bindings": [{ "name": "WEBAUTHN", "class_name": "WebAuthnObject" }]
+  },
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["WebAuthnObject"] }
+  ],
   "r2_buckets": [
     { "binding": "MEDIA", "bucket_name": "" }
   ],

--- a/tests/__stubs__/dwk-indieauth.ts
+++ b/tests/__stubs__/dwk-indieauth.ts
@@ -1,14 +1,52 @@
-// Stub for the unpublished @dwk/indieauth package. site-entry.js composes the
-// real handler at module load; in tests we only need a tagged handler so the
-// dispatch assertions can prove which endpoint a request reached. Tests never
-// mock this — the stub IS the substitute (the real package is 0.0.0/unpublished).
-export function createHandler(_config?: unknown) {
-  return Object.assign(
-    (_request: Request, _env: unknown, _ctx: unknown) =>
-      new Response("indieauth", { headers: { "x-handler": "indieauth" } }),
-    {
-      queue: async () => {},
-      scheduled: async () => {},
-    },
-  );
+// Stub for the @dwk/indieauth package (real 0.1.0-beta.3 API). site-entry.js
+// composes createIndieAuth({ baseUrl, approveAuthorization }) per-env. The stub
+// reproduces just enough of the authorization endpoint to exercise our
+// approveAuthorization hook: on GET /auth with a client_id it parses the request,
+// calls the hook, and either returns the hook's Response verbatim (the consent
+// page) or surfaces an AuthorizationApproval as JSON so tests can assert it.
+// Every other /auth* path is a tagged passthrough (proves dispatch reached here).
+
+interface AuthorizationRequest {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  scope: string;
+  scopes: readonly string[];
+  me?: string;
+}
+
+function parseAuthRequest(url: URL): AuthorizationRequest {
+  const q = url.searchParams;
+  const scope = q.get("scope") ?? "";
+  return {
+    clientId: q.get("client_id") ?? "",
+    redirectUri: q.get("redirect_uri") ?? "",
+    state: q.get("state") ?? "",
+    codeChallenge: q.get("code_challenge") ?? "",
+    codeChallengeMethod: q.get("code_challenge_method") ?? "S256",
+    scope,
+    scopes: scope ? scope.split(/\s+/) : [],
+    me: q.get("me") ?? undefined,
+  };
+}
+
+export function createIndieAuth(config: any) {
+  return async (request: Request, _env: unknown, _ctx: unknown) => {
+    const url = new URL(request.url);
+    if (url.pathname === "/auth" && url.searchParams.get("client_id")) {
+      const authReq = parseAuthRequest(url);
+      const result = await config.approveAuthorization(authReq, request);
+      if (result instanceof Response) return result;
+      return new Response(JSON.stringify(result), {
+        headers: {
+          "x-handler": "indieauth",
+          "x-approval": "1",
+          "content-type": "application/json",
+        },
+      });
+    }
+    return new Response("indieauth", { headers: { "x-handler": "indieauth" } });
+  };
 }

--- a/tests/__stubs__/dwk-webauthn.ts
+++ b/tests/__stubs__/dwk-webauthn.ts
@@ -1,0 +1,24 @@
+// Stub for the @dwk/webauthn package (real 0.1.0-beta.3 API). site-entry.js
+// composes createWebAuthn at module load and binds WebAuthnObject as a Durable
+// Object. The vitest alias maps "@dwk/webauthn" to this file so the worker and
+// the test share one module instance (and one counter).
+export const webauthnCalls = { fetch: 0 };
+export function resetWebauthnCalls() {
+  webauthnCalls.fetch = 0;
+}
+
+// Bound as a Durable Object class in wrangler; never instantiated in tests.
+export class WebAuthnObject {}
+
+// createWebAuthn(config) → fetch handler exposing the four ceremony endpoints.
+// The stub tags the response and echoes the ceremony path so dispatch + the
+// /auth/consent verify step can assert which ceremony was reached.
+export function createWebAuthn(_config?: unknown) {
+  return (req: Request, _env: unknown, _ctx: unknown) => {
+    webauthnCalls.fetch++;
+    const path = new URL(req.url).pathname;
+    return new Response("webauthn", {
+      headers: { "x-handler": "webauthn", "x-webauthn-path": path },
+    });
+  };
+}

--- a/tests/indieauth-approve.test.ts
+++ b/tests/indieauth-approve.test.ts
@@ -3,13 +3,39 @@
  * approval to one specific authorization request so a malicious client can't
  * deep-link past the visible consent screen.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import worker from "../template/worker/site-entry.js";
 import {
   mintConsentToken,
   verifyConsentToken,
+  issueOwnerSession,
+  OWNER_COOKIE,
 } from "../template/worker/owner-auth.js";
 
 const KEY = "00112233445566778899aabbccddeeff";
+const SESSION_KEY = "aabbccddeeff00112233445566778899";
+
+function ctx() {
+  return { waitUntil: vi.fn(), passThroughOnException: vi.fn() };
+}
+function env(o: Record<string, unknown> = {}) {
+  return {
+    ASSETS: { fetch: vi.fn(async () => new Response("asset")) },
+    SITE_URL: "https://example.com",
+    AUTH_DB: {},
+    WEBAUTHN: {},
+    INDIEAUTH_SESSION_KEY: SESSION_KEY,
+    ...o,
+  } as any;
+}
+function authUrl(extra = "") {
+  return (
+    "https://example.com/auth?response_type=code" +
+    "&client_id=https://app.example&redirect_uri=https://app.example/cb" +
+    "&state=xyz&code_challenge=abc&code_challenge_method=S256&scope=create" +
+    extra
+  );
+}
 const REQ = {
   clientId: "https://app.example",
   redirectUri: "https://app.example/cb",
@@ -38,5 +64,45 @@ describe("consent token", () => {
   it("rejects a malformed token", async () => {
     expect(await verifyConsentToken("", KEY, REQ)).toBe(false);
     expect(await verifyConsentToken("nodot", KEY, REQ)).toBe(false);
+  });
+});
+
+describe("approveAuthorization via the worker", () => {
+  it("returns the consent page when there is no owner session", async () => {
+    const res = await worker.fetch(new Request(authUrl()), env(), ctx());
+    expect(res.headers.get("x-approval")).toBeNull();
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('id="passkey-signin"');
+  });
+
+  it("returns an approval (me=SITE_URL) given a valid session + consent token", async () => {
+    const session = await issueOwnerSession(SESSION_KEY, 900);
+    const consent = await mintConsentToken(
+      SESSION_KEY,
+      {
+        clientId: "https://app.example",
+        redirectUri: "https://app.example/cb",
+        scope: "create",
+      },
+      300,
+    );
+    const request = new Request(authUrl("&_consent=" + encodeURIComponent(consent)), {
+      headers: { Cookie: `${OWNER_COOKIE}=${session}` },
+    });
+    const res = await worker.fetch(request, env(), ctx());
+    expect(res.headers.get("x-approval")).toBe("1");
+    const approval = await res.json();
+    expect(approval.me).toBe("https://example.com");
+    expect(approval.scopes).toContain("create");
+  });
+
+  it("ignores a forged consent token even with a valid session", async () => {
+    const session = await issueOwnerSession(SESSION_KEY, 900);
+    const request = new Request(authUrl("&_consent=deadbeef.0000"), {
+      headers: { Cookie: `${OWNER_COOKIE}=${session}` },
+    });
+    const res = await worker.fetch(request, env(), ctx());
+    expect(res.headers.get("x-approval")).toBeNull();
+    expect(await res.text()).toContain("passkey");
   });
 });

--- a/tests/indieauth-approve.test.ts
+++ b/tests/indieauth-approve.test.ts
@@ -1,0 +1,42 @@
+/**
+ * approveAuthorization + consent (#363, problem 2). The consent token binds an
+ * approval to one specific authorization request so a malicious client can't
+ * deep-link past the visible consent screen.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  mintConsentToken,
+  verifyConsentToken,
+} from "../template/worker/owner-auth.js";
+
+const KEY = "00112233445566778899aabbccddeeff";
+const REQ = {
+  clientId: "https://app.example",
+  redirectUri: "https://app.example/cb",
+  scope: "create",
+};
+
+describe("consent token", () => {
+  it("verifies a token bound to the same request", async () => {
+    const t = await mintConsentToken(KEY, REQ, 300);
+    expect(await verifyConsentToken(t, KEY, REQ)).toBe(true);
+  });
+
+  it("rejects when a bound field differs", async () => {
+    const t = await mintConsentToken(KEY, REQ, 300);
+    expect(await verifyConsentToken(t, KEY, { ...REQ, scope: "create media" })).toBe(false);
+    expect(
+      await verifyConsentToken(t, KEY, { ...REQ, redirectUri: "https://evil.example/cb" }),
+    ).toBe(false);
+  });
+
+  it("rejects an expired token", async () => {
+    const t = await mintConsentToken(KEY, REQ, -1);
+    expect(await verifyConsentToken(t, KEY, REQ)).toBe(false);
+  });
+
+  it("rejects a malformed token", async () => {
+    expect(await verifyConsentToken("", KEY, REQ)).toBe(false);
+    expect(await verifyConsentToken("nodot", KEY, REQ)).toBe(false);
+  });
+});

--- a/tests/indieauth-backup-codes.test.ts
+++ b/tests/indieauth-backup-codes.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Printable single-use backup codes (#363, problem 2 — recovery factor). Hashed
+ * in OWNER_AUTH_DB; redeemable exactly once.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  generateBackupCodes,
+  redeemBackupCode,
+} from "../template/worker/owner-auth.js";
+
+// Minimal in-memory D1 fake: prepare(sql).bind(...).run()/first()/all().
+function fakeD1() {
+  const rows: any[] = [];
+  return {
+    prepare(sql: string) {
+      const stmt: any = {
+        _args: [] as any[],
+        bind(...a: any[]) {
+          stmt._args = a;
+          return stmt;
+        },
+        async run() {
+          if (/INSERT/.test(sql)) {
+            rows.push({ code_hash: stmt._args[0], used_at: null });
+          } else if (/UPDATE/.test(sql)) {
+            const r = rows.find((x) => x.code_hash === stmt._args[0] && !x.used_at);
+            if (r) r.used_at = stmt._args[1];
+          }
+          return { success: true };
+        },
+        async first() {
+          if (/SELECT/.test(sql)) {
+            return rows.find((x) => x.code_hash === stmt._args[0] && !x.used_at) ?? null;
+          }
+          return null;
+        },
+        async all() {
+          return { results: rows };
+        },
+      };
+      return stmt;
+    },
+  } as any;
+}
+
+describe("backup codes", () => {
+  it("generates N distinct codes and redeems each exactly once", async () => {
+    const db = fakeD1();
+    const codes = await generateBackupCodes(db, 10);
+    expect(codes).toHaveLength(10);
+    expect(new Set(codes).size).toBe(10);
+
+    expect(await redeemBackupCode(db, codes[0])).toBe(true);
+    expect(await redeemBackupCode(db, codes[0])).toBe(false); // single-use
+    expect(await redeemBackupCode(db, codes[1])).toBe(true);
+  });
+
+  it("rejects an unknown code without leaking which", async () => {
+    const db = fakeD1();
+    await generateBackupCodes(db, 3);
+    expect(await redeemBackupCode(db, "ZZZZZ-ZZZZZ")).toBe(false);
+    expect(await redeemBackupCode(db, "")).toBe(false);
+  });
+
+  it("redeems case-insensitively (codes are emitted uppercase)", async () => {
+    const db = fakeD1();
+    const [code] = await generateBackupCodes(db, 1);
+    expect(await redeemBackupCode(db, code.toLowerCase())).toBe(true);
+  });
+});

--- a/tests/indieauth-consent.test.ts
+++ b/tests/indieauth-consent.test.ts
@@ -1,0 +1,98 @@
+/**
+ * /auth/consent (#363, problem 2): a verified passkey assertion or a redeemed
+ * backup code establishes the owner session and mints a request-bound consent
+ * token, then 302s back to /auth so approveAuthorization can complete.
+ */
+import { describe, it, expect, vi } from "vitest";
+import worker from "../template/worker/site-entry.js";
+import {
+  generateBackupCodes,
+  verifyConsentToken,
+  OWNER_COOKIE,
+} from "../template/worker/owner-auth.js";
+
+const SESSION_KEY = "aabbccddeeff00112233445566778899";
+const QUERY =
+  "response_type=code&client_id=https://app.example" +
+  "&redirect_uri=https://app.example/cb&state=xyz&code_challenge=abc&scope=create";
+
+function ctx() {
+  return { waitUntil: vi.fn(), passThroughOnException: vi.fn() };
+}
+function fakeD1() {
+  const rows: any[] = [];
+  return {
+    prepare(sql: string) {
+      const stmt: any = {
+        _args: [] as any[],
+        bind(...a: any[]) { stmt._args = a; return stmt; },
+        async run() {
+          if (/INSERT/.test(sql)) rows.push({ code_hash: stmt._args[0], used_at: null });
+          else if (/UPDATE/.test(sql)) { const r = rows.find((x) => x.code_hash === stmt._args[0] && !x.used_at); if (r) r.used_at = stmt._args[1]; }
+          return { success: true };
+        },
+        async first() {
+          if (/SELECT/.test(sql)) return rows.find((x) => x.code_hash === stmt._args[0] && !x.used_at) ?? null;
+          return null;
+        },
+        async all() { return { results: rows }; },
+      };
+      return stmt;
+    },
+  } as any;
+}
+function env(db: any) {
+  return {
+    ASSETS: { fetch: vi.fn(async () => new Response("asset")) },
+    SITE_URL: "https://example.com",
+    AUTH_DB: {},
+    WEBAUTHN: {},
+    INDIEAUTH_SESSION_KEY: SESSION_KEY,
+    OWNER_AUTH_DB: db,
+  } as any;
+}
+function consentPost(body: unknown) {
+  return new Request("https://example.com/auth/consent", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/auth/consent", () => {
+  it("redeems a backup code → 302 with owner session + valid consent token", async () => {
+    const db = fakeD1();
+    const [code] = await generateBackupCodes(db, 1);
+    const res = await worker.fetch(consentPost({ backupCode: code, query: QUERY }), env(db), ctx());
+
+    expect(res.status).toBe(302);
+    const loc = res.headers.get("Location")!;
+    expect(loc).toContain("/auth?");
+    expect(res.headers.get("Set-Cookie")).toContain(`${OWNER_COOKIE}=`);
+
+    const consent = new URL("https://example.com" + loc).searchParams.get("_consent")!;
+    expect(
+      await verifyConsentToken(consent, SESSION_KEY, {
+        clientId: "https://app.example",
+        redirectUri: "https://app.example/cb",
+        scope: "create",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a bad backup code → 401, no session cookie", async () => {
+    const db = fakeD1();
+    await generateBackupCodes(db, 1);
+    const res = await worker.fetch(consentPost({ backupCode: "ZZZZZ-ZZZZZ", query: QUERY }), env(db), ctx());
+    expect(res.status).toBe(401);
+    expect(res.headers.get("Set-Cookie")).toBeNull();
+  });
+
+  it("rejects a used backup code on the second attempt", async () => {
+    const db = fakeD1();
+    const [code] = await generateBackupCodes(db, 1);
+    await worker.fetch(consentPost({ backupCode: code, query: QUERY }), env(db), ctx());
+    const res = await worker.fetch(consentPost({ backupCode: code, query: QUERY }), env(db), ctx());
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/indieauth-dispatch.test.ts
+++ b/tests/indieauth-dispatch.test.ts
@@ -5,6 +5,10 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import worker from "../template/worker/site-entry.js";
+import { issueOwnerSession, OWNER_COOKIE } from "../template/worker/owner-auth.js";
+
+const REG_TOKEN = "one-time-reg-token";
+const SESSION_KEY = "aabbccddeeff00112233445566778899";
 
 function ctx() {
   return { waitUntil: vi.fn(), passThroughOnException: vi.fn() };
@@ -35,5 +39,46 @@ describe("WebAuthn ceremony dispatch", () => {
     const res = await worker.fetch(req("/auth/webauthn/authenticate/options"), e, ctx());
     expect(e.ASSETS.fetch).toHaveBeenCalledOnce();
     expect(res.headers.get("x-handler")).toBeNull();
+  });
+});
+
+describe("owner-only registration gating", () => {
+  const base = { AUTH_DB: {}, WEBAUTHN: {}, INDIEWEB_REG_TOKEN: REG_TOKEN, INDIEAUTH_SESSION_KEY: SESSION_KEY };
+
+  it("403s /auth/webauthn/register/* with no token and no session", async () => {
+    const res = await worker.fetch(req("/auth/webauthn/register/options"), env(base), ctx());
+    expect(res.status).toBe(403);
+    expect(res.headers.get("x-handler")).toBeNull();
+  });
+
+  it("allows registration with the one-time token", async () => {
+    const res = await worker.fetch(
+      req(`/auth/webauthn/register/options?token=${REG_TOKEN}`),
+      env(base),
+      ctx(),
+    );
+    expect(res.headers.get("x-handler")).toBe("webauthn");
+  });
+
+  it("allows registration with a valid owner session", async () => {
+    const session = await issueOwnerSession(SESSION_KEY, 900);
+    const r = new Request("https://example.com/auth/webauthn/register/options", {
+      method: "POST",
+      headers: { Cookie: `${OWNER_COOKIE}=${session}` },
+    });
+    const res = await worker.fetch(r, env(base), ctx());
+    expect(res.headers.get("x-handler")).toBe("webauthn");
+  });
+
+  it("does NOT gate the authenticate ceremony (proves possession only)", async () => {
+    const res = await worker.fetch(req("/auth/webauthn/authenticate/options"), env(base), ctx());
+    expect(res.headers.get("x-handler")).toBe("webauthn");
+  });
+
+  it("serves the register page at GET /auth/register", async () => {
+    const r = new Request(`https://example.com/auth/register?token=${REG_TOKEN}`, { method: "GET" });
+    const res = await worker.fetch(r, env(base), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('id="passkey-register"');
   });
 });

--- a/tests/indieauth-dispatch.test.ts
+++ b/tests/indieauth-dispatch.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Passkey-IndieAuth dispatch (Anglesite/anglesite#363, problem 2 / IndieAuth).
+ * The WebAuthn ceremony endpoints, the consent endpoint, and the generic /auth
+ * authorization endpoint mount under /auth, gated on AUTH_DB.
+ */
+import { describe, it, expect, vi } from "vitest";
+import worker from "../template/worker/site-entry.js";
+
+function ctx() {
+  return { waitUntil: vi.fn(), passThroughOnException: vi.fn() };
+}
+function env(overrides: Record<string, unknown> = {}) {
+  return {
+    ASSETS: { fetch: vi.fn(async () => new Response("asset", { headers: { "x-asset": "1" } })) },
+    SITE_URL: "https://example.com",
+    ...overrides,
+  } as any;
+}
+function req(path: string, init: RequestInit = {}) {
+  return new Request(`https://example.com${path}`, { method: "POST", ...init });
+}
+
+describe("WebAuthn ceremony dispatch", () => {
+  it("routes /auth/webauthn/* to the WebAuthn handler when AUTH_DB is bound", async () => {
+    const res = await worker.fetch(
+      req("/auth/webauthn/authenticate/options"),
+      env({ AUTH_DB: {}, WEBAUTHN: {} }),
+      ctx(),
+    );
+    expect(res.headers.get("x-handler")).toBe("webauthn");
+  });
+
+  it("falls through /auth/webauthn/* to ASSETS when AUTH_DB is absent", async () => {
+    const e = env();
+    const res = await worker.fetch(req("/auth/webauthn/authenticate/options"), e, ctx());
+    expect(e.ASSETS.fetch).toHaveBeenCalledOnce();
+    expect(res.headers.get("x-handler")).toBeNull();
+  });
+});

--- a/tests/indieauth-pages-safety.test.ts
+++ b/tests/indieauth-pages-safety.test.ts
@@ -1,0 +1,30 @@
+/**
+ * auth-pages script-context safety (#363, problem 2). Values interpolated into
+ * an inline <script> (the register token, the consent query) must be escaped so
+ * a `</script>` in attacker-controlled input can't break out of the element.
+ * The register token comes from searchParams.get() — decoded, literal `<` — so
+ * /auth/register?token=</script><script>… is the exploitable vector.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  renderRegisterPage,
+  renderConsentPage,
+} from "../template/worker/auth-pages.js";
+
+const BREAKOUT = "</script><script>alert(1)</script>";
+
+describe("auth page script-context safety", () => {
+  it("escapes </script> in the register token so it can't break out", () => {
+    const html = renderRegisterPage({ token: BREAKOUT });
+    expect(html).not.toContain("</script><script>alert(1)");
+    expect(html).toContain("\\u003C"); // escaped form inside the JSON string
+  });
+
+  it("escapes </script> in the consent query", () => {
+    const url =
+      "https://example.com/auth?client_id=https://app.example&x=" +
+      encodeURIComponent(BREAKOUT);
+    const html = renderConsentPage({ request: new Request(url) });
+    expect(html).not.toContain("</script><script>alert(1)");
+  });
+});

--- a/tests/indieauth-session.test.ts
+++ b/tests/indieauth-session.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Owner session cookie (#363, problem 2). A signed cookie proving the owner
+ * authenticated via passkey/backup-code, mirroring the membership HMAC pattern.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  issueOwnerSession,
+  verifyOwnerSession,
+} from "../template/worker/owner-auth.js";
+
+const KEY = "00112233445566778899aabbccddeeff";
+
+describe("owner session cookie", () => {
+  it("round-trips a valid session", async () => {
+    const v = await issueOwnerSession(KEY, 900);
+    const p = await verifyOwnerSession(v, KEY);
+    expect(p?.sub).toBe("owner");
+    expect(p?.exp).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  it("rejects a tampered payload", async () => {
+    const v = await issueOwnerSession(KEY, 900);
+    const [, sig] = v.split(".");
+    expect(await verifyOwnerSession("ZXZpbA." + sig, KEY)).toBeNull();
+  });
+
+  it("rejects an expired session", async () => {
+    const v = await issueOwnerSession(KEY, -1);
+    expect(await verifyOwnerSession(v, KEY)).toBeNull();
+  });
+
+  it("rejects under a different key", async () => {
+    const v = await issueOwnerSession(KEY, 900);
+    expect(
+      await verifyOwnerSession(v, "ffffffffffffffffffffffffffffffff"),
+    ).toBeNull();
+  });
+
+  it("rejects empty / malformed input", async () => {
+    expect(await verifyOwnerSession("", KEY)).toBeNull();
+    expect(await verifyOwnerSession("nodothere", KEY)).toBeNull();
+  });
+});

--- a/tests/pre-deploy-scan.test.ts
+++ b/tests/pre-deploy-scan.test.ts
@@ -124,6 +124,19 @@ describe("runScan", () => {
     expect(failure!.remediation).toContain("wrangler secret put");
   });
 
+  it("flags a committed INDIEAUTH_SESSION_KEY or INDIEWEB_REG_TOKEN as an exposed-token failure", () => {
+    writeFile("dist/index.html", "<!doctype html><p>hi</p>");
+    writeFile(
+      "wrangler.jsonc",
+      `{ "vars": { "INDIEWEB_REG_TOKEN": "${"ab01cd23".repeat(8)}" } }`,
+    );
+
+    const report = runScan({ siteDir: site });
+
+    expect(report.ok).toBe(false);
+    expect(report.failures.find(f => f.category === "exposed-token")).toBeDefined();
+  });
+
   it("passes on a correctly-configured IndieWeb site (intentional routes, secrets as bindings)", () => {
     writeFile(
       "dist/index.html",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
       "@dwk/indieauth": resolve(__dirname, "tests/__stubs__/dwk-indieauth.ts"),
       "@dwk/micropub": resolve(__dirname, "tests/__stubs__/dwk-micropub.ts"),
       "@dwk/webmention": resolve(__dirname, "tests/__stubs__/dwk-webmention.ts"),
+      "@dwk/webauthn": resolve(__dirname, "tests/__stubs__/dwk-webauthn.ts"),
     },
   },
   esbuild: {


### PR DESCRIPTION
Implements the **IndieAuth slice of #363, problem 2** — `@dwk/indieauth`'s required `approveAuthorization` hook wired to a passkey (`@dwk/webauthn`) owner-authentication + consent flow, with printable single-use backup codes. Spec + plan + implementation, built test-first.

## What's here
- **Owner-auth core** (`template/worker/owner-auth.js`): signed owner-session cookie, request-bound consent token (HMAC over `client_id|redirect_uri|scope|exp`), single-use backup codes (SHA-256 in `OWNER_AUTH_DB`).
- **Consent flow** (`site-entry.js` + `auth-pages.js`): `approveAuthorization` returns the consent page until a valid session **and** consent token exist, then `AuthorizationApproval { me: SITE_URL }`. `POST /auth/consent` redeems a passkey assertion or backup code → session + consent token → 302 back to `/auth`.
- **WebAuthn ceremonies**: `WEBAUTHN` Durable Object (first DO in the template, with `migrations`); `/auth/webauthn/*` mounted; `/register/*` gated owner-only (one-time `INDIEWEB_REG_TOKEN` or an existing session); `GET /auth/register` page.
- **Provisioning**: `OWNER_AUTH_DB` binding, SKILL Step 5c (secrets, one-time link, backup codes, recovery/reset), deploy-scan rejects committed `INDIEAUTH_SESSION_KEY`/`INDIEWEB_REG_TOKEN` (both the bash hook and the TS `runScan`), `dwk-workers.md`, **ADR-0022**.

## Security
- Consent token blocks consent-screen-skip deep links; `user_verification` required; rpId/origin domain-bound; registration fails closed (403); backup codes hashed + single-use with no unknown-code oracle.

## Tests (TDD, 9 tasks)
~40 new tests across session / consent-token / backup-codes / approveAuthorization / consent-endpoint / dispatch / registration-gating / deploy-scan. Full suite green (excluding the pre-existing local `optimize-images` sandbox artifact).

Design: `docs/superpowers/specs/2026-06-21-passkey-indieauth-design.md` · Plan: `docs/superpowers/plans/2026-06-21-passkey-indieauth.md`.

> Depends on `@dwk/* beta.3` (workers#165, merged) being published for real-Node loading; tests use aliased stubs, and wrangler/esbuild bundle past it at deploy. Micropub realignment (#2c) is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)