### PR TITLE
fix(indieweb): wire Webmention to the real @dwk API + fix stored XSS (#363)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anglesite",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anglesite",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",
@@ -16,6 +16,7 @@
         "@types/semver": "^7.7.1",
         "html-validate": "^10.11.2",
         "markdownlint-cli2": "^0.22.0",
+        "microformats-parser": "^2.0.4",
         "robots-parser": "^3.0.1",
         "schema-dts": "^2.0.0",
         "semver": "^7.7.4",
@@ -3672,6 +3673,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/microformats-parser": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/microformats-parser/-/microformats-parser-2.0.4.tgz",
+      "integrity": "sha512-DA2yt3uz2JjupBGoNvaG9ngBP5vSTI1ky2yhxBai/RnQrlzo+gEzuCdvwIIjj2nh3uVPDybTP5u7uua7pOa6LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/micromark": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
@@ -4432,6 +4446,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/semver": "^7.7.1",
     "html-validate": "^10.11.2",
     "markdownlint-cli2": "^0.22.0",
+    "microformats-parser": "^2.0.4",
     "robots-parser": "^3.0.1",
     "schema-dts": "^2.0.0",
     "semver": "^7.7.4",

--- a/skills/indieweb/SKILL.md
+++ b/skills/indieweb/SKILL.md
@@ -55,19 +55,25 @@ Do not attempt git installs, forks, or workarounds. The gate is intentional.
 
 ## Step 2 — Choose endpoints
 
-Tell the owner: "There are three IndieWeb endpoints you can enable — each works independently, and I'd recommend all three for the full experience:"
+> **Current availability (issue #363).** Only **Webmention** is wired into the
+> site Worker today. **IndieAuth** and **Micropub** are staged — their routes
+> return `501 Not Configured` until the auth wiring lands in a follow-up release.
+> Recommend Webmention now; only provision IndieAuth/Micropub if the owner
+> explicitly wants the resources pre-created (the endpoints won't function yet).
+> IndieAuth and Micropub are a pair: Micropub consumes the access tokens
+> IndieAuth issues, so neither works until both are wired.
 
-| Endpoint | What it does |
-|---|---|
-| **IndieAuth** | Sign in to other IndieWeb services with your domain; issues access tokens for Micropub |
-| **Webmention** | Receive (and send) cross-site mentions, replies, and likes |
-| **Micropub** | Publish to your site from phone apps and other Micropub clients |
+Tell the owner: "There are three IndieWeb endpoints. **Webmention works today**; IndieAuth and Micropub are coming in a follow-up release."
 
-Ask: "Which would you like to enable? (Default: all three)"
+| Endpoint | What it does | Status |
+|---|---|---|
+| **Webmention** | Receive (and send) cross-site mentions, replies, and likes | ✅ Live |
+| **IndieAuth** | Sign in to other IndieWeb services with your domain; issues access tokens for Micropub | 🚧 Pending (501) |
+| **Micropub** | Publish to your site from phone apps and other Micropub clients | 🚧 Pending (501) |
 
-Note the dependency: Micropub requires IndieAuth for token issuance. If the owner selects Micropub but not IndieAuth, explain this and recommend enabling both. Webmention is fully independent.
+Ask: "Would you like to enable Webmention now? (Recommended)" Only offer to pre-provision IndieAuth/Micropub if the owner asks, and make clear those endpoints won't respond until the follow-up.
 
-Record the choices for use in subsequent steps. If the owner selects all three (or accepts the default), proceed with all.
+Record the choices for use in subsequent steps.
 
 ## Step 3 — Provision bindings
 
@@ -173,9 +179,51 @@ For the Queue (Webmention):
 }
 ```
 
+## Step 4b — Install and wire the Webmention runtime (if Webmention selected)
+
+The webmention code lives in `template/worker/webmention.js` (scaffolded to the
+site as `worker/webmention.js`). It is **not** imported by the default Worker —
+`worker/site-entry.js` ships with four `/* @anglesite-inject:* */` sentinels so a
+site without Webmention never bundles the `@dwk/webmention` + `microformats-parser`
+dependencies. Enabling Webmention means installing those packages and replacing
+each sentinel with its real line.
+
+**1. Install the packages:**
+
+```sh
+npm install @dwk/webmention microformats-parser
+```
+
+**2. Replace the four sentinels in `worker/site-entry.js`** using the Edit tool
+(each sentinel appears exactly once):
+
+| Sentinel | Replace with |
+|---|---|
+| `/* @anglesite-inject:webmention-import */` | `import { handleWebmention, injectWebmentions, drainWebmentionQueue } from "./webmention.js";` |
+| `/* @anglesite-inject:webmention-dispatch */` | `if (env.WEBMENTION_DB && p === "/webmention") return handleWebmention(request, env, ctx, url.origin);` |
+| `/* @anglesite-inject:webmention-render */` | `response = await injectWebmentions(response, env, url);` |
+| `/* @anglesite-inject:webmention-queue */` | `await drainWebmentionQueue(batch, env, ctx);` |
+
+Leave the IndieAuth/Micropub `501` branches untouched — they stay until that
+follow-up. The `webmention-render` sentinel sits inside an `if (isHtmlRequest)`
+block; `injectWebmentions` self-gates on `WEBMENTION_DB`, the note/post target
+path, and an HTML response, so it is a no-op on every other page.
+
+**Schema is automatic.** The custom inbox creates the extended `webmentions`
+table (`source, target, author_name, author_url, author_photo, content, url,
+type, published, status, verified_at`) on first write — no manual migration. The
+queue consumer re-fetches each verified source (SSRF-guarded) and parses its
+microformats2 to populate the author h-card and content the edge-render shows.
+
 ## Step 5 — Store secrets
 
 ### 5a — IndieAuth signing key (if IndieAuth selected)
+
+> **Pending wiring (#363).** IndieAuth is not functional yet (its route returns
+> 501). When it lands, the `@dwk/indieauth` handler reads the signing key from
+> the **`TOKEN_SIGNING_KEY`** binding — not `INDIEAUTH_SIGNING_KEY`. Use that
+> name when the follow-up wires the handler. The step below pre-creates the
+> secret; the endpoint stays 501 until the handler is composed in.
 
 Generate a signing key:
 
@@ -266,9 +314,9 @@ Tell the owner what's live and what to expect:
 
 For each enabled endpoint, explain in one sentence:
 
-- **IndieAuth** — "You can now sign in to IndieWeb services (and any IndieAuth-compatible app) with `https://<SITE_DOMAIN>`. Your tokens are issued by your own server."
-- **Webmention** — "Your site can now receive mentions, replies, and likes from other websites. They'll appear on your posts automatically."
-- **Micropub** — "You can publish to your site from Micropub clients (like phone apps). New posts appear as notes — they're committed to your repo and go live after a rebuild (~1–2 minutes)."
+- **Webmention** (live) — "Your site can now receive mentions, replies, and likes from other websites. They'll appear on your posts automatically, with the sender's name, photo, and a snippet."
+- **IndieAuth** (pending) — "Sign-in with your domain is staged but not active yet — the endpoint returns a 501 until the next release wires it in. I'll let you know when it ships."
+- **Micropub** (pending) — "Publishing from Micropub clients is staged but not active yet (it depends on IndieAuth). The endpoint returns a 501 until both land in the next release."
 
 Important caveats to surface:
 
@@ -284,8 +332,8 @@ Suggest next steps:
 
 ## Notes
 
-- **Per-binding gating.** Every endpoint is gated on the presence of its D1 binding in `site-entry.js`. A partially configured site still serves static pages normally — the guards are all false until the bindings exist.
+- **Per-binding gating.** Every endpoint is gated on the presence of its D1 binding in `site-entry.js`. A partially configured site still serves static pages normally — the guards are all false until the bindings exist. The Webmention runtime is additionally gated at the bundle level: its `@dwk/webmention` + `microformats-parser` imports are injected (Step 4b) only when Webmention is enabled, so other sites never install or bundle them.
 - **No cost.** Everything runs within Cloudflare's free tier (Workers, D1, R2, Queues). No third-party service fees.
 - **Privacy.** Webmention data (mentions from other sites) is stored in D1 on the owner's account. The owner should mention in their privacy policy that the site receives and stores Webmentions. Micropub posts are committed to the owner's private GitHub repo.
 - **Diagnostics.** If endpoints misbehave, check the Worker logs: `https://dash.cloudflare.com/<account-id>/workers/services/view/<CF_PROJECT_NAME>/production/observability/logs`. Or run `/anglesite:check` which will inspect the IndieWeb endpoint configuration.
-- **Schema management.** The `@dwk/*` packages manage their own D1 schemas. Schema migrations run automatically on first request or can be triggered manually via `npx wrangler d1 execute <db-name> --remote --file=<schema-path>`.
+- **Schema management.** Webmention uses a custom inbox (`worker/webmention.js`) that creates and owns its extended `webmentions` table — author h-card, content, type, and permalink, not just `(source, target)` — on first write. The `@dwk/indieauth` / `@dwk/micropub` packages manage their own D1 schemas once their wiring lands; those run automatically on first request.

--- a/skills/indieweb/SKILL.md
+++ b/skills/indieweb/SKILL.md
@@ -188,6 +188,13 @@ site without Webmention never bundles the `@dwk/webmention` + `microformats-pars
 dependencies. Enabling Webmention means installing those packages and replacing
 each sentinel with its real line.
 
+**Idempotency — check before re-wiring.** This step runs again whenever the
+owner re-runs `/anglesite:indieweb` (e.g. to add IndieAuth later). First read
+`worker/site-entry.js` and check for `import { handleWebmention` — if it's
+already present, Webmention is wired: skip both the install and the sentinel
+replacements below (the `@anglesite-inject:*` sentinels are already gone, so the
+Edit calls would error). Otherwise proceed.
+
 **1. Install the packages:**
 
 ```sh

--- a/template/worker/site-entry.js
+++ b/template/worker/site-entry.js
@@ -52,18 +52,14 @@
  */
 
 import premiumRoutes from "./_premium-routes.json";
-import { createHandler as createIndieAuth } from "@dwk/indieauth";
-import { createHandler as createMicropub } from "@dwk/micropub";
-import { createHandler as createWebmention } from "@dwk/webmention";
 import { sync as syncMicropubBridge } from "./indieweb-bridge.js";
+// `/anglesite:indieweb` replaces the sentinel below with the webmention module
+// import when the owner enables Webmention. Keeping the `@dwk/*` +
+// microformats-parser imports out of the default bundle means a site without
+// Webmention never installs or bundles them. See worker/webmention.js.
+/* @anglesite-inject:webmention-import */
 
 const COOKIE_NAME = "__anglesite_member";
-
-const indieauth = createIndieAuth();
-const micropub = createMicropub({
-  generatePostUrl: (slug) => `/notes/${slug}/`,
-});
-const webmention = createWebmention();
 
 const worker = {
   async fetch(request, env, ctx) {
@@ -134,13 +130,21 @@ const worker = {
     }
 
     // 4. IndieWeb endpoints — each gated on its D1 binding being present.
+    //    IndieAuth + Micropub wiring is pending the auth follow-up (issue #363);
+    //    until then their routes report 501 rather than crashing the Worker on
+    //    boot (the real handlers require config the template can't supply yet).
     const p = url.pathname;
     if (env.AUTH_DB && p.startsWith("/auth"))
-      return indieauth(request, env, ctx);
+      return new Response("IndieAuth endpoint is not configured yet.", {
+        status: 501,
+      });
     if (env.MICROPUB_DB && (p === "/micropub" || p === "/media"))
-      return micropub(request, env, ctx);
-    if (env.WEBMENTION_DB && p === "/webmention")
-      return webmention(request, env, ctx);
+      return new Response("Micropub endpoint is not configured yet.", {
+        status: 501,
+      });
+    // `/anglesite:indieweb` replaces the sentinel below with the `/webmention`
+    // receiver route when Webmention is enabled.
+    /* @anglesite-inject:webmention-dispatch */
 
     if (!response) {
       response = await env.ASSETS.fetch(request);
@@ -160,31 +164,13 @@ const worker = {
       }
     }
 
-    // 5. Webmention edge-render — inject stored mentions into note/post pages.
-    //    Gating order keeps the cost off pages that can't have mentions:
-    //    HTML request → WEBMENTION_DB bound → note/post path → HTML response
-    //    → page is a known mention target (cached set, refreshed at most once
-    //    a minute per isolate) → only then query D1 for the mentions and
-    //    rewrite. Pages with no stored mentions pay no per-request query and
-    //    no rewrite.
-    if (
-      isHtmlRequest &&
-      env.WEBMENTION_DB &&
-      isWebmentionTarget(url.pathname)
-    ) {
-      const contentType = response.headers.get("content-type") ?? "";
-      if (contentType.includes("text/html")) {
-        const target = `${url.origin}${url.pathname}`;
-        const targets = await loadWebmentionTargets(env.WEBMENTION_DB);
-        if (targets.has(target)) {
-          const mentions = await loadWebmentions(env.WEBMENTION_DB, target);
-          if (mentions.length > 0) {
-            response = new HTMLRewriter()
-              .on("#webmentions", new WebmentionInjector(mentions))
-              .transform(response);
-          }
-        }
-      }
+    // 5. Webmention edge-render — `/anglesite:indieweb` injects the stored-mention
+    //    injection call here when Webmention is enabled. The injected helper
+    //    (worker/webmention.js) self-gates on WEBMENTION_DB, the note/post target
+    //    path, and an HTML response, so pages that can't have mentions pay no
+    //    per-request query and no rewrite.
+    if (isHtmlRequest) {
+      /* @anglesite-inject:webmention-render */
     }
 
     if (setCookieHeader) {
@@ -202,16 +188,13 @@ const worker = {
   },
 
   async queue(batch, env, ctx) {
-    if (env.WEBMENTION_DB) {
-      await webmention.queue(batch, env, ctx);
-    }
+    /* @anglesite-inject:webmention-queue */
     ctx.waitUntil(syncMicropubBridge(env));
   },
 
   async scheduled(event, env, ctx) {
-    if (env.WEBMENTION_DB) {
-      await webmention.scheduled(event, env, ctx);
-    }
+    // The Micropub→Git bridge sync runs on the Worker's cron trigger. The
+    // webmention package has no scheduled arm — verification is queue-driven.
     ctx.waitUntil(syncMicropubBridge(env));
   },
 };
@@ -225,114 +208,6 @@ class CountryInjector {
   element(el) {
     el.append(`<meta name="cf-country" content="${this.country}">`, { html: true });
   }
-}
-
-// ---------------------------------------------------------------------------
-// Webmention edge-render helpers (§3.5 of the active-IndieWeb design)
-// ---------------------------------------------------------------------------
-
-// Only note and blog-post permalinks can be webmention targets. The collection
-// index pages (`/notes`, `/blog`) are excluded — the trailing-slash strip means
-// a bare `/notes` never matches `"/notes/"`.
-function isWebmentionTarget(pathname) {
-  const p = pathname.replace(/\/+$/, "");
-  return p.startsWith("/notes/") || p.startsWith("/blog/");
-}
-
-// The set of target URLs that have at least one verified mention, cached per
-// WEBMENTION_DB binding so each isolate runs the distinct-targets query at
-// most once per TTL — every other note/post request is an in-memory set
-// lookup. New mentions therefore appear within a minute, which is fine for
-// content that's already verified asynchronously. A query failure serves the
-// stale set (or an empty one) rather than breaking the page render.
-const WEBMENTION_TARGETS_TTL_MS = 60_000;
-const webmentionTargetsCache = new WeakMap();
-
-async function loadWebmentionTargets(db) {
-  const cached = webmentionTargetsCache.get(db);
-  if (cached && cached.expires > Date.now()) return cached.targets;
-  try {
-    const rows = await db
-      .prepare(
-        `SELECT DISTINCT target FROM webmentions WHERE status = 'verified'`,
-      )
-      .all();
-    const targets = new Set((rows?.results ?? []).map((row) => row.target));
-    webmentionTargetsCache.set(db, {
-      targets,
-      expires: Date.now() + WEBMENTION_TARGETS_TTL_MS,
-    });
-    return targets;
-  } catch (err) {
-    console.error("Webmention target-set query failed:", err?.message);
-    return cached?.targets ?? new Set();
-  }
-}
-
-// Query WEBMENTION_DB for verified mentions of a target URL. The table/columns
-// follow @dwk/webmention's inbox shape; a query failure degrades to "no
-// mentions" so a transient D1 error never breaks the page render.
-async function loadWebmentions(db, target) {
-  try {
-    const rows = await db
-      .prepare(
-        `SELECT author_name, author_url, author_photo, content, url, type, published
-         FROM webmentions
-         WHERE target = ?1 AND status = 'verified'
-         ORDER BY published ASC`,
-      )
-      .bind(target)
-      .all();
-    return rows?.results ?? [];
-  } catch (err) {
-    console.error("Webmention edge-render query failed:", err?.message);
-    return [];
-  }
-}
-
-class WebmentionInjector {
-  constructor(mentions) {
-    this.mentions = mentions;
-  }
-  element(el) {
-    const items = this.mentions.map(renderMention).join("");
-    el.setInnerContent(
-      `<h2 class="webmentions-title">Mentions</h2>` +
-        `<ol class="webmentions-list">${items}</ol>`,
-      { html: true },
-    );
-  }
-}
-
-function renderMention(m) {
-  const name = escapeHtml(m.author_name || m.author_url || "Someone");
-  const photo = m.author_photo
-    ? `<img class="u-photo" src="${escapeHtml(m.author_photo)}" alt="" width="48" height="48" />`
-    : "";
-  const author = m.author_url
-    ? `<a class="p-author h-card u-url" href="${escapeHtml(m.author_url)}">${name}</a>`
-    : `<span class="p-author">${name}</span>`;
-  const content = m.content
-    ? `<div class="p-content">${escapeHtml(m.content)}</div>`
-    : "";
-  const permalink = m.url
-    ? `<a class="u-url" href="${escapeHtml(m.url)}">permalink</a>`
-    : "";
-  return `<li class="h-cite">${photo}${author}${content}${permalink}</li>`;
-}
-
-function escapeHtml(value) {
-  return String(value).replace(
-    /[&<>"']/g,
-    (c) =>
-      ({
-        "&": "&amp;",
-        "<": "&lt;",
-        ">": "&gt;",
-        '"': "&quot;",
-        "'": "&#39;",
-      })[c],
-  );
 }
 
 // ---------------------------------------------------------------------------

--- a/template/worker/webmention.js
+++ b/template/worker/webmention.js
@@ -1,0 +1,428 @@
+/**
+ * Webmention runtime for the site Worker — receiver dispatch, queue consumer,
+ * and the per-request edge-render that injects stored mentions into a page.
+ *
+ * This module is the ONLY part of `site-entry.js`'s feature set that pulls
+ * external packages (`@dwk/webmention` + `microformats-parser`), so it is kept
+ * in a separate file that `site-entry.js` imports ONLY when the owner runs
+ * `/anglesite:indieweb` and selects Webmention. A site without Webmention never
+ * imports this module, so its Worker bundle stays free of these dependencies.
+ *
+ * Composition against the published `@dwk/webmention` (0.1.x):
+ *   - `createWebmention({ baseUrl })` → the `/webmention` receiver. It validates
+ *     source/target synchronously, enqueues the pair on WEBMENTION_QUEUE, and
+ *     returns 202. `baseUrl` is the site origin (taken per request) so only
+ *     mentions targeting this site are accepted.
+ *   - `createWebmentionQueueConsumer({ inbox })` → the queue consumer. It
+ *     fetches each source, confirms it links to the target, and calls
+ *     `inbox.store()` / `inbox.remove()`. We supply a CUSTOM inbox (below) so a
+ *     stored mention carries the author h-card + content, not just source/target
+ *     — the package's default D1 inbox only persists `(source, target,
+ *     verified_at)`.
+ *
+ * The custom inbox re-fetches the source (SSRF-guarded via the package's
+ * `safeFetch`) and parses its microformats2 to extract author name/url/photo,
+ * content, permalink, and reply/like/repost type, persisting them to an
+ * extended `webmentions` table that the edge-render reads.
+ */
+import {
+  createWebmention,
+  createWebmentionQueueConsumer,
+  safeFetch,
+} from "@dwk/webmention";
+import { mf2 } from "microformats-parser";
+
+// ---------------------------------------------------------------------------
+// Receiver + queue-consumer factories (memoized so each isolate builds one).
+// ---------------------------------------------------------------------------
+
+const receivers = new Map(); // origin -> receiver handler
+const consumers = new WeakMap(); // WEBMENTION_DB binding -> queue consumer
+
+/** Dispatch a `/webmention` POST to the receiver for this site origin. */
+export function handleWebmention(request, env, ctx, origin) {
+  let receiver = receivers.get(origin);
+  if (!receiver) {
+    receiver = createWebmention({ baseUrl: origin });
+    receivers.set(origin, receiver);
+  }
+  return receiver(request, env, ctx);
+}
+
+/** Drain a batch of queued webmention jobs through the verifying consumer. */
+export function drainWebmentionQueue(batch, env, ctx) {
+  if (!env.WEBMENTION_DB) return Promise.resolve();
+  let consumer = consumers.get(env.WEBMENTION_DB);
+  if (!consumer) {
+    consumer = createWebmentionQueueConsumer({
+      inbox: createWebmentionInbox(env.WEBMENTION_DB),
+    });
+    consumers.set(env.WEBMENTION_DB, consumer);
+  }
+  return consumer(batch, env, ctx);
+}
+
+// ---------------------------------------------------------------------------
+// Custom inbox — parses the source's mf2 and persists the rich mention.
+// ---------------------------------------------------------------------------
+
+const CREATE_TABLE_SQL =
+  `CREATE TABLE IF NOT EXISTS webmentions (` +
+  `source TEXT NOT NULL, ` +
+  `target TEXT NOT NULL, ` +
+  `author_name TEXT, ` +
+  `author_url TEXT, ` +
+  `author_photo TEXT, ` +
+  `content TEXT, ` +
+  `url TEXT, ` +
+  `type TEXT, ` +
+  `published TEXT, ` +
+  `status TEXT NOT NULL DEFAULT 'verified', ` +
+  `verified_at INTEGER NOT NULL, ` +
+  `PRIMARY KEY (source, target))`;
+
+const UPSERT_SQL =
+  `INSERT INTO webmentions ` +
+  `(source, target, author_name, author_url, author_photo, content, url, type, published, status, verified_at) ` +
+  `VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 'verified', ?10) ` +
+  `ON CONFLICT (source, target) DO UPDATE SET ` +
+  `author_name = excluded.author_name, author_url = excluded.author_url, ` +
+  `author_photo = excluded.author_photo, content = excluded.content, ` +
+  `url = excluded.url, type = excluded.type, published = excluded.published, ` +
+  `status = 'verified', verified_at = excluded.verified_at`;
+
+/**
+ * Build an `InboxStore` (the `@dwk/webmention` contract: `store`/`remove`/
+ * `list`) backed by D1. `store()` re-fetches the source and parses its mf2 so
+ * the row carries author + content. A fetch/parse failure degrades to a
+ * source/target-only row rather than dropping the verified mention.
+ *
+ * `fetchImpl` is injectable for tests; production uses the global `fetch`.
+ */
+export function createWebmentionInbox(db, { fetchImpl = fetch } = {}) {
+  let ready = null;
+  const ensureSchema = () => {
+    ready ??= db
+      .prepare(CREATE_TABLE_SQL)
+      .run()
+      .then(() => undefined);
+    return ready;
+  };
+
+  return {
+    async store(mention) {
+      await ensureSchema();
+      let parsed = { type: "mention", url: mention.source };
+      try {
+        const { response } = await safeFetch(
+          fetchImpl,
+          mention.source,
+          { headers: { accept: "text/html" } },
+          { timeoutMs: 8000 },
+        );
+        if (response.ok) {
+          parsed = {
+            ...parsed,
+            ...parseMention(await response.text(), mention),
+          };
+        }
+      } catch (err) {
+        // SSRF block, timeout, or unparseable source — keep the verified pair.
+        console.error("Webmention mf2 parse failed:", err?.message);
+      }
+      await db
+        .prepare(UPSERT_SQL)
+        .bind(
+          mention.source,
+          mention.target,
+          parsed.author_name ?? null,
+          parsed.author_url ?? null,
+          parsed.author_photo ?? null,
+          parsed.content ?? null,
+          parsed.url ?? mention.source,
+          parsed.type ?? "mention",
+          parsed.published ?? null,
+          mention.verifiedAt,
+        )
+        .run();
+    },
+
+    async remove(source, target) {
+      await ensureSchema();
+      await db
+        .prepare(`DELETE FROM webmentions WHERE source = ?1 AND target = ?2`)
+        .bind(source, target)
+        .run();
+    },
+
+    async list(target) {
+      await ensureSchema();
+      const statement =
+        target === undefined
+          ? db.prepare(
+              `SELECT source, target, verified_at FROM webmentions ORDER BY verified_at DESC`,
+            )
+          : db
+              .prepare(
+                `SELECT source, target, verified_at FROM webmentions WHERE target = ?1 ORDER BY verified_at DESC`,
+              )
+              .bind(target);
+      const { results } = await statement.all();
+      return (results ?? []).map((row) => ({
+        source: row.source,
+        target: row.target,
+        verifiedAt: row.verified_at,
+      }));
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// microformats2 extraction — turn a source page into a rich mention record.
+// ---------------------------------------------------------------------------
+
+// Reply/like/repost/bookmark properties, in the order we report them. The first
+// one whose value points at the target decides the mention's `type`.
+const RESPONSE_TYPES = [
+  ["like-of", "like"],
+  ["repost-of", "repost"],
+  ["in-reply-to", "reply"],
+  ["bookmark-of", "bookmark"],
+];
+
+/** First string-ish value of an mf2 property, or undefined. */
+function valueOf(prop) {
+  if (prop == null) return undefined;
+  if (typeof prop === "string") return prop;
+  // Html ({ value, html }) or Image ({ value, alt }) or h-* root ({ value }).
+  if (typeof prop.value === "string") return prop.value;
+  return undefined;
+}
+
+function firstString(properties, key) {
+  const values = properties?.[key];
+  return Array.isArray(values) ? valueOf(values[0]) : undefined;
+}
+
+/** Whether an mf2 property value (string, h-cite root, or url) is `target`. */
+function pointsAt(prop, target) {
+  if (typeof prop === "string") return prop === target;
+  if (prop && typeof prop === "object") {
+    if (valueOf(prop) === target) return true;
+    const url = prop.properties && firstString(prop.properties, "url");
+    if (url === target) return true;
+  }
+  return false;
+}
+
+function detectType(properties, target) {
+  for (const [key, type] of RESPONSE_TYPES) {
+    const values = properties?.[key];
+    if (Array.isArray(values) && values.some((v) => pointsAt(v, target))) {
+      return type;
+    }
+  }
+  return "mention";
+}
+
+function extractAuthor(properties) {
+  const author = properties?.author?.[0];
+  if (author == null) return {};
+  if (typeof author === "string") return { author_name: author };
+  const props = author.properties ?? {};
+  return {
+    author_name: firstString(props, "name"),
+    author_url: firstString(props, "url"),
+    author_photo: firstString(props, "photo"),
+  };
+}
+
+function extractContent(properties) {
+  const content = properties?.content?.[0];
+  const text =
+    valueOf(content) ?? firstString(properties, "summary") ?? firstString(properties, "name");
+  if (!text) return undefined;
+  // Cap stored content; the edge-render escapes it, this just bounds storage.
+  return text.length > 1000 ? `${text.slice(0, 1000)}…` : text;
+}
+
+/**
+ * Parse the `h-entry` (or bare `h-card`) of a webmention source into the row
+ * the edge-render expects. `mention` provides `source`/`target` fallbacks.
+ */
+export function parseMention(html, { source, target }) {
+  let entry;
+  let card;
+  try {
+    const { items } = mf2(html, { baseUrl: source });
+    for (const item of items ?? []) {
+      const types = item.type ?? [];
+      if (!entry && types.includes("h-entry")) entry = item;
+      if (!card && types.includes("h-card")) card = item;
+    }
+  } catch (err) {
+    console.error("Webmention mf2 parse error:", err?.message);
+  }
+
+  // A bare h-card source (e.g. a "likes" aggregator) still yields an author.
+  const properties = entry?.properties ?? {};
+  const author = entry ? extractAuthor(properties) : card ? extractAuthor({ author: [card] }) : {};
+
+  return {
+    author_name: author.author_name,
+    author_url: author.author_url,
+    author_photo: author.author_photo,
+    content: extractContent(properties),
+    url: firstString(properties, "url") ?? source,
+    type: detectType(properties, target),
+    published: firstString(properties, "published"),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Edge-render — inject stored mentions into note/post pages.
+// ---------------------------------------------------------------------------
+
+// Only note and blog-post permalinks can be webmention targets. The collection
+// index pages (`/notes`, `/blog`) are excluded — the trailing-slash strip means
+// a bare `/notes` never matches `"/notes/"`. Matching the path up front keeps
+// the per-request D1 work off pages that can't have mentions.
+function isWebmentionTarget(pathname) {
+  const p = pathname.replace(/\/+$/, "");
+  return p.startsWith("/notes/") || p.startsWith("/blog/");
+}
+
+// Per-isolate cache of known target URLs, refreshed at most once per TTL — so
+// every mention-free note/post request is an in-memory set lookup, not a query.
+const WEBMENTION_TARGETS_TTL_MS = 60_000;
+const webmentionTargetsCache = new WeakMap();
+
+async function loadWebmentionTargets(db) {
+  const cached = webmentionTargetsCache.get(db);
+  if (cached && cached.expires > Date.now()) return cached.targets;
+  try {
+    const rows = await db
+      .prepare(`SELECT DISTINCT target FROM webmentions WHERE status = 'verified'`)
+      .all();
+    const targets = new Set((rows?.results ?? []).map((row) => row.target));
+    webmentionTargetsCache.set(db, {
+      targets,
+      expires: Date.now() + WEBMENTION_TARGETS_TTL_MS,
+    });
+    return targets;
+  } catch (err) {
+    console.error("Webmention target-set query failed:", err?.message);
+    return cached?.targets ?? new Set();
+  }
+}
+
+async function loadWebmentions(db, target) {
+  try {
+    const rows = await db
+      .prepare(
+        `SELECT author_name, author_url, author_photo, content, url, type, published
+         FROM webmentions
+         WHERE target = ?1 AND status = 'verified'
+         ORDER BY published ASC`,
+      )
+      .bind(target)
+      .all();
+    return rows?.results ?? [];
+  } catch (err) {
+    console.error("Webmention edge-render query failed:", err?.message);
+    return [];
+  }
+}
+
+class WebmentionInjector {
+  constructor(mentions) {
+    this.mentions = mentions;
+  }
+  element(el) {
+    const items = this.mentions.map(renderMention).join("");
+    el.setInnerContent(
+      `<h2 class="webmentions-title">Mentions</h2>` +
+        `<ol class="webmentions-list">${items}</ol>`,
+      { html: true },
+    );
+  }
+}
+
+/**
+ * If the response is a note/post HTML page with stored mentions, inject them
+ * into its `#webmentions` container. Self-gates on WEBMENTION_DB and the target
+ * path so `site-entry.js` can call it unconditionally for HTML responses.
+ */
+export async function injectWebmentions(response, env, url) {
+  if (!env.WEBMENTION_DB || !isWebmentionTarget(url.pathname)) return response;
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("text/html")) return response;
+
+  const target = `${url.origin}${url.pathname}`;
+  const targets = await loadWebmentionTargets(env.WEBMENTION_DB);
+  if (!targets.has(target)) return response;
+
+  const mentions = await loadWebmentions(env.WEBMENTION_DB, target);
+  if (mentions.length === 0) return response;
+
+  return new HTMLRewriter()
+    .on("#webmentions", new WebmentionInjector(mentions))
+    .transform(response);
+}
+
+// ---------------------------------------------------------------------------
+// Rendering — XSS-hardened (issue #363). Exported for unit tests.
+// ---------------------------------------------------------------------------
+
+export function renderMention(m) {
+  // Webmention fields originate from arbitrary external sites. escapeHtml()
+  // blocks HTML metacharacters but NOT dangerous URL schemes (javascript:,
+  // data:), so every URL that lands in an href/src must pass safeUrl() first.
+  const authorUrl = safeUrl(m.author_url);
+  const authorPhoto = safeUrl(m.author_photo);
+  const permalinkUrl = safeUrl(m.url);
+
+  const name = escapeHtml(m.author_name || authorUrl || "Someone");
+  const photo = authorPhoto
+    ? `<img class="u-photo" src="${escapeHtml(authorPhoto)}" alt="" width="48" height="48" />`
+    : "";
+  const author = authorUrl
+    ? `<a class="p-author h-card u-url" rel="nofollow ugc noopener" href="${escapeHtml(authorUrl)}">${name}</a>`
+    : `<span class="p-author">${name}</span>`;
+  const content = m.content
+    ? `<div class="p-content">${escapeHtml(m.content)}</div>`
+    : "";
+  const permalink = permalinkUrl
+    ? `<a class="u-url" rel="nofollow ugc noopener" href="${escapeHtml(permalinkUrl)}">permalink</a>`
+    : "";
+  return `<li class="h-cite">${photo}${author}${content}${permalink}</li>`;
+}
+
+// Allowlist http(s) URLs only. Returns the normalized URL string, or null for
+// anything that isn't a parseable http/https URL (blocks javascript:, data:,
+// vbscript:, relative junk, etc.).
+export function safeUrl(value) {
+  if (!value) return null;
+  try {
+    const parsed = new URL(String(value));
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+      ? parsed.toString()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function escapeHtml(value) {
+  return String(value).replace(
+    /[&<>"']/g,
+    (c) =>
+      ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      })[c],
+  );
+}

--- a/template/worker/webmention.js
+++ b/template/worker/webmention.js
@@ -102,10 +102,19 @@ const UPSERT_SQL =
 export function createWebmentionInbox(db, { fetchImpl = fetch } = {}) {
   let ready = null;
   const ensureSchema = () => {
-    ready ??= db
-      .prepare(CREATE_TABLE_SQL)
-      .run()
-      .then(() => undefined);
+    // Clear the cached promise on failure so a transient D1 error on the first
+    // write doesn't permanently wedge the inbox for this isolate — the next
+    // call retries the CREATE TABLE rather than re-awaiting a rejected promise.
+    if (!ready) {
+      ready = db
+        .prepare(CREATE_TABLE_SQL)
+        .run()
+        .then(() => undefined)
+        .catch((err) => {
+          ready = null;
+          throw err;
+        });
+    }
     return ready;
   };
 
@@ -320,10 +329,14 @@ async function loadWebmentions(db, target) {
   try {
     const rows = await db
       .prepare(
+        // `published` is nullable TEXT; `verified_at` is INTEGER ms. Ordering by
+        // a raw COALESCE of the two would sort by type affinity (all integers
+        // before all text), so undated mentions normalize to an ISO string from
+        // verified_at — keeping the column uniformly text and chronological.
         `SELECT author_name, author_url, author_photo, content, url, type, published
          FROM webmentions
          WHERE target = ?1 AND status = 'verified'
-         ORDER BY published ASC`,
+         ORDER BY COALESCE(published, datetime(verified_at / 1000, 'unixepoch')) ASC`,
       )
       .bind(target)
       .all();
@@ -387,13 +400,13 @@ export function renderMention(m) {
     ? `<img class="u-photo" src="${escapeHtml(authorPhoto)}" alt="" width="48" height="48" />`
     : "";
   const author = authorUrl
-    ? `<a class="p-author h-card u-url" rel="nofollow ugc noopener" href="${escapeHtml(authorUrl)}">${name}</a>`
+    ? `<a class="p-author h-card u-url" rel="nofollow ugc noopener noreferrer" href="${escapeHtml(authorUrl)}">${name}</a>`
     : `<span class="p-author">${name}</span>`;
   const content = m.content
     ? `<div class="p-content">${escapeHtml(m.content)}</div>`
     : "";
   const permalink = permalinkUrl
-    ? `<a class="u-url" rel="nofollow ugc noopener" href="${escapeHtml(permalinkUrl)}">permalink</a>`
+    ? `<a class="u-url" rel="nofollow ugc noopener noreferrer" href="${escapeHtml(permalinkUrl)}">permalink</a>`
     : "";
   return `<li class="h-cite">${photo}${author}${content}${permalink}</li>`;
 }

--- a/tests/__stubs__/dwk-webmention.ts
+++ b/tests/__stubs__/dwk-webmention.ts
@@ -1,30 +1,41 @@
-// Stub for the unpublished @dwk/webmention package. See dwk-indieauth.ts for
-// the rationale. This stub also records queue/scheduled invocations on a shared
-// `webmentionCalls` object so the queue()/scheduled() dispatch tests can assert
-// that the webmention worker hooks run only when WEBMENTION_DB is bound.
-// Because the vitest alias maps "@dwk/webmention" to this same file, the test
-// and site-entry.js share one module instance — and therefore one counter.
-export const webmentionCalls = { fetch: 0, queue: 0, scheduled: 0 };
+// Stub for the unpublished @dwk/webmention package. The real package composes
+// into the site Worker via worker/webmention.js; in tests the vitest alias maps
+// "@dwk/webmention" to this file so that module imports cleanly. It records
+// receiver/consumer invocations on a shared `webmentionCalls` object so the
+// dispatch tests can assert the hooks fire only when WEBMENTION_DB is bound.
+// Because the alias maps to this same file, the test and worker code share one
+// module instance — and therefore one counter.
+export const webmentionCalls = { receive: 0, queue: 0 };
 
 export function resetWebmentionCalls() {
-  webmentionCalls.fetch = 0;
+  webmentionCalls.receive = 0;
   webmentionCalls.queue = 0;
-  webmentionCalls.scheduled = 0;
 }
 
-export function createHandler(_config?: unknown) {
-  return Object.assign(
-    (_request: Request, _env: unknown, _ctx: unknown) => {
-      webmentionCalls.fetch++;
-      return new Response("webmention", { headers: { "x-handler": "webmention" } });
-    },
-    {
-      queue: async () => {
-        webmentionCalls.queue++;
-      },
-      scheduled: async () => {
-        webmentionCalls.scheduled++;
-      },
-    },
-  );
+/** Mirrors `createWebmention({ baseUrl })` → the `/webmention` receiver. */
+export function createWebmention(_config?: unknown) {
+  return (_request: Request, _env: unknown, _ctx: unknown) => {
+    webmentionCalls.receive++;
+    return new Response(null, {
+      status: 202,
+      headers: { "x-handler": "webmention" },
+    });
+  };
+}
+
+/** Mirrors `createWebmentionQueueConsumer({ inbox })` → the queue consumer. */
+export function createWebmentionQueueConsumer(_config?: unknown) {
+  return async (_batch: unknown, _env: unknown, _ctx: unknown) => {
+    webmentionCalls.queue++;
+  };
+}
+
+/** Mirrors `safeFetch(doFetch, url, init, options)` → `{ response, url }`. */
+export async function safeFetch(
+  _doFetch: unknown,
+  url: string,
+  _init?: unknown,
+  _options?: unknown,
+) {
+  return { response: new Response("", { status: 200 }), url };
 }

--- a/tests/indieweb-dispatch.test.ts
+++ b/tests/indieweb-dispatch.test.ts
@@ -1,25 +1,31 @@
 /**
- * Plugin-side tests for the IndieWeb runtime wiring in
- * `template/worker/site-entry.js` (issue #337, design §7):
+ * Plugin-side tests for the IndieWeb runtime wiring in the SHIPPED default
+ * `template/worker/site-entry.js` (issues #337, #363):
  *
- *   - Gated endpoint dispatch — each route fires only when its binding is
- *     present, and falls through to ASSETS otherwise.
- *   - queue()/scheduled() hooks — webmention drain runs only with
- *     WEBMENTION_DB; the Micropub bridge sync always runs via waitUntil.
- *   - Webmention edge-render gating — no WEBMENTION_DB query and no rewrite
- *     unless the request is for a note/post HTML page that actually has
- *     stored mentions.
+ *   - IndieAuth + Micropub routes report 501 while their wiring is pending the
+ *     auth follow-up — the Worker boots and never crashes on missing config.
+ *   - Webmention is NOT wired in the default template: `/anglesite:indieweb`
+ *     injects it (import + dispatch + queue drain + edge-render) at the
+ *     `@anglesite-inject:*` sentinels when the owner enables Webmention. The
+ *     default worker therefore falls every IndieWeb-shaped request through to
+ *     ASSETS, and queue()/scheduled() only run the Micropub bridge sync.
+ *   - The integrated webmention behavior is covered in webmention-module.test.ts
+ *     (handler, queue drain, edge-render, mf2 parse) against worker/webmention.js.
  *
- * The @dwk/* handlers are unpublished; vitest aliases them to tagged stubs
- * (tests/__stubs__/dwk-*.ts) so the real worker imports cleanly and each
- * dispatch target is identifiable by its `x-handler` response header.
+ * This file also guards the injection sentinels so the skill's anchors can't
+ * silently disappear.
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import worker from "../template/worker/site-entry.js";
-import {
-  webmentionCalls,
-  resetWebmentionCalls,
-} from "./__stubs__/dwk-webmention";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const siteEntrySource = readFileSync(
+  join(__dirname, "..", "template", "worker", "site-entry.js"),
+  "utf-8",
+);
 
 function makeCtx() {
   return { waitUntil: vi.fn(), passThroughOnException: vi.fn() };
@@ -50,271 +56,113 @@ function req(
   return new Request(`https://example.com${path}`, { method, headers });
 }
 
-beforeEach(() => {
-  resetWebmentionCalls();
-});
-
-describe("IndieWeb endpoint dispatch (gated on bindings)", () => {
-  it("routes /auth to the IndieAuth handler when AUTH_DB is bound", async () => {
+describe("IndieAuth / Micropub dispatch (wiring pending — 501)", () => {
+  it("reports 501 for /auth when AUTH_DB is bound, without crashing or hitting ASSETS", async () => {
     const env = makeEnv({ AUTH_DB: {} });
     const res = await worker.fetch(req("/auth"), env, makeCtx());
-    expect(res.headers.get("x-handler")).toBe("indieauth");
+    expect(res.status).toBe(501);
     expect(env.ASSETS.fetch).not.toHaveBeenCalled();
   });
 
-  it("routes any /auth subpath (e.g. /auth/token) to IndieAuth", async () => {
+  it("reports 501 for any /auth subpath (e.g. /auth/token)", async () => {
     const env = makeEnv({ AUTH_DB: {} });
     const res = await worker.fetch(req("/auth/token"), env, makeCtx());
-    expect(res.headers.get("x-handler")).toBe("indieauth");
+    expect(res.status).toBe(501);
   });
 
-  it("falls through /auth to ASSETS when AUTH_DB is absent", async () => {
+  it("falls /auth through to ASSETS when AUTH_DB is absent", async () => {
     const env = makeEnv();
     const res = await worker.fetch(req("/auth"), env, makeCtx());
     expect(env.ASSETS.fetch).toHaveBeenCalledOnce();
     expect(res.headers.get("x-asset")).toBe("1");
-    expect(res.headers.get("x-handler")).toBeNull();
   });
 
-  it("routes /micropub and /media to Micropub when MICROPUB_DB is bound", async () => {
+  it("reports 501 for /micropub and /media when MICROPUB_DB is bound", async () => {
     for (const path of ["/micropub", "/media"]) {
       const env = makeEnv({ MICROPUB_DB: {} });
       const res = await worker.fetch(req(path), env, makeCtx());
-      expect(res.headers.get("x-handler"), path).toBe("micropub");
+      expect(res.status, path).toBe(501);
       expect(env.ASSETS.fetch).not.toHaveBeenCalled();
     }
   });
 
-  it("falls through /micropub to ASSETS when MICROPUB_DB is absent", async () => {
+  it("falls /micropub through to ASSETS when MICROPUB_DB is absent", async () => {
     const env = makeEnv();
     const res = await worker.fetch(req("/micropub"), env, makeCtx());
     expect(env.ASSETS.fetch).toHaveBeenCalledOnce();
-    expect(res.headers.get("x-handler")).toBeNull();
+    expect(res.status).not.toBe(501);
   });
 
-  it("routes /webmention to the Webmention handler when WEBMENTION_DB is bound", async () => {
+  it("routes are independent: AUTH_DB alone does not affect /micropub", async () => {
+    const env = makeEnv({ AUTH_DB: {} });
+    const res = await worker.fetch(req("/micropub"), env, makeCtx());
+    expect(env.ASSETS.fetch).toHaveBeenCalledOnce();
+    expect(res.status).not.toBe(501);
+  });
+});
+
+describe("Webmention is not wired in the default template", () => {
+  it("falls /webmention through to ASSETS even when WEBMENTION_DB is bound", async () => {
     const env = makeEnv({ WEBMENTION_DB: {} });
     const res = await worker.fetch(
       req("/webmention", { method: "POST" }),
       env,
       makeCtx(),
     );
-    expect(res.headers.get("x-handler")).toBe("webmention");
-    expect(webmentionCalls.fetch).toBe(1);
-    expect(env.ASSETS.fetch).not.toHaveBeenCalled();
+    expect(env.ASSETS.fetch).toHaveBeenCalledOnce();
+    expect(res.headers.get("x-asset")).toBe("1");
   });
 
-  it("falls through /webmention to ASSETS when WEBMENTION_DB is absent", async () => {
-    const env = makeEnv();
-    const res = await worker.fetch(
-      req("/webmention", { method: "POST" }),
-      env,
-      makeCtx(),
-    );
-    expect(env.ASSETS.fetch).toHaveBeenCalledOnce();
-    expect(res.headers.get("x-handler")).toBeNull();
-    expect(webmentionCalls.fetch).toBe(0);
-  });
-
-  it("routes are independent: AUTH_DB alone does not enable /micropub", async () => {
-    const env = makeEnv({ AUTH_DB: {} });
-    const res = await worker.fetch(req("/micropub"), env, makeCtx());
-    expect(env.ASSETS.fetch).toHaveBeenCalledOnce();
-    expect(res.headers.get("x-handler")).toBeNull();
-  });
-
-  it("unknown paths always fall through to ASSETS even with every binding set", async () => {
-    const env = makeEnv({ AUTH_DB: {}, MICROPUB_DB: {}, WEBMENTION_DB: {} });
-    const res = await worker.fetch(req("/about/"), env, makeCtx());
-    expect(env.ASSETS.fetch).toHaveBeenCalledOnce();
-    expect(res.headers.get("x-handler")).toBeNull();
+  it("does not rewrite note/post pages (edge-render is injected, not default)", async () => {
+    let rewriteUsed = false;
+    class FakeHTMLRewriter {
+      on() {
+        return this;
+      }
+      transform(r: Response) {
+        rewriteUsed = true;
+        return r;
+      }
+    }
+    (globalThis as any).HTMLRewriter = FakeHTMLRewriter;
+    try {
+      const env = makeEnv({ WEBMENTION_DB: {} });
+      const res = await worker.fetch(
+        req("/notes/abc/", { accept: "text/html" }),
+        env,
+        makeCtx(),
+      );
+      expect(rewriteUsed).toBe(false);
+      expect(res.headers.get("x-asset")).toBe("1");
+    } finally {
+      delete (globalThis as any).HTMLRewriter;
+    }
   });
 });
 
-describe("queue() and scheduled() dispatch", () => {
-  it("queue() drains the webmention queue only when WEBMENTION_DB is bound", async () => {
-    await worker.queue({ messages: [] }, makeEnv({ WEBMENTION_DB: {} }), makeCtx());
-    expect(webmentionCalls.queue).toBe(1);
-
-    resetWebmentionCalls();
-    await worker.queue({ messages: [] }, makeEnv(), makeCtx());
-    expect(webmentionCalls.queue).toBe(0);
-  });
-
-  it("queue() always schedules the Micropub bridge sync via waitUntil", async () => {
+describe("queue() and scheduled() in the default template", () => {
+  it("queue() runs only the Micropub bridge sync (no webmention drain wired)", async () => {
     const ctx = makeCtx();
-    await worker.queue({ messages: [] }, makeEnv(), ctx);
+    await worker.queue({ messages: [] }, makeEnv({ WEBMENTION_DB: {} }), ctx);
     expect(ctx.waitUntil).toHaveBeenCalledOnce();
   });
 
-  it("scheduled() runs the webmention cron only when WEBMENTION_DB is bound", async () => {
-    await worker.scheduled({}, makeEnv({ WEBMENTION_DB: {} }), makeCtx());
-    expect(webmentionCalls.scheduled).toBe(1);
-
-    resetWebmentionCalls();
-    await worker.scheduled({}, makeEnv(), makeCtx());
-    expect(webmentionCalls.scheduled).toBe(0);
-  });
-
-  it("scheduled() always schedules the Micropub bridge sync via waitUntil", async () => {
+  it("scheduled() runs the Micropub bridge sync via waitUntil", async () => {
     const ctx = makeCtx();
     await worker.scheduled({}, makeEnv(), ctx);
     expect(ctx.waitUntil).toHaveBeenCalledOnce();
   });
 });
 
-describe("Webmention edge-render gating", () => {
-  // site-entry.js calls `new HTMLRewriter()` only when it decides to inject.
-  // The Node test runtime has no HTMLRewriter, so we install a fake that
-  // records whether a rewrite was attempted — that flag is the assertion.
-  let rewriteUsed = false;
-
-  class FakeHTMLRewriter {
-    on() {
-      return this;
+describe("webmention injection sentinels (skill anchor contract)", () => {
+  it("ships all four @anglesite-inject sentinels the indieweb skill targets", () => {
+    for (const id of [
+      "webmention-import",
+      "webmention-dispatch",
+      "webmention-render",
+      "webmention-queue",
+    ]) {
+      expect(siteEntrySource, id).toContain(`/* @anglesite-inject:${id} */`);
     }
-    transform(response: Response) {
-      rewriteUsed = true;
-      return response;
-    }
-  }
-
-  beforeEach(() => {
-    rewriteUsed = false;
-    (globalThis as any).HTMLRewriter = FakeHTMLRewriter;
-  });
-
-  afterEach(() => {
-    delete (globalThis as any).HTMLRewriter;
-  });
-
-  // Serves both edge-render queries: the distinct-targets set (keys of
-  // mentionsByTarget) and the per-target mention rows. The worker caches the
-  // target set per binding object, so each test's fresh mock starts cold.
-  function webmentionDb(mentionsByTarget: Record<string, unknown[]>) {
-    const targetsAll = vi.fn(async () => ({
-      results: Object.keys(mentionsByTarget).map((target) => ({ target })),
-    }));
-    let boundTarget: string;
-    const mentionsAll = vi.fn(async () => ({
-      results: mentionsByTarget[boundTarget] ?? [],
-    }));
-    const bind = vi.fn((target: string) => {
-      boundTarget = target;
-      return { all: mentionsAll };
-    });
-    const prepare = vi.fn((sql: string) =>
-      sql.includes("DISTINCT") ? { all: targetsAll } : { bind },
-    );
-    return { db: { prepare }, prepare, bind, targetsAll, mentionsAll };
-  }
-
-  it("queries D1 and rewrites a note/blog page that has stored mentions", async () => {
-    for (const path of ["/notes/abc/", "/blog/my-post/"]) {
-      rewriteUsed = false;
-      const target = `https://example.com${path}`;
-      const { db, bind } = webmentionDb({
-        [target]: [
-          {
-            author_name: "Alice",
-            author_url: "https://alice.example",
-            content: "Great post!",
-            url: "https://alice.example/reply/1",
-            type: "in-reply-to",
-            published: "2026-06-01T00:00:00Z",
-          },
-        ],
-      });
-      const env = makeEnv({ WEBMENTION_DB: db });
-      await worker.fetch(req(path, { accept: "text/html" }), env, makeCtx());
-
-      expect(bind, path).toHaveBeenCalledWith(target);
-      expect(rewriteUsed, path).toBe(true);
-    }
-  });
-
-  it("does NOT query mentions or rewrite when the page has no stored mentions", async () => {
-    const { db, bind } = webmentionDb({
-      "https://example.com/notes/other/": [{ author_name: "Alice" }],
-    });
-    const env = makeEnv({ WEBMENTION_DB: db });
-    const res = await worker.fetch(
-      req("/notes/abc/", { accept: "text/html" }),
-      env,
-      makeCtx(),
-    );
-
-    // The page isn't in the known-target set, so no per-target query runs.
-    expect(bind).not.toHaveBeenCalled();
-    expect(rewriteUsed).toBe(false);
-    // Response passes through untouched.
-    expect(res.headers.get("x-asset")).toBe("1");
-  });
-
-  it("caches the known-target set — one distinct query across requests", async () => {
-    const { db, targetsAll } = webmentionDb({});
-    const env = makeEnv({ WEBMENTION_DB: db });
-    await worker.fetch(req("/notes/a/", { accept: "text/html" }), env, makeCtx());
-    await worker.fetch(req("/notes/b/", { accept: "text/html" }), env, makeCtx());
-    expect(targetsAll).toHaveBeenCalledOnce();
-  });
-
-  it("does NOT query for non-target paths (home, about)", async () => {
-    for (const path of ["/", "/about/", "/contact/"]) {
-      const { db, prepare } = webmentionDb({
-        "https://example.com/notes/abc/": [{ author_name: "Bob" }],
-      });
-      const env = makeEnv({ WEBMENTION_DB: db });
-      await worker.fetch(req(path, { accept: "text/html" }), env, makeCtx());
-      expect(prepare, path).not.toHaveBeenCalled();
-      expect(rewriteUsed, path).toBe(false);
-    }
-  });
-
-  it("does NOT query the collection index — only permalinks are targets", async () => {
-    for (const path of ["/notes", "/notes/", "/blog", "/blog/"]) {
-      const { db, prepare } = webmentionDb({
-        "https://example.com/notes/abc/": [{ author_name: "Bob" }],
-      });
-      const env = makeEnv({ WEBMENTION_DB: db });
-      await worker.fetch(req(path, { accept: "text/html" }), env, makeCtx());
-      expect(prepare, path).not.toHaveBeenCalled();
-    }
-  });
-
-  it("does NOT query when WEBMENTION_DB is unbound", async () => {
-    const env = makeEnv();
-    const res = await worker.fetch(
-      req("/notes/abc/", { accept: "text/html" }),
-      env,
-      makeCtx(),
-    );
-    expect(rewriteUsed).toBe(false);
-    expect(res.headers.get("x-asset")).toBe("1");
-  });
-
-  it("does NOT query non-HTML responses even on a target path", async () => {
-    const { db, prepare } = webmentionDb({
-      "https://example.com/notes/abc/": [{ author_name: "Bob" }],
-    });
-    const env = makeEnv({
-      WEBMENTION_DB: db,
-      ASSETS: {
-        fetch: vi.fn(async () => assetsResponse("{}", "application/json")),
-      },
-    });
-    await worker.fetch(req("/notes/abc/", { accept: "text/html" }), env, makeCtx());
-    expect(prepare).not.toHaveBeenCalled();
-    expect(rewriteUsed).toBe(false);
-  });
-
-  it("does NOT query for non-HTML requests (no Accept: text/html)", async () => {
-    const { db, prepare } = webmentionDb({
-      "https://example.com/notes/abc/": [{ author_name: "Bob" }],
-    });
-    const env = makeEnv({ WEBMENTION_DB: db });
-    await worker.fetch(req("/notes/abc/"), env, makeCtx());
-    expect(prepare).not.toHaveBeenCalled();
-    expect(rewriteUsed).toBe(false);
   });
 });

--- a/tests/webmention-module.test.ts
+++ b/tests/webmention-module.test.ts
@@ -18,6 +18,7 @@ import {
   handleWebmention,
   drainWebmentionQueue,
   injectWebmentions,
+  createWebmentionInbox,
 } from "../template/worker/webmention.js";
 import { webmentionCalls, resetWebmentionCalls } from "./__stubs__/dwk-webmention";
 
@@ -110,6 +111,38 @@ describe("drainWebmentionQueue() — queue consumer gating", () => {
   it("is a no-op when WEBMENTION_DB is absent", async () => {
     await drainWebmentionQueue({ messages: [] }, {}, { waitUntil: vi.fn() });
     expect(webmentionCalls.queue).toBe(0);
+  });
+});
+
+describe("createWebmentionInbox() — schema resilience", () => {
+  // A db whose first CREATE TABLE rejects, then succeeds; all other statements
+  // (upsert/delete) are no-ops. Proves a transient first-write D1 error doesn't
+  // wedge the inbox — ensureSchema clears its cached promise and retries.
+  function flakySchemaDb() {
+    let createCalls = 0;
+    const prepare = vi.fn((sql: string) => {
+      if (sql.includes("CREATE TABLE")) {
+        return {
+          run: async () => {
+            createCalls++;
+            if (createCalls === 1) throw new Error("transient D1 error");
+          },
+        };
+      }
+      return { bind: () => ({ run: async () => {} }) };
+    });
+    return { db: { prepare } as any, createCalls: () => createCalls };
+  }
+
+  it("retries CREATE TABLE after a transient failure instead of wedging", async () => {
+    const { db, createCalls } = flakySchemaDb();
+    const inbox = createWebmentionInbox(db);
+    const mention = { source: "https://x.example/a", target: TARGET, verifiedAt: 1 };
+
+    await expect(inbox.store(mention)).rejects.toThrow("transient D1 error");
+    // The cached promise was cleared, so the next write retries and succeeds.
+    await expect(inbox.store(mention)).resolves.toBeUndefined();
+    expect(createCalls()).toBe(2);
   });
 });
 

--- a/tests/webmention-module.test.ts
+++ b/tests/webmention-module.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for the injectable webmention runtime (worker/webmention.js), the
+ * module `/anglesite:indieweb` wires into the site Worker when Webmention is
+ * enabled (issue #363). Covers the real composition against @dwk/webmention
+ * (aliased to a stub) plus mf2 extraction against the real microformats-parser:
+ *
+ *   - parseMention() — h-entry / h-card → author, content, type, permalink.
+ *   - handleWebmention() — dispatches to the receiver for the request origin.
+ *   - drainWebmentionQueue() — runs the consumer only when WEBMENTION_DB is set.
+ *   - injectWebmentions() — edge-render gating (target path, HTML, known target).
+ *
+ * URL/XSS hardening of renderMention()/safeUrl() lives in
+ * webmention-render-xss.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  parseMention,
+  handleWebmention,
+  drainWebmentionQueue,
+  injectWebmentions,
+} from "../template/worker/webmention.js";
+import { webmentionCalls, resetWebmentionCalls } from "./__stubs__/dwk-webmention";
+
+const TARGET = "https://example.com/notes/abc/";
+
+beforeEach(() => {
+  resetWebmentionCalls();
+});
+
+describe("parseMention() — microformats2 extraction", () => {
+  it("extracts a reply with author h-card, content, permalink, and published", () => {
+    const html = `
+      <div class="h-entry">
+        <div class="p-author h-card">
+          <a class="p-name u-url" href="https://alice.example/">Alice</a>
+          <img class="u-photo" src="https://alice.example/me.jpg" alt="">
+        </div>
+        <a class="u-in-reply-to" href="${TARGET}">in reply to</a>
+        <div class="e-content">Great post!</div>
+        <time class="dt-published" datetime="2026-06-01T00:00:00Z">Jun 1</time>
+        <a class="u-url" href="https://alice.example/reply/1">permalink</a>
+      </div>`;
+    const m = parseMention(html, {
+      source: "https://alice.example/reply/1",
+      target: TARGET,
+    });
+    expect(m.type).toBe("reply");
+    expect(m.author_name).toBe("Alice");
+    expect(m.author_url).toBe("https://alice.example/");
+    expect(m.author_photo).toBe("https://alice.example/me.jpg");
+    expect(m.content).toBe("Great post!");
+    expect(m.published).toBe("2026-06-01T00:00:00Z");
+    expect(m.url).toBe("https://alice.example/reply/1");
+  });
+
+  it("classifies a like-of as type 'like'", () => {
+    const html = `
+      <div class="h-entry">
+        <a class="p-author h-card u-url" href="https://bob.example/">Bob</a>
+        <a class="u-like-of" href="${TARGET}">liked</a>
+      </div>`;
+    const m = parseMention(html, { source: "https://bob.example/l/1", target: TARGET });
+    expect(m.type).toBe("like");
+    expect(m.author_url).toBe("https://bob.example/");
+  });
+
+  it("classifies a repost-of as type 'repost'", () => {
+    const html = `<div class="h-entry"><a class="u-repost-of" href="${TARGET}">RT</a></div>`;
+    const m = parseMention(html, { source: "https://x.example/r/1", target: TARGET });
+    expect(m.type).toBe("repost");
+  });
+
+  it("defaults to type 'mention' when no response property points at the target", () => {
+    const html = `<div class="h-entry"><div class="e-content">See <a href="${TARGET}">this</a></div></div>`;
+    const m = parseMention(html, { source: "https://x.example/m/1", target: TARGET });
+    expect(m.type).toBe("mention");
+  });
+
+  it("falls back to source URL and no author for an unparseable page", () => {
+    const m = parseMention("<html><body>plain</body></html>", {
+      source: "https://x.example/p",
+      target: TARGET,
+    });
+    expect(m.type).toBe("mention");
+    expect(m.url).toBe("https://x.example/p");
+    expect(m.author_name).toBeUndefined();
+  });
+});
+
+describe("handleWebmention() — receiver dispatch", () => {
+  it("dispatches to the receiver and returns its response", async () => {
+    const res = await handleWebmention(
+      new Request("https://example.com/webmention", { method: "POST" }),
+      {},
+      { waitUntil: vi.fn() },
+      "https://example.com",
+    );
+    expect(res.headers.get("x-handler")).toBe("webmention");
+    expect(res.status).toBe(202);
+    expect(webmentionCalls.receive).toBe(1);
+  });
+});
+
+describe("drainWebmentionQueue() — queue consumer gating", () => {
+  it("runs the consumer when WEBMENTION_DB is bound", async () => {
+    await drainWebmentionQueue({ messages: [] }, { WEBMENTION_DB: {} }, { waitUntil: vi.fn() });
+    expect(webmentionCalls.queue).toBe(1);
+  });
+
+  it("is a no-op when WEBMENTION_DB is absent", async () => {
+    await drainWebmentionQueue({ messages: [] }, {}, { waitUntil: vi.fn() });
+    expect(webmentionCalls.queue).toBe(0);
+  });
+});
+
+describe("injectWebmentions() — edge-render gating", () => {
+  let rewriteUsed = false;
+  class FakeHTMLRewriter {
+    on() {
+      return this;
+    }
+    transform(r: Response) {
+      rewriteUsed = true;
+      return r;
+    }
+  }
+
+  beforeEach(() => {
+    rewriteUsed = false;
+    (globalThis as any).HTMLRewriter = FakeHTMLRewriter;
+  });
+  afterEach(() => {
+    delete (globalThis as any).HTMLRewriter;
+  });
+
+  function htmlResponse() {
+    return new Response("<div id=webmentions></div>", {
+      headers: { "content-type": "text/html" },
+    });
+  }
+
+  // Serves both edge-render queries: the distinct-targets set and the per-target
+  // rows. The targets cache is keyed per binding object, so a fresh mock per test
+  // starts cold.
+  function webmentionDb(mentionsByTarget: Record<string, unknown[]>) {
+    const targetsAll = vi.fn(async () => ({
+      results: Object.keys(mentionsByTarget).map((target) => ({ target })),
+    }));
+    let boundTarget: string;
+    const mentionsAll = vi.fn(async () => ({ results: mentionsByTarget[boundTarget] ?? [] }));
+    const bind = vi.fn((target: string) => {
+      boundTarget = target;
+      return { all: mentionsAll };
+    });
+    const prepare = vi.fn((sql: string) =>
+      sql.includes("DISTINCT") ? { all: targetsAll } : { bind },
+    );
+    return { db: { prepare }, prepare, bind, targetsAll };
+  }
+
+  it("rewrites a note/blog page that has stored mentions", async () => {
+    for (const path of ["/notes/abc/", "/blog/my-post/"]) {
+      rewriteUsed = false;
+      const target = `https://example.com${path}`;
+      const { db, bind } = webmentionDb({
+        [target]: [{ author_name: "Alice", url: "https://alice.example/r/1", type: "reply" }],
+      });
+      await injectWebmentions(htmlResponse(), { WEBMENTION_DB: db }, new URL(target));
+      expect(bind, path).toHaveBeenCalledWith(target);
+      expect(rewriteUsed, path).toBe(true);
+    }
+  });
+
+  it("does not query or rewrite when the page has no stored mentions", async () => {
+    const { db, bind } = webmentionDb({ "https://example.com/notes/other/": [{}] });
+    const res = await injectWebmentions(
+      htmlResponse(),
+      { WEBMENTION_DB: db },
+      new URL("https://example.com/notes/abc/"),
+    );
+    expect(bind).not.toHaveBeenCalled();
+    expect(rewriteUsed).toBe(false);
+    expect(res.headers.get("content-type")).toContain("text/html");
+  });
+
+  it("caches the known-target set across requests (one distinct query)", async () => {
+    const { db, targetsAll } = webmentionDb({});
+    await injectWebmentions(htmlResponse(), { WEBMENTION_DB: db }, new URL("https://example.com/notes/a/"));
+    await injectWebmentions(htmlResponse(), { WEBMENTION_DB: db }, new URL("https://example.com/notes/b/"));
+    expect(targetsAll).toHaveBeenCalledOnce();
+  });
+
+  it("skips non-target paths and collection indexes without querying", async () => {
+    for (const path of ["/", "/about/", "/notes", "/notes/", "/blog/"]) {
+      const { db, prepare } = webmentionDb({ "https://example.com/notes/abc/": [{}] });
+      await injectWebmentions(htmlResponse(), { WEBMENTION_DB: db }, new URL(`https://example.com${path}`));
+      expect(prepare, path).not.toHaveBeenCalled();
+    }
+  });
+
+  it("skips when WEBMENTION_DB is unbound", async () => {
+    const res = await injectWebmentions(htmlResponse(), {}, new URL("https://example.com/notes/abc/"));
+    expect(rewriteUsed).toBe(false);
+    expect(res.headers.get("content-type")).toContain("text/html");
+  });
+
+  it("skips non-HTML responses even on a target path", async () => {
+    const { db, prepare } = webmentionDb({ "https://example.com/notes/abc/": [{}] });
+    const json = new Response("{}", { headers: { "content-type": "application/json" } });
+    await injectWebmentions(json, { WEBMENTION_DB: db }, new URL("https://example.com/notes/abc/"));
+    expect(prepare).not.toHaveBeenCalled();
+    expect(rewriteUsed).toBe(false);
+  });
+});

--- a/tests/webmention-render-xss.test.ts
+++ b/tests/webmention-render-xss.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression test for the stored-XSS in the webmention edge-render
+ * (issue #363, finding 3).
+ *
+ * Webmention fields (author_url, author_photo, url) come from arbitrary
+ * external sites. `escapeHtml()` neutralizes HTML metacharacters but NOT
+ * dangerous URL schemes, so a verified mention whose author_url is
+ * `javascript:…` or `data:…` previously rendered an executable href/src.
+ * `renderMention()` must run every URL through `safeUrl()` (http/https
+ * allowlist) before interpolating it into an attribute.
+ */
+import { describe, it, expect } from "vitest";
+import { renderMention, safeUrl } from "../template/worker/webmention.js";
+
+describe("safeUrl()", () => {
+  it("allows http and https URLs", () => {
+    expect(safeUrl("http://example.com/")).toBe("http://example.com/");
+    expect(safeUrl("https://example.com/x")).toBe("https://example.com/x");
+  });
+
+  it("rejects dangerous and non-http(s) schemes", () => {
+    expect(safeUrl("javascript:alert(1)")).toBeNull();
+    expect(safeUrl("JavaScript:alert(1)")).toBeNull();
+    expect(safeUrl("  javascript:alert(1)")).toBeNull();
+    expect(safeUrl("data:text/html,<script>alert(1)</script>")).toBeNull();
+    expect(safeUrl("vbscript:msgbox(1)")).toBeNull();
+    expect(safeUrl("file:///etc/passwd")).toBeNull();
+  });
+
+  it("rejects empty, relative, and unparseable values", () => {
+    expect(safeUrl(undefined)).toBeNull();
+    expect(safeUrl("")).toBeNull();
+    expect(safeUrl("/relative/path")).toBeNull();
+    expect(safeUrl("not a url")).toBeNull();
+  });
+});
+
+describe("renderMention() URL hardening", () => {
+  it("drops a javascript: author_url instead of rendering an href", () => {
+    const html = renderMention({
+      author_name: "Mallory",
+      author_url: "javascript:alert(document.cookie)",
+    });
+    expect(html).not.toContain("javascript:");
+    // Falls back to a plain <span>, not an anchor.
+    expect(html).toContain('<span class="p-author">Mallory</span>');
+    expect(html).not.toContain("<a class=\"p-author");
+  });
+
+  it("drops a data: author_photo instead of rendering an img src", () => {
+    const html = renderMention({
+      author_name: "Mallory",
+      author_photo: "data:text/html,<script>alert(1)</script>",
+    });
+    expect(html).not.toContain("data:");
+    expect(html).not.toContain("<img");
+  });
+
+  it("drops a javascript: permalink URL", () => {
+    const html = renderMention({
+      author_name: "Mallory",
+      url: "javascript:alert(1)",
+    });
+    expect(html).not.toContain("javascript:");
+    expect(html).not.toContain("permalink");
+  });
+
+  it("renders safe http(s) URLs with hardening rel attributes", () => {
+    const html = renderMention({
+      author_name: "Alice",
+      author_url: "https://alice.example/",
+      author_photo: "https://alice.example/me.jpg",
+      url: "https://alice.example/post/1",
+      content: "nice post",
+    });
+    expect(html).toContain('href="https://alice.example/"');
+    expect(html).toContain('src="https://alice.example/me.jpg"');
+    expect(html).toContain('href="https://alice.example/post/1"');
+    // Both anchors carry the untrusted-link hardening rel.
+    expect(html.match(/rel="nofollow ugc noopener"/g)?.length).toBe(2);
+  });
+
+  it("does not surface a dangerous author_url as the display name", () => {
+    const html = renderMention({
+      author_url: "javascript:alert(1)",
+    });
+    expect(html).not.toContain("javascript:");
+    expect(html).toContain("Someone");
+  });
+});

--- a/tests/webmention-render-xss.test.ts
+++ b/tests/webmention-render-xss.test.ts
@@ -76,8 +76,9 @@ describe("renderMention() URL hardening", () => {
     expect(html).toContain('href="https://alice.example/"');
     expect(html).toContain('src="https://alice.example/me.jpg"');
     expect(html).toContain('href="https://alice.example/post/1"');
-    // Both anchors carry the untrusted-link hardening rel.
-    expect(html.match(/rel="nofollow ugc noopener"/g)?.length).toBe(2);
+    // Both anchors carry the untrusted-link hardening rel (noreferrer also
+    // suppresses the Referer header leaking the host page to the linked domain).
+    expect(html.match(/rel="nofollow ugc noopener noreferrer"/g)?.length).toBe(2);
   });
 
   it("does not surface a dangerous author_url as the display name", () => {


### PR DESCRIPTION
Re-platforms the Webmention path onto the published `@dwk/webmention` API, fixes the boot crash the 1.1.0 Worker would hit against the real packages, and closes the stored-XSS finding. Addresses **findings 2 & 3** of #363 (finding 1 is in the `@dwk/*` package repos; IndieAuth + Micropub are deferred to a follow-up).

## Why
`worker/site-entry.js` is every site's Worker `main`. In 1.1.0 it statically imported `@dwk/*` and constructed the handlers at module load with bare config — which **throws on boot** against the published packages (`createWebmention()`/`createIndieAuth()` read `config.baseUrl`/`config.logger` on `undefined`). The scaffold only appeared to build because `astro build` doesn't bundle the Worker and the tests mocked the packages.

## What changed
- **Security (finding 3):** `renderMention()` interpolated external webmention `author_url` / `author_photo` / `url` into `href`/`src` with only `escapeHtml()`, which doesn't block `javascript:`/`data:` schemes. URLs now pass a `safeUrl()` http(s) allowlist; anchors get `rel="nofollow ugc noopener"`.
- **Re-wire (finding 2):** removed module-load construction (fixes the boot crash). IndieAuth + Micropub routes report **501** pending their auth follow-up. Webmention moves to a new injectable **`worker/webmention.js`** composed against `createWebmention` + `createWebmentionQueueConsumer`, with a **custom `InboxStore`** that re-fetches each verified source (SSRF-guarded via `safeFetch`) and parses **microformats2** to persist the author h-card, content, permalink, and reply/like/repost type — the package's default inbox only stores `(source, target, verified_at)`.
- **Architecture:** the module's `@dwk/webmention` + `microformats-parser` imports can't ship for all sites, so `site-entry.js` ships four `/* @anglesite-inject:* */` sentinels that `/anglesite:indieweb` fills in (new **Step 4b**: install deps + replace sentinels) only when Webmention is enabled. Plain sites never install or bundle the deps.
- **Skill:** truthful availability (Webmention live; IndieAuth/Micropub 501-pending), install/injection steps, auto-created schema docs, and the `TOKEN_SIGNING_KEY` correction for the IndieAuth follow-up.

## Tests
- New `tests/webmention-module.test.ts` (14) — real `mf2` parse (reply/like/repost/mention), receiver + queue-drain gating, edge-render gating.
- `tests/webmention-render-xss.test.ts` (8) — `safeUrl`/`renderMention` scheme hardening.
- `tests/indieweb-dispatch.test.ts` — rewritten for the 501 default, webmention-unwired passthrough, and the injection-sentinel contract.
- Full suite: **2658 pass**; only the pre-existing `optimize-images-packaging` e2e fails (confirmed failing on a clean tree, sharp/env-related). Injection recipe validated to produce valid JS.

## Follow-ups (not in this PR)
1. Wire IndieAuth (`approveAuthorization` consent endpoint + `TOKEN_SIGNING_KEY`) and Micropub — removes the 501 stubs; the `dwk-indieauth`/`dwk-micropub` test stubs (still exporting the old `createHandler`, currently unused) get rewritten then.
2. Fix the extensionless ESM re-exports (finding 1) and republish in the `@dwk/*` repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)