### PR TITLE
feat(indieweb): rich Webmention author cards via mf2-parsing inbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anglesite",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anglesite",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",
@@ -16,6 +16,7 @@
         "@types/semver": "^7.7.1",
         "html-validate": "^10.11.2",
         "markdownlint-cli2": "^0.22.0",
+        "microformats-parser": "^2.0.4",
         "robots-parser": "^3.0.1",
         "schema-dts": "^2.0.0",
         "semver": "^7.7.4",
@@ -3672,6 +3673,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/microformats-parser": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/microformats-parser/-/microformats-parser-2.0.4.tgz",
+      "integrity": "sha512-DA2yt3uz2JjupBGoNvaG9ngBP5vSTI1ky2yhxBai/RnQrlzo+gEzuCdvwIIjj2nh3uVPDybTP5u7uua7pOa6LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/micromark": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
@@ -4432,6 +4446,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/semver": "^7.7.1",
     "html-validate": "^10.11.2",
     "markdownlint-cli2": "^0.22.0",
+    "microformats-parser": "^2.0.4",
     "robots-parser": "^3.0.1",
     "schema-dts": "^2.0.0",
     "semver": "^7.7.4",

--- a/skills/indieweb/SKILL.md
+++ b/skills/indieweb/SKILL.md
@@ -182,6 +182,26 @@ For the Queue (Webmention):
 }
 ```
 
+## Step 4b — Install the endpoint packages
+
+`site-entry.js` imports the `@dwk/*` worker packages for the endpoints it serves, so install the ones for the selected endpoints. Webmention additionally needs `microformats-parser`: the site's rich inbox (`worker/webmention-inbox.js`) parses each verified source's microformats2 so stored mentions carry the author's name, photo, and a content snippet — not just the source URL.
+
+Install only what the owner selected:
+
+```sh
+npm install @dwk/webmention microformats-parser
+```
+
+```sh
+npm install @dwk/indieauth @dwk/webauthn
+```
+
+```sh
+npm install @dwk/micropub
+```
+
+(IndieAuth and Micropub are a pair — Micropub validates IndieAuth-issued tokens — so install `@dwk/indieauth` whenever `@dwk/micropub` is selected.)
+
 ## Step 5 — Store secrets
 
 ### 5a — IndieAuth signing key (if IndieAuth selected)
@@ -326,7 +346,7 @@ Tell the owner what's live and what to expect:
 For each enabled endpoint, explain in one sentence:
 
 - **IndieAuth** — "You can now sign in to IndieWeb services (and any IndieAuth-compatible app) with `https://<SITE_DOMAIN>`. Your tokens are issued by your own server."
-- **Webmention** — "Your site can now receive mentions, replies, and likes from other websites. They'll appear on your posts automatically."
+- **Webmention** — "Your site can now receive mentions, replies, and likes from other websites. They appear on your posts automatically as cards showing the sender's name, photo, and a snippet of what they wrote."
 - **Micropub** — "You can publish to your site from Micropub clients (like phone apps). New posts appear as notes — they're committed to your repo and go live after a rebuild (~1–2 minutes)."
 
 Important caveats to surface:
@@ -347,4 +367,4 @@ Suggest next steps:
 - **No cost.** Everything runs within Cloudflare's free tier (Workers, D1, R2, Queues). No third-party service fees.
 - **Privacy.** Webmention data (mentions from other sites) is stored in D1 on the owner's account. The owner should mention in their privacy policy that the site receives and stores Webmentions. Micropub posts are committed to the owner's private GitHub repo.
 - **Diagnostics.** If endpoints misbehave, check the Worker logs: `https://dash.cloudflare.com/<account-id>/workers/services/view/<CF_PROJECT_NAME>/production/observability/logs`. Or run `/anglesite:check` which will inspect the IndieWeb endpoint configuration.
-- **Schema management.** The `@dwk/*` packages manage their own D1 schemas. Schema migrations run automatically on first request or can be triggered manually via `npx wrangler d1 execute <db-name> --remote --file=<schema-path>`.
+- **Schema management.** The `@dwk/indieauth` / `@dwk/micropub` packages manage their own D1 schemas, which run automatically on first request. Webmention is the exception: the site's rich inbox (`worker/webmention-inbox.js`) owns its `webmentions` table — an extended schema (author name/url/photo, content, permalink, reply/like/repost type) created on first verified mention, replacing the package's default source/target-only inbox. **Migration:** a site that already ran the earlier minimal Webmention has a 3-column `webmentions` table; `CREATE TABLE IF NOT EXISTS` won't add the new columns, so the first rich UPSERT would fail. Drop the old table once so the rich schema is recreated on the next mention (verified mentions are re-sent/re-verifiable, so nothing is permanently lost): `npx wrangler d1 execute webmention --remote --command "DROP TABLE IF EXISTS webmentions"`.

--- a/template/package-lock.json
+++ b/template/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dwk/anglesite",
-  "version": "1.0.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dwk/anglesite",
-      "version": "1.0.2",
+      "version": "1.2.0",
       "dependencies": {
         "@astrojs/cloudflare": "13.5.0",
         "@astrojs/markdoc": "1.0.4",
@@ -17,6 +17,7 @@
         "@keystatic/core": "0.5.50",
         "astro": "6.3.1",
         "astro-pagefind": "^1.6.0",
+        "microformats-parser": "2.0.4",
         "react": "18.3.1",
         "react-dom": "18.3.1"
       },
@@ -9460,6 +9461,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/microformats-parser": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/microformats-parser/-/microformats-parser-2.0.4.tgz",
+      "integrity": "sha512-DA2yt3uz2JjupBGoNvaG9ngBP5vSTI1ky2yhxBai/RnQrlzo+gEzuCdvwIIjj2nh3uVPDybTP5u7uua7pOa6LA==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/micromark": {

--- a/template/package.json
+++ b/template/package.json
@@ -41,6 +41,7 @@
     "@keystatic/core": "0.5.50",
     "astro": "6.3.1",
     "astro-pagefind": "^1.6.0",
+    "microformats-parser": "2.0.4",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },

--- a/template/worker/site-entry.js
+++ b/template/worker/site-entry.js
@@ -59,8 +59,8 @@ import { createHandler as createMicropub } from "@dwk/micropub";
 import {
   createWebmention,
   createWebmentionQueueConsumer,
-  createD1Inbox,
 } from "@dwk/webmention";
+import { createRichWebmentionInbox } from "./webmention-inbox.js";
 import { createWebAuthn, WebAuthnObject } from "@dwk/webauthn";
 import { sync as syncMicropubBridge } from "./indieweb-bridge.js";
 import {
@@ -192,10 +192,17 @@ function webmentionFor(env) {
           "to configure it.",
       );
     }
+    // The rich inbox parses each verified source's microformats2 so mentions
+    // carry the author h-card + content, not just the source/target pair. It
+    // backs BOTH the queue consumer (verification writes the rich row) and the
+    // edge-render reader (the page shows it).
+    const inbox = env.WEBMENTION_INBOX
+      ? createRichWebmentionInbox(env.WEBMENTION_INBOX)
+      : null;
     bundle = {
       handler: createWebmention({ baseUrl }),
-      consumer: createWebmentionQueueConsumer({ baseUrl }),
-      inbox: env.WEBMENTION_INBOX ? createD1Inbox(env.WEBMENTION_INBOX) : null,
+      consumer: createWebmentionQueueConsumer({ baseUrl, inbox }),
+      inbox,
     };
     webmentionByEnv.set(env, bundle);
   }
@@ -430,7 +437,7 @@ const WEBMENTION_TARGETS_TTL_MS = 60_000;
 const webmentionTargetsCache = new WeakMap();
 
 // `dbKey` is the WEBMENTION_INBOX binding (the stable cache key); `inbox` is the
-// createD1Inbox reader over it. Each isolate runs the full list() scan at most
+// rich inbox reader over it. Each isolate runs the full list() scan at most
 // once per TTL — every other note/post request is an in-memory set lookup. A
 // failure serves the stale (or empty) set rather than breaking the render.
 async function loadWebmentionTargets(dbKey, inbox) {
@@ -481,17 +488,36 @@ class WebmentionInjector {
 // must pass the http(s) scheme allow-list before reaching an href, and the
 // anchor is `nofollow ugc noopener` (untrusted, user-generated). A source that
 // isn't a safe http(s) URL is dropped entirely.
+const MENTION_TYPES = new Set(["mention", "reply", "like", "repost", "bookmark"]);
+
 export function renderMention(m) {
-  const href = safeUrl(m.source);
-  if (!href) return "";
-  // safeUrl already returned a normalized, valid URL string, so re-parsing for
-  // the display host cannot throw.
-  const host = new URL(href).host;
-  return (
-    `<li class="h-cite">` +
-    `<a class="u-url" rel="nofollow ugc noopener noreferrer" href="${escapeHtml(href)}">${escapeHtml(host)}</a>` +
-    `</li>`
+  // Every external URL is scheme-checked before it can reach an href/src —
+  // escapeHtml alone wouldn't block `javascript:`/`data:` (stored XSS, since
+  // webmention data is attacker-controlled). A mention with no usable http(s)
+  // permalink/source is hostile or malformed, so drop it entirely.
+  const permalink = safeUrl(m.url) ?? safeUrl(m.source);
+  if (!permalink) return "";
+  const authorUrl = safeUrl(m.author_url);
+  const authorPhoto = safeUrl(m.author_photo);
+  // safeUrl returns normalized, valid URL strings, so re-parsing for a display
+  // host cannot throw.
+  const name = escapeHtml(
+    m.author_name ||
+      (authorUrl ? new URL(authorUrl).host : new URL(permalink).host),
   );
+  const type = MENTION_TYPES.has(m.type) ? m.type : "mention";
+
+  const photo = authorPhoto
+    ? `<img class="u-photo" src="${escapeHtml(authorPhoto)}" alt="" width="48" height="48" loading="lazy" />`
+    : "";
+  const author = authorUrl
+    ? `<a class="p-author h-card u-url" rel="nofollow ugc noopener noreferrer" href="${escapeHtml(authorUrl)}">${name}</a>`
+    : `<span class="p-author">${name}</span>`;
+  const content = m.content
+    ? `<div class="p-content">${escapeHtml(m.content)}</div>`
+    : "";
+  const link = `<a class="u-url" rel="nofollow ugc noopener noreferrer" href="${escapeHtml(permalink)}">permalink</a>`;
+  return `<li class="h-cite webmention-${type}">${photo}${author}${content}${link}</li>`;
 }
 
 // Return the URL only if it parses to an http(s) URL, else null. Blocks

--- a/template/worker/site-entry.js
+++ b/template/worker/site-entry.js
@@ -508,7 +508,7 @@ export function renderMention(m) {
   const type = MENTION_TYPES.has(m.type) ? m.type : "mention";
 
   const photo = authorPhoto
-    ? `<img class="u-photo" src="${escapeHtml(authorPhoto)}" alt="" width="48" height="48" loading="lazy" />`
+    ? `<img class="u-photo" src="${escapeHtml(authorPhoto)}" alt="" width="48" height="48" loading="lazy" referrerpolicy="no-referrer" />`
     : "";
   const author = authorUrl
     ? `<a class="p-author h-card u-url" rel="nofollow ugc noopener noreferrer" href="${escapeHtml(authorUrl)}">${name}</a>`

--- a/template/worker/webmention-inbox.js
+++ b/template/worker/webmention-inbox.js
@@ -1,0 +1,250 @@
+/**
+ * Rich Webmention inbox for the site Worker.
+ *
+ * `@dwk/webmention`'s default `createD1Inbox` stores only `(source, target,
+ * verified_at)`, so the edge-render can show no more than the mentioning host.
+ * This drop-in `InboxStore` (same `store` / `remove` / `list` contract) instead
+ * re-fetches each verified source — SSRF-guarded via the package's `safeFetch` —
+ * parses its microformats2, and persists the author h-card, content, permalink,
+ * and reply/like/repost type to an extended `webmentions` table that
+ * `renderMention()` reads to build full mention cards.
+ *
+ * It is wired in `site-entry.js`'s `webmentionFor(env)` as BOTH the queue
+ * consumer's inbox (so verification populates the rich row) and the edge-render
+ * reader (so the page shows it). A fetch/parse failure degrades to a
+ * source/target-only row rather than dropping the verified mention.
+ */
+import { safeFetch } from "@dwk/webmention";
+import { mf2 } from "microformats-parser";
+
+const CREATE_TABLE_SQL =
+  `CREATE TABLE IF NOT EXISTS webmentions (` +
+  `source TEXT NOT NULL, ` +
+  `target TEXT NOT NULL, ` +
+  `author_name TEXT, ` +
+  `author_url TEXT, ` +
+  `author_photo TEXT, ` +
+  `content TEXT, ` +
+  `url TEXT, ` +
+  `type TEXT, ` +
+  `published TEXT, ` +
+  `verified_at INTEGER NOT NULL, ` +
+  `PRIMARY KEY (source, target))`;
+
+const UPSERT_SQL =
+  `INSERT INTO webmentions ` +
+  `(source, target, author_name, author_url, author_photo, content, url, type, published, verified_at) ` +
+  `VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10) ` +
+  `ON CONFLICT (source, target) DO UPDATE SET ` +
+  `author_name = excluded.author_name, author_url = excluded.author_url, ` +
+  `author_photo = excluded.author_photo, content = excluded.content, ` +
+  `url = excluded.url, type = excluded.type, published = excluded.published, ` +
+  `verified_at = excluded.verified_at`;
+
+// `published` is nullable TEXT; `verified_at` is INTEGER ms. A raw
+// COALESCE(published, verified_at) would sort by type affinity (all integers
+// before all text), so undated rows normalize to an ISO string — keeping the
+// sort key uniformly text and chronological.
+const ORDER_BY = `ORDER BY COALESCE(published, datetime(verified_at / 1000, 'unixepoch')) ASC`;
+const SELECT_COLUMNS = `source, target, author_name, author_url, author_photo, content, url, type, published, verified_at`;
+
+function rowToMention(row) {
+  return {
+    source: row.source,
+    target: row.target,
+    author_name: row.author_name ?? undefined,
+    author_url: row.author_url ?? undefined,
+    author_photo: row.author_photo ?? undefined,
+    content: row.content ?? undefined,
+    url: row.url ?? row.source,
+    type: row.type ?? "mention",
+    published: row.published ?? undefined,
+    verifiedAt: row.verified_at,
+  };
+}
+
+/**
+ * Build the rich `InboxStore`. `fetchImpl` is injectable for tests; production
+ * uses the global `fetch`.
+ */
+export function createRichWebmentionInbox(db, { fetchImpl = fetch } = {}) {
+  let ready = null;
+  const ensureSchema = () => {
+    // Clear the cached promise on failure so a transient D1 error on the first
+    // write doesn't permanently wedge the inbox for this isolate — the next call
+    // retries the CREATE TABLE rather than re-awaiting a rejected promise.
+    if (!ready) {
+      ready = db
+        .prepare(CREATE_TABLE_SQL)
+        .run()
+        .then(() => undefined)
+        .catch((err) => {
+          ready = null;
+          throw err;
+        });
+    }
+    return ready;
+  };
+
+  return {
+    async store(mention) {
+      await ensureSchema();
+      let parsed = { type: "mention", url: mention.source };
+      try {
+        const { response } = await safeFetch(
+          fetchImpl,
+          mention.source,
+          { headers: { accept: "text/html" } },
+          { timeoutMs: 8000 },
+        );
+        if (response.ok) {
+          parsed = { ...parsed, ...parseMention(await response.text(), mention) };
+        }
+      } catch (err) {
+        // SSRF block, timeout, or unparseable source — keep the verified pair.
+        console.error("Webmention mf2 parse failed:", err?.message);
+      }
+      await db
+        .prepare(UPSERT_SQL)
+        .bind(
+          mention.source,
+          mention.target,
+          parsed.author_name ?? null,
+          parsed.author_url ?? null,
+          parsed.author_photo ?? null,
+          parsed.content ?? null,
+          parsed.url ?? mention.source,
+          parsed.type ?? "mention",
+          parsed.published ?? null,
+          mention.verifiedAt,
+        )
+        .run();
+    },
+
+    async remove(source, target) {
+      await ensureSchema();
+      await db
+        .prepare(`DELETE FROM webmentions WHERE source = ?1 AND target = ?2`)
+        .bind(source, target)
+        .run();
+    },
+
+    async list(target) {
+      await ensureSchema();
+      const statement =
+        target === undefined
+          ? db.prepare(`SELECT ${SELECT_COLUMNS} FROM webmentions ${ORDER_BY}`)
+          : db
+              .prepare(`SELECT ${SELECT_COLUMNS} FROM webmentions WHERE target = ?1 ${ORDER_BY}`)
+              .bind(target);
+      const { results } = await statement.all();
+      return (results ?? []).map(rowToMention);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// microformats2 extraction — turn a source page into a rich mention record.
+// ---------------------------------------------------------------------------
+
+// Reply/like/repost/bookmark properties, in the order we report them. The first
+// one whose value points at the target decides the mention's `type`.
+const RESPONSE_TYPES = [
+  ["like-of", "like"],
+  ["repost-of", "repost"],
+  ["in-reply-to", "reply"],
+  ["bookmark-of", "bookmark"],
+];
+
+/** First string-ish value of an mf2 property, or undefined. */
+function valueOf(prop) {
+  if (prop == null) return undefined;
+  if (typeof prop === "string") return prop;
+  // Html ({ value, html }) or Image ({ value, alt }) or h-* root ({ value }).
+  if (typeof prop.value === "string") return prop.value;
+  return undefined;
+}
+
+function firstString(properties, key) {
+  const values = properties?.[key];
+  return Array.isArray(values) ? valueOf(values[0]) : undefined;
+}
+
+/** Whether an mf2 property value (string, h-cite root, or url) is `target`. */
+function pointsAt(prop, target) {
+  if (typeof prop === "string") return prop === target;
+  if (prop && typeof prop === "object") {
+    if (valueOf(prop) === target) return true;
+    const url = prop.properties && firstString(prop.properties, "url");
+    if (url === target) return true;
+  }
+  return false;
+}
+
+function detectType(properties, target) {
+  for (const [key, type] of RESPONSE_TYPES) {
+    const values = properties?.[key];
+    if (Array.isArray(values) && values.some((v) => pointsAt(v, target))) {
+      return type;
+    }
+  }
+  return "mention";
+}
+
+function extractAuthor(properties) {
+  const author = properties?.author?.[0];
+  if (author == null) return {};
+  if (typeof author === "string") return { author_name: author };
+  const props = author.properties ?? {};
+  return {
+    author_name: firstString(props, "name"),
+    author_url: firstString(props, "url"),
+    author_photo: firstString(props, "photo"),
+  };
+}
+
+function extractContent(properties) {
+  const content = properties?.content?.[0];
+  const text =
+    valueOf(content) ?? firstString(properties, "summary") ?? firstString(properties, "name");
+  if (!text) return undefined;
+  // Cap stored content; the edge-render escapes it, this just bounds storage.
+  return text.length > 1000 ? `${text.slice(0, 1000)}…` : text;
+}
+
+/**
+ * Parse the `h-entry` (or bare `h-card`) of a webmention source into the row
+ * the edge-render expects. `mention` provides `source`/`target` fallbacks.
+ */
+export function parseMention(html, { source, target }) {
+  let entry;
+  let card;
+  try {
+    const { items } = mf2(html, { baseUrl: source });
+    for (const item of items ?? []) {
+      const types = item.type ?? [];
+      if (!entry && types.includes("h-entry")) entry = item;
+      if (!card && types.includes("h-card")) card = item;
+    }
+  } catch (err) {
+    console.error("Webmention mf2 parse error:", err?.message);
+  }
+
+  // A bare h-card source (e.g. a "likes" aggregator) still yields an author.
+  const properties = entry?.properties ?? {};
+  const author = entry
+    ? extractAuthor(properties)
+    : card
+      ? extractAuthor({ author: [card] })
+      : {};
+
+  return {
+    author_name: author.author_name,
+    author_url: author.author_url,
+    author_photo: author.author_photo,
+    content: extractContent(properties),
+    url: firstString(properties, "url") ?? source,
+    type: detectType(properties, target),
+    published: firstString(properties, "published"),
+  };
+}

--- a/template/worker/webmention-inbox.js
+++ b/template/worker/webmention-inbox.js
@@ -1,19 +1,4 @@
-/**
- * Rich Webmention inbox for the site Worker.
- *
- * `@dwk/webmention`'s default `createD1Inbox` stores only `(source, target,
- * verified_at)`, so the edge-render can show no more than the mentioning host.
- * This drop-in `InboxStore` (same `store` / `remove` / `list` contract) instead
- * re-fetches each verified source — SSRF-guarded via the package's `safeFetch` —
- * parses its microformats2, and persists the author h-card, content, permalink,
- * and reply/like/repost type to an extended `webmentions` table that
- * `renderMention()` reads to build full mention cards.
- *
- * It is wired in `site-entry.js`'s `webmentionFor(env)` as BOTH the queue
- * consumer's inbox (so verification populates the rich row) and the edge-render
- * reader (so the page shows it). A fetch/parse failure degrades to a
- * source/target-only row rather than dropping the verified mention.
- */
+// Rich `InboxStore` for @dwk/webmention: re-fetches each verified source and parses its mf2 into an extended `webmentions` table so mentions render as full author cards. Wire the SAME instance into the queue consumer and the edge-render reader.
 import { safeFetch } from "@dwk/webmention";
 import { mf2 } from "microformats-parser";
 
@@ -95,7 +80,9 @@ export function createRichWebmentionInbox(db, { fetchImpl = fetch } = {}) {
           fetchImpl,
           mention.source,
           { headers: { accept: "text/html" } },
-          { timeoutMs: 8000 },
+          // Cap below the package default (10s) so one slow source can't stall
+          // the queue drain, which processes a batch's messages in sequence.
+          { timeoutMs: 5000 },
         );
         if (response.ok) {
           parsed = { ...parsed, ...parseMention(await response.text(), mention) };

--- a/tests/__stubs__/dwk-webmention.ts
+++ b/tests/__stubs__/dwk-webmention.ts
@@ -1,10 +1,8 @@
-// Stub for the @dwk/webmention package, matching the real 0.1.0-beta.3 API.
-// site-entry.js composes the receiver and queue consumer at module load and
-// reads the inbox through createD1Inbox(); the vitest alias maps
-// "@dwk/webmention" to this file so the worker and the test share one module
-// instance (and one set of counters).
-//
-// The real inbox stores only { source, target, verifiedAt } — no author/content.
+// Stub for the @dwk/webmention package (real API: 0.1.0-beta.2). site-entry.js
+// composes the receiver + queue consumer at module load and backs the inbox
+// with the rich inbox (worker/webmention-inbox.js, which imports `safeFetch`
+// from here). The vitest alias maps "@dwk/webmention" to this file so the worker
+// and the test share one module instance (and one set of counters).
 export const webmentionCalls = { fetch: 0, queue: 0 };
 
 export function resetWebmentionCalls() {
@@ -21,20 +19,26 @@ export function createWebmention(_config?: unknown) {
 }
 
 // createWebmentionQueueConsumer(config) → (batch, env, ctx) => Promise<void>.
-// The queue consumer is a SEPARATE factory from the handler in the real package.
+// The queue consumer is a SEPARATE factory from the handler in the real package;
+// here it just records that the drain ran.
 export function createWebmentionQueueConsumer(_config?: unknown) {
   return async (_batch: unknown, _env: unknown, _ctx: unknown) => {
     webmentionCalls.queue++;
   };
 }
 
-// createD1Inbox(db) → InboxStore. The edge-render reads mentions via
-// inbox.list(target?). Tests drive the data through a fake `db.__list`.
-export function createD1Inbox(db: any) {
-  return {
-    list: async (target?: string) =>
-      db && typeof db.__list === "function" ? db.__list(target) : [],
-    upsert: async () => {},
-    remove: async () => {},
-  };
+// safeFetch(doFetch, url, init, options) → { response, url }. The real package
+// adds SSRF guards; the stub just delegates to the injected fetch so inbox tests
+// can serve canned source HTML through `fetchImpl`.
+export async function safeFetch(
+  doFetch: unknown,
+  url: string,
+  init?: RequestInit,
+  _options?: unknown,
+) {
+  const response =
+    typeof doFetch === "function"
+      ? await (doFetch as typeof fetch)(url, init)
+      : new Response("", { status: 200 });
+  return { response, url };
 }

--- a/tests/indieweb-dispatch.test.ts
+++ b/tests/indieweb-dispatch.test.ts
@@ -208,48 +208,62 @@ describe("Webmention edge-render gating", () => {
     delete (globalThis as any).HTMLRewriter;
   });
 
-  // The edge-render reads through createD1Inbox(env.WEBMENTION_INBOX).list(). The
-  // stub's createD1Inbox delegates to `db.__list(target)`, so this fake serves
-  // both the known-target set query (list() — no arg) and the per-target query
-  // (list(target)). The worker caches the target set per inbox object, so each
-  // test's fresh fake starts cold.
+  // The edge-render reads through the rich inbox (createRichWebmentionInbox),
+  // which runs `db.prepare(sql).all()` against the WEBMENTION_INBOX D1 binding —
+  // a no-WHERE SELECT for the known-target set and a `WHERE target = ?1` SELECT
+  // (via `bind`) per page, after an `ensureSchema` CREATE TABLE. This fake routes
+  // by SQL and serves the rows. The worker caches the target set per inbox
+  // object, so each test's fresh fake starts cold.
   function webmentionInbox(mentionsByTarget: Record<string, { source: string }[]>) {
-    const list = vi.fn(async (target?: string) => {
-      const row = (source: string, t: string) => ({
-        source,
-        target: t,
-        verifiedAt: "2026-06-01T00:00:00Z",
-      });
-      if (target === undefined) {
-        return Object.entries(mentionsByTarget).flatMap(([t, arr]) =>
-          arr.map((m) => row(m.source, t)),
-        );
-      }
-      return (mentionsByTarget[target] ?? []).map((m) => row(m.source, target));
+    const makeRow = (source: string, t: string) => ({
+      source,
+      target: t,
+      verified_at: 1717200000000,
+      author_name: null,
+      author_url: null,
+      author_photo: null,
+      content: null,
+      url: source,
+      type: "mention",
+      published: null,
     });
-    // How many times the worker ran the "all targets" set query.
-    const setQueries = () =>
-      list.mock.calls.filter((c) => c[0] === undefined).length;
-    return { db: { __list: list }, list, setQueries };
+    const allRows = () =>
+      Object.entries(mentionsByTarget).flatMap(([t, arr]) =>
+        arr.map((m) => makeRow(m.source, t)),
+      );
+    const setScan = vi.fn(async () => ({ results: allRows() }));
+    const bind = vi.fn((t: string) => ({
+      all: async () => ({
+        results: (mentionsByTarget[t] ?? []).map((m) => makeRow(m.source, t)),
+      }),
+    }));
+    const prepare = vi.fn((sql: string) => {
+      if (sql.includes("CREATE TABLE")) return { run: async () => ({}) };
+      if (sql.includes("WHERE target")) return { bind };
+      return { all: setScan }; // no-WHERE SELECT — the known-target set scan
+    });
+    // How many times the worker ran the "all targets" set scan.
+    const setQueries = () => setScan.mock.calls.length;
+    return { db: { prepare }, prepare, bind, setQueries };
   }
 
   it("queries the inbox and rewrites a note/blog page that has stored mentions", async () => {
     for (const path of ["/notes/abc/", "/blog/my-post/"]) {
       rewriteUsed = false;
       const target = `https://example.com${path}`;
-      const { db, list } = webmentionInbox({
+      const { db, bind } = webmentionInbox({
         [target]: [{ source: "https://alice.example/reply/1" }],
       });
       const env = makeEnv({ WEBMENTION_INBOX: db });
       await worker.fetch(req(path, { accept: "text/html" }), env, makeCtx());
 
-      expect(list, path).toHaveBeenCalledWith(target);
+      expect(bind, path).toHaveBeenCalledWith(target);
       expect(rewriteUsed, path).toBe(true);
     }
   });
 
   it("does NOT query mentions or rewrite when the page has no stored mentions", async () => {
-    const { db, list } = webmentionInbox({
+    const { db, bind } = webmentionInbox({
       "https://example.com/notes/other/": [{ source: "https://alice.example" }],
     });
     const env = makeEnv({ WEBMENTION_INBOX: db });
@@ -260,7 +274,7 @@ describe("Webmention edge-render gating", () => {
     );
 
     // The page isn't in the known-target set, so no per-target query runs.
-    expect(list).not.toHaveBeenCalledWith("https://example.com/notes/abc/");
+    expect(bind).not.toHaveBeenCalled();
     expect(rewriteUsed).toBe(false);
     // Response passes through untouched.
     expect(res.headers.get("x-asset")).toBe("1");
@@ -276,24 +290,24 @@ describe("Webmention edge-render gating", () => {
 
   it("does NOT query for non-target paths (home, about)", async () => {
     for (const path of ["/", "/about/", "/contact/"]) {
-      const { db, list } = webmentionInbox({
+      const { db, prepare } = webmentionInbox({
         "https://example.com/notes/abc/": [{ source: "https://bob.example" }],
       });
       const env = makeEnv({ WEBMENTION_INBOX: db });
       await worker.fetch(req(path, { accept: "text/html" }), env, makeCtx());
-      expect(list, path).not.toHaveBeenCalled();
+      expect(prepare, path).not.toHaveBeenCalled();
       expect(rewriteUsed, path).toBe(false);
     }
   });
 
   it("does NOT query the collection index — only permalinks are targets", async () => {
     for (const path of ["/notes", "/notes/", "/blog", "/blog/"]) {
-      const { db, list } = webmentionInbox({
+      const { db, prepare } = webmentionInbox({
         "https://example.com/notes/abc/": [{ source: "https://bob.example" }],
       });
       const env = makeEnv({ WEBMENTION_INBOX: db });
       await worker.fetch(req(path, { accept: "text/html" }), env, makeCtx());
-      expect(list, path).not.toHaveBeenCalled();
+      expect(prepare, path).not.toHaveBeenCalled();
     }
   });
 
@@ -309,7 +323,7 @@ describe("Webmention edge-render gating", () => {
   });
 
   it("does NOT query non-HTML responses even on a target path", async () => {
-    const { db, list } = webmentionInbox({
+    const { db, prepare } = webmentionInbox({
       "https://example.com/notes/abc/": [{ source: "https://bob.example" }],
     });
     const env = makeEnv({
@@ -319,17 +333,17 @@ describe("Webmention edge-render gating", () => {
       },
     });
     await worker.fetch(req("/notes/abc/", { accept: "text/html" }), env, makeCtx());
-    expect(list).not.toHaveBeenCalled();
+    expect(prepare).not.toHaveBeenCalled();
     expect(rewriteUsed).toBe(false);
   });
 
   it("does NOT query for non-HTML requests (no Accept: text/html)", async () => {
-    const { db, list } = webmentionInbox({
+    const { db, prepare } = webmentionInbox({
       "https://example.com/notes/abc/": [{ source: "https://bob.example" }],
     });
     const env = makeEnv({ WEBMENTION_INBOX: db });
     await worker.fetch(req("/notes/abc/"), env, makeCtx());
-    expect(list).not.toHaveBeenCalled();
+    expect(prepare).not.toHaveBeenCalled();
     expect(rewriteUsed).toBe(false);
   });
 });

--- a/tests/webmention-inbox.test.ts
+++ b/tests/webmention-inbox.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Rich Webmention inbox (worker/webmention-inbox.js) — the drop-in InboxStore
+ * that upgrades @dwk/webmention's source/target-only default to full mention
+ * cards (Anglesite/anglesite#363, rich author cards). Covers mf2 extraction
+ * against the real microformats-parser, the store→fetch→parse→upsert path, and
+ * schema-creation resilience.
+ *
+ * @dwk/webmention is aliased to a stub whose `safeFetch` delegates to the
+ * injected `fetchImpl`, so a test can serve canned source HTML.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  parseMention,
+  createRichWebmentionInbox,
+} from "../template/worker/webmention-inbox.js";
+
+const TARGET = "https://example.com/notes/abc/";
+
+const REPLY_HTML = `
+  <div class="h-entry">
+    <div class="p-author h-card">
+      <a class="p-name u-url" href="https://alice.example/">Alice</a>
+      <img class="u-photo" src="https://alice.example/me.jpg" alt="">
+    </div>
+    <a class="u-in-reply-to" href="${TARGET}">in reply to</a>
+    <div class="e-content">Great post!</div>
+    <time class="dt-published" datetime="2026-06-01T00:00:00Z">Jun 1</time>
+    <a class="u-url" href="https://alice.example/reply/1">permalink</a>
+  </div>`;
+
+describe("parseMention() — microformats2 extraction", () => {
+  it("extracts a reply with author h-card, content, permalink, and published", () => {
+    const m = parseMention(REPLY_HTML, {
+      source: "https://alice.example/reply/1",
+      target: TARGET,
+    });
+    expect(m.type).toBe("reply");
+    expect(m.author_name).toBe("Alice");
+    expect(m.author_url).toBe("https://alice.example/");
+    expect(m.author_photo).toBe("https://alice.example/me.jpg");
+    expect(m.content).toBe("Great post!");
+    expect(m.published).toBe("2026-06-01T00:00:00Z");
+    expect(m.url).toBe("https://alice.example/reply/1");
+  });
+
+  it("classifies like-of and repost-of", () => {
+    const like = parseMention(
+      `<div class="h-entry"><a class="u-like-of" href="${TARGET}">♥</a></div>`,
+      { source: "https://x.example/l", target: TARGET },
+    );
+    expect(like.type).toBe("like");
+    const repost = parseMention(
+      `<div class="h-entry"><a class="u-repost-of" href="${TARGET}">RT</a></div>`,
+      { source: "https://x.example/r", target: TARGET },
+    );
+    expect(repost.type).toBe("repost");
+  });
+
+  it("defaults to 'mention' and falls back to the source URL when unparseable", () => {
+    const m = parseMention("", { source: "https://x.example/p", target: TARGET });
+    expect(m.type).toBe("mention");
+    expect(m.url).toBe("https://x.example/p");
+    expect(m.author_name).toBeUndefined();
+  });
+});
+
+describe("createRichWebmentionInbox()", () => {
+  // Captures the bound args of the INSERT…UPSERT; SELECT/DELETE are no-ops.
+  function captureDb({ failFirstCreate = false } = {}) {
+    let createCalls = 0;
+    const upserts: unknown[][] = [];
+    const prepare = vi.fn((sql: string) => {
+      if (sql.includes("CREATE TABLE")) {
+        return {
+          run: async () => {
+            createCalls++;
+            if (failFirstCreate && createCalls === 1) throw new Error("transient D1");
+            return {};
+          },
+        };
+      }
+      if (sql.startsWith("INSERT")) {
+        return {
+          bind: (...args: unknown[]) => {
+            upserts.push(args);
+            return { run: async () => ({}) };
+          },
+        };
+      }
+      return { bind: () => ({ run: async () => ({}) }) };
+    });
+    return { db: { prepare }, upserts, createCalls: () => createCalls };
+  }
+
+  it("fetches the source, parses mf2, and upserts a rich row", async () => {
+    const { db, upserts } = captureDb();
+    const fetchImpl = vi.fn(async () =>
+      new Response(REPLY_HTML, { status: 200, headers: { "content-type": "text/html" } }),
+    );
+    const inbox = createRichWebmentionInbox(db as any, { fetchImpl });
+
+    await inbox.store({
+      source: "https://alice.example/reply/1",
+      target: TARGET,
+      verifiedAt: 1717200000000,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    // bind order: source, target, author_name, author_url, author_photo,
+    // content, url, type, published, verified_at.
+    const row = upserts[0];
+    expect(row[0]).toBe("https://alice.example/reply/1");
+    expect(row[1]).toBe(TARGET);
+    expect(row[2]).toBe("Alice");
+    expect(row[3]).toBe("https://alice.example/");
+    expect(row[4]).toBe("https://alice.example/me.jpg");
+    expect(row[5]).toBe("Great post!");
+    expect(row[7]).toBe("reply");
+    expect(row[9]).toBe(1717200000000);
+  });
+
+  it("degrades to a source/target row when the source fetch fails", async () => {
+    const { db, upserts } = captureDb();
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network");
+    });
+    const inbox = createRichWebmentionInbox(db as any, { fetchImpl });
+
+    await inbox.store({ source: "https://x.example/p", target: TARGET, verifiedAt: 1 });
+
+    const row = upserts[0];
+    expect(row[2]).toBeNull(); // author_name
+    expect(row[6]).toBe("https://x.example/p"); // url falls back to source
+    expect(row[7]).toBe("mention");
+  });
+
+  it("retries CREATE TABLE after a transient failure instead of wedging", async () => {
+    const { db, createCalls } = captureDb({ failFirstCreate: true });
+    const fetchImpl = vi.fn(async () => new Response("", { status: 200 }));
+    const inbox = createRichWebmentionInbox(db as any, { fetchImpl });
+    const mention = { source: "https://x.example/a", target: TARGET, verifiedAt: 1 };
+
+    await expect(inbox.store(mention)).rejects.toThrow("transient D1");
+    await expect(inbox.store(mention)).resolves.toBeUndefined();
+    expect(createCalls()).toBe(2);
+  });
+
+  it("list(target) maps D1 rows to rich mention objects", async () => {
+    const db = {
+      prepare: (sql: string) => {
+        if (sql.includes("CREATE TABLE")) return { run: async () => ({}) };
+        return {
+          bind: () => ({
+            all: async () => ({
+              results: [
+                {
+                  source: "https://alice.example/reply/1",
+                  target: TARGET,
+                  author_name: "Alice",
+                  author_url: "https://alice.example/",
+                  author_photo: null,
+                  content: "Hi",
+                  url: "https://alice.example/reply/1",
+                  type: "reply",
+                  published: "2026-06-01T00:00:00Z",
+                  verified_at: 1717200000000,
+                },
+              ],
+            }),
+          }),
+        };
+      },
+    };
+    const inbox = createRichWebmentionInbox(db as any);
+    const rows = await inbox.list(TARGET);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      author_name: "Alice",
+      type: "reply",
+      verifiedAt: 1717200000000,
+      content: "Hi",
+    });
+  });
+});

--- a/tests/webmention-inbox.test.ts
+++ b/tests/webmention-inbox.test.ts
@@ -145,6 +145,28 @@ describe("createRichWebmentionInbox()", () => {
     expect(createCalls()).toBe(2);
   });
 
+  it("remove() deletes by (source, target) in the right bind order", async () => {
+    const calls: { sql: string; args: unknown[] }[] = [];
+    const db = {
+      prepare: (sql: string) => {
+        if (sql.includes("CREATE TABLE")) return { run: async () => ({}) };
+        return {
+          bind: (...args: unknown[]) => {
+            calls.push({ sql, args });
+            return { run: async () => ({}) };
+          },
+        };
+      },
+    };
+    const inbox = createRichWebmentionInbox(db as any);
+    await inbox.remove("https://x.example/s", "https://example.com/notes/abc/");
+    expect(calls[0].sql).toContain("DELETE FROM webmentions");
+    expect(calls[0].args).toEqual([
+      "https://x.example/s",
+      "https://example.com/notes/abc/",
+    ]);
+  });
+
   it("list(target) maps D1 rows to rich mention objects", async () => {
     const db = {
       prepare: (sql: string) => {

--- a/tests/webmention-render-rich.test.ts
+++ b/tests/webmention-render-rich.test.ts
@@ -22,6 +22,8 @@ describe("renderMention() — rich author cards", () => {
     });
     expect(html).toContain('class="h-cite webmention-reply"');
     expect(html).toContain('src="https://alice.example/me.jpg"');
+    // The avatar origin is attacker-controlled — don't leak the visitor's page.
+    expect(html).toContain('referrerpolicy="no-referrer"');
     expect(html).toContain('href="https://alice.example/"');
     expect(html).toContain(">Alice<");
     expect(html).toContain('<div class="p-content">Great post!</div>');

--- a/tests/webmention-render-rich.test.ts
+++ b/tests/webmention-render-rich.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Rich Webmention render (Anglesite/anglesite#363, rich author cards).
+ *
+ * renderMention() now builds an author card (photo, name, content, permalink),
+ * not just the source host. This covers the rich output and that EACH external
+ * URL (author_url, author_photo, permalink/source) is independently scheme-
+ * checked — escapeHtml alone wouldn't block javascript:/data: in an href/src.
+ * Source-only safety invariants live in indieweb-render-safety.test.ts.
+ */
+import { describe, it, expect } from "vitest";
+import { renderMention } from "../template/worker/site-entry.js";
+
+describe("renderMention() — rich author cards", () => {
+  it("renders photo, author link, content, permalink, and a type class", () => {
+    const html = renderMention({
+      author_name: "Alice",
+      author_url: "https://alice.example/",
+      author_photo: "https://alice.example/me.jpg",
+      content: "Great post!",
+      url: "https://alice.example/reply/1",
+      type: "reply",
+    });
+    expect(html).toContain('class="h-cite webmention-reply"');
+    expect(html).toContain('src="https://alice.example/me.jpg"');
+    expect(html).toContain('href="https://alice.example/"');
+    expect(html).toContain(">Alice<");
+    expect(html).toContain('<div class="p-content">Great post!</div>');
+    expect(html).toContain('href="https://alice.example/reply/1"');
+    // Every rendered anchor carries the untrusted-link hardening rel.
+    expect(html.match(/rel="nofollow ugc noopener noreferrer"/g)?.length).toBe(2);
+  });
+
+  it("drops a javascript: author_url to a plain span (no anchor, no scheme)", () => {
+    const html = renderMention({
+      author_name: "Mallory",
+      author_url: "javascript:alert(1)",
+      url: "https://m.example/p",
+    });
+    expect(html).not.toContain("javascript:");
+    expect(html).toContain('<span class="p-author">Mallory</span>');
+  });
+
+  it("drops a data: author_photo (no img element)", () => {
+    const html = renderMention({
+      author_name: "Mallory",
+      author_photo: "data:text/html,<script>alert(1)</script>",
+      url: "https://m.example/p",
+    });
+    expect(html).not.toContain("data:");
+    expect(html).not.toContain("<img");
+  });
+
+  it("clamps an unknown type to webmention-mention", () => {
+    const html = renderMention({ url: "https://x.example/p", type: "../evil" });
+    expect(html).toContain('class="h-cite webmention-mention"');
+    expect(html).not.toContain("evil");
+  });
+
+  it("drops a mention with no usable http(s) permalink/source", () => {
+    expect(renderMention({ source: "javascript:alert(1)" })).toBe("");
+    expect(renderMention({ url: "data:text/html,x" })).toBe("");
+  });
+});


### PR DESCRIPTION
Builds on `main`'s Webmention realignment (#370) to render **full mention cards** — sender name, photo, content snippet, and reply/like/repost type — instead of just the source host. This is the rich-cards delta from the now-closed #372, reimplemented on main's architecture.

## Why
`@dwk/webmention`'s default `createD1Inbox` persists only `(source, target, verified_at)`, so #370's edge-render can show no more than the mentioning host. Rich cards need the source's author h-card and content, which means parsing the source's microformats2 at verification time.

## What changed
- **New `worker/webmention-inbox.js`** — `createRichWebmentionInbox(db)` is a drop-in `InboxStore` (`store`/`remove`/`list`, the beta.2 contract). On `store` it re-fetches the verified source (SSRF-guarded via the package's `safeFetch`) and parses its mf2 (`microformats-parser`) into an extended `webmentions` table: author name/url/photo, content, permalink, type.
- **`site-entry.js`** — `webmentionFor(env)` builds the rich inbox and passes it to **both** the queue consumer (so verification writes the rich row) and the edge-render reader. `renderMention` becomes a full card (photo, author link, content, permalink, `webmention-<type>` class). Every external URL is still `safeUrl`-checked; a mention with no usable http(s) URL is dropped — the XSS contract from #369 is preserved (main's `indieweb-render-safety.test.ts` passes unchanged).
- **Resilience** — `ensureSchema` clears its cached promise on failure (transient first-write D1 error retries instead of wedging the inbox); chronological ordering is NULL-safe via `COALESCE(published, datetime(verified_at/1000,'unixepoch'))`.
- **Skill** — installs `microformats-parser` alongside `@dwk/webmention` (filling a missing install step), documents the rich schema, and gives the drop-table migration from the minimal install.

## Tests
- `tests/webmention-inbox.test.ts` — real mf2 parse (reply/like/repost/fallback), `store`→fetch→parse→upsert, fetch-failure degrade, schema-retry, rich `list`.
- `tests/webmention-render-rich.test.ts` — author-card output + per-field URL safety (`javascript:`/`data:` dropped) + type clamp + no-URL drop.
- `tests/indieweb-dispatch.test.ts` — edge-render mock moved from the stub inbox to a `prepare()`-based D1 fake (the rich inbox reads via `db.prepare().all()`).
- Full suite: **2693 pass**; only the pre-existing `optimize-images-packaging` e2e fails (sharp/env, confirmed failing on a clean tree).

## Note
`site-entry.js` (on main, unmodified) imports `readCookie` from `owner-auth.js` *and* declares it locally — esbuild tolerates it by shadowing, but it's a latent duplicate binding (the import is dead). Flagging since I noticed it; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)