### PR TITLE
fix(pre-deploy): stop false positives in phone PII + third-party script scans (#362, #365)

### DIFF
--- a/scripts/pre-deploy-check.sh
+++ b/scripts/pre-deploy-check.sh
@@ -56,17 +56,35 @@ fi
 # Trailing: not followed by a digit or '/' (a trailing '.' is allowed so a
 # number that ends a sentence still matches). POSIX ERE has no lookaround, so
 # the boundaries are matched as literal context chars.
-PHONE_HITS=$(grep -rE '(^|[^0-9/.])\(?[0-9]{3}\)?[-.[:space:]]?[0-9]{3}[-.[:space:]]?[0-9]{4}([^0-9/]|$)' "$DIST/" --include='*.html' 2>/dev/null || true)
+# Extract each phone occurrence (-o keeps the boundary context chars, which the
+# digit normalization below strips). Line-based -r output can't be normalized
+# per-number, so the allowlist comparison needs the individual matches.
+PHONE_MATCHES=$(grep -rohE '(^|[^0-9/.])\(?[0-9]{3}\)?[-.[:space:]]?[0-9]{3}[-.[:space:]]?[0-9]{4}([^0-9/]|$)' "$DIST/" --include='*.html' 2>/dev/null || true)
 
-# Filter out allowlisted phone numbers (normalize to digits-only for comparison)
-if [[ -n "$PHONE_HITS" && -n "$PHONE_ALLOW" ]]; then
+# Filter out allowlisted phone numbers. Normalize BOTH the allowlist entry and
+# each hit to their last 10 digits before comparing, so formatting differences
+# (dashes vs dots, a 1- country-code prefix) never defeat the allowlist. The
+# previous digits-only grep -v matched the normalized allowlist string against
+# the still-formatted hit and so never suppressed anything (issues #362, #365).
+if [[ -n "$PHONE_MATCHES" && -n "$PHONE_ALLOW" ]]; then
+  ALLOWED_NORM=""
   IFS=',' read -ra ALLOWED_PHONES <<< "$PHONE_ALLOW"
   for phone in "${ALLOWED_PHONES[@]}"; do
-    digits=$(echo "$phone" | tr -cd '0-9')
-    if [[ -n "$digits" ]]; then
-      PHONE_HITS=$(echo "$PHONE_HITS" | grep -v "$digits" || true)
-    fi
+    d=$(printf '%s' "$phone" | tr -cd '0-9')
+    d=${d: -10}
+    [[ -n "$d" ]] && ALLOWED_NORM+="${d}"$'\n'
   done
+  PHONE_HITS=""
+  while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    hd=$(printf '%s' "$hit" | tr -cd '0-9')
+    hd=${hd: -10}
+    if ! printf '%s' "$ALLOWED_NORM" | grep -qxF "$hd"; then
+      PHONE_HITS+="${hit}"$'\n'
+    fi
+  done <<< "$PHONE_MATCHES"
+else
+  PHONE_HITS="$PHONE_MATCHES"
 fi
 
 if [[ -n "$PHONE_HITS" ]]; then

--- a/scripts/pre-deploy-check.sh
+++ b/scripts/pre-deploy-check.sh
@@ -49,7 +49,14 @@ if [[ -n "$EMAIL_HITS" ]]; then
   REASONS+=("Possible email address found in built HTML")
 fi
 
-PHONE_HITS=$(grep -rE '\(?\d{3}\)?[-.[[:space:]]]?\d{3}[-.[[:space:]]]?\d{4}' "$DIST/" --include='*.html' 2>/dev/null || true)
+# Boundary guards keep the 3-3-4 shape from matching digit runs embedded in
+# longer tokens — DOIs in citation URLs, Wayback timestamps, decimal
+# coordinates (issues #362, #365). Leading: not preceded by a digit, '/', or
+# '.' (a preceding '-' is allowed so a '1-800-…' country code still matches).
+# Trailing: not followed by a digit or '/' (a trailing '.' is allowed so a
+# number that ends a sentence still matches). POSIX ERE has no lookaround, so
+# the boundaries are matched as literal context chars.
+PHONE_HITS=$(grep -rE '(^|[^0-9/.])\(?[0-9]{3}\)?[-.[:space:]]?[0-9]{3}[-.[:space:]]?[0-9]{4}([^0-9/]|$)' "$DIST/" --include='*.html' 2>/dev/null || true)
 
 # Filter out allowlisted phone numbers (normalize to digits-only for comparison)
 if [[ -n "$PHONE_HITS" && -n "$PHONE_ALLOW" ]]; then
@@ -93,10 +100,16 @@ fi
 # 3. Third-party scripts — unauthorized external JS (allowlist driven by .site-config)
 check_third_party_scripts() {
   local result
-  result=$(grep -r '<script[^>]*src=' "$DIST/" --include='*.html' 2>/dev/null || true)
+  # Extract individual <script …src=…> tags (the -o keeps minified one-line
+  # HTML from collapsing the whole document into a single match that later
+  # grep -v exclusions could be defeated by), then keep only EXTERNAL srcs:
+  # scheme-qualified (https://) or protocol-relative (//). Root-relative (/…)
+  # and relative srcs are first-party by definition (issues #362, #365).
+  result=$(grep -rohE '<script[^>]*src=[^>]*>' "$DIST/" --include='*.html' 2>/dev/null \
+    | grep -E "src=[\"']?(https?:)?//" || true)
 
-  # Always exclude Cloudflare analytics and Astro bundles
-  result=$(echo "$result" | grep -v 'cloudflareinsights' | grep -v '_astro' || true)
+  # Always exclude Cloudflare analytics (external, but first-party-approved)
+  result=$(echo "$result" | grep -v 'cloudflareinsights' || true)
 
   # Add provider-specific exclusions based on .site-config
   if [[ -f ".site-config" ]]; then

--- a/template/scripts/pre-deploy-check.ts
+++ b/template/scripts/pre-deploy-check.ts
@@ -117,7 +117,6 @@ export const indiewebWorkerRoutes: Readonly<Record<string, readonly string[]>> =
 
 /** @deprecated Use airtablePatPattern or openaiKeyPattern. Kept for backwards-compatible imports. */
 export const tokenPattern = new RegExp(`${airtablePatPattern.source}|${openaiKeyPattern.source}`);
-export const scriptSrcPattern = /<script[^>]*src=/gi;
 
 /**
  * Allowed third-party script domains for the pre-deploy scan.

--- a/template/scripts/pre-deploy-check.ts
+++ b/template/scripts/pre-deploy-check.ts
@@ -54,7 +54,23 @@ export function isReservedExampleEmail(email: string): boolean {
   if (reservedExampleDomains.includes(domain)) return true;
   return reservedExampleTlds.some(tld => domain.endsWith(tld));
 }
-export const phonePattern = /\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}/g;
+/**
+ * North-American phone numbers (3-3-4 with optional separators / parens).
+ *
+ * Boundary guards keep the unanchored 3-3-4 shape from matching digit runs
+ * embedded in longer tokens — the false positives that were blocking real
+ * deploys (issues #362, #365):
+ *   - a Nature DOI in a citation URL (`…s41598-025-97652-6` → `598-025-9765`)
+ *   - a Wayback Machine timestamp (`/web/20120120031959/` → `2012012003`)
+ *   - a decimal geo-coordinate (`37.3268981241` → `3268981241`)
+ *
+ * Leading: reject when preceded by a digit or `/` (URL path / longer number),
+ * or by a digit-then-dot (the fractional part of a decimal). A preceding `-`
+ * is allowed so a country-code prefix (`1-800-662-4357`) is still detected.
+ * Trailing: reject when followed by a digit or `/`, or by a dot-then-digit
+ * (a decimal) — while still allowing a sentence-ending period after the number.
+ */
+export const phonePattern = /(?<![\d/])(?<!\d\.)\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}(?![\d/])(?!\.\d)/g;
 /**
  * Airtable Personal Access Token: `pat` + 14 alphanumerics + `.` + 32+ alphanumerics.
  * The literal dot and second segment are mandatory in real PATs and eliminate
@@ -211,14 +227,22 @@ const tokenRemediations: Record<TokenKind, string> = {
 
 export function scanScripts(content: string, scriptAllowlist?: string[]): string[] {
   const allowed = scriptAllowlist ?? allowedScripts;
-  scriptSrcPattern.lastIndex = 0;
   const results: string[] = [];
-  const matches = content.match(scriptSrcPattern) || [];
-  for (const match of matches) {
-    const lineIdx = content.indexOf(match);
-    const line = content.slice(lineIdx, content.indexOf(">", lineIdx) + 1);
-    if (!allowed.some(a => line.includes(a))) {
-      results.push(line);
+  // Capture each <script …> tag along with its src value. Iterating with
+  // exec (rather than indexOf on a prefix match) handles repeated and minified
+  // one-line tags correctly.
+  const re = /<script[^>]*\bsrc\s*=\s*["']?([^"'\s>]+)[^>]*>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    const tag = m[0];
+    const src = m[1] ?? "";
+    // Only EXTERNAL scripts can be third-party. A "third-party script" gate
+    // flags external origins only — scheme-qualified (https://) or
+    // protocol-relative (//). Root-relative (/…), relative, and same-document
+    // srcs are first-party by definition (issues #362, #365).
+    if (!/^(?:https?:)?\/\//i.test(src)) continue;
+    if (!allowed.some(a => tag.includes(a))) {
+      results.push(tag);
     }
   }
   return results;

--- a/tests/pre-deploy-check.test.ts
+++ b/tests/pre-deploy-check.test.ts
@@ -48,6 +48,16 @@ describe("pre-deploy-check.sh safety", () => {
       expect(src).toContain(route);
     }
   });
+
+  it("boundary-guards the phone scan so URL/DOI/coordinate digit runs don't match (issues #362, #365)", () => {
+    // Leading/trailing context classes emulate the .ts lookarounds in POSIX ERE.
+    expect(src).toContain("(^|[^0-9/.])");
+    expect(src).toContain("([^0-9/]|$)");
+  });
+
+  it("only flags external (third-party) script srcs, not same-origin ones (issues #362, #365)", () => {
+    expect(src).toContain('src=[\\"\']?(https?:)?//');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -182,6 +192,29 @@ describe("scanPhones", () => {
   it("handles multiple allowlisted numbers", () => {
     const content = "Lines: 800-662-4357, 800-273-8255, 555-000-1234";
     expect(scanPhones(content, ["800-662-4357", "800-273-8255"])).toEqual(["555-000-1234"]);
+  });
+
+  // Boundary-guard regressions (issues #362, #365): digit runs embedded in
+  // longer tokens must not be mistaken for phone numbers.
+  it("ignores a Nature DOI / article id in a citation URL", () => {
+    expect(scanPhones("See https://www.nature.com/articles/s41598-025-97652-6 for details.")).toEqual([]);
+  });
+
+  it("ignores a Wayback Machine URL timestamp", () => {
+    expect(scanPhones('<a href="https://web.archive.org/web/20120120031959/http://example.com/">snapshot</a>')).toEqual([]);
+  });
+
+  it("ignores a decimal geo-coordinate", () => {
+    expect(scanPhones("The marker sits at 37.3268981241 degrees.")).toEqual([]);
+  });
+
+  it("still detects a phone number that ends a sentence", () => {
+    expect(scanPhones("Reach the front desk at 555-123-4567.")).toEqual(["555-123-4567"]);
+  });
+
+  it("still detects a number with a country-code prefix", () => {
+    // The leading '1-' must not suppress the match.
+    expect(scanPhones("Call 1-800-662-4357 anytime.")).toEqual(["800-662-4357"]);
   });
 });
 
@@ -349,6 +382,32 @@ describe("scanScripts", () => {
 
   it("returns empty array for content with no scripts", () => {
     expect(scanScripts("<p>No scripts here</p>")).toEqual([]);
+  });
+
+  // First-party scripts are not third-party (issues #362, #365).
+  it("allows a site's own root-relative script", () => {
+    const html = '<script src="/js/footnote-popup.js"></script>';
+    expect(scanScripts(html)).toEqual([]);
+  });
+
+  it("allows a relative script path", () => {
+    const html = '<script src="js/footnote-popup.js"></script>';
+    expect(scanScripts(html)).toEqual([]);
+  });
+
+  it("flags protocol-relative external scripts", () => {
+    const html = '<script src="//evil.example.com/x.js"></script>';
+    const result = scanScripts(html);
+    expect(result.length).toBe(1);
+    expect(result[0]).toContain("evil.example.com");
+  });
+
+  it("flags only the external script when first- and third-party scripts coexist", () => {
+    const html =
+      '<script src="/js/app.js"></script><script src="https://evil.example.com/x.js"></script>';
+    const result = scanScripts(html);
+    expect(result.length).toBe(1);
+    expect(result[0]).toContain("evil.example.com");
   });
 });
 

--- a/tests/pre-deploy-check.test.ts
+++ b/tests/pre-deploy-check.test.ts
@@ -58,6 +58,13 @@ describe("pre-deploy-check.sh safety", () => {
   it("only flags external (third-party) script srcs, not same-origin ones (issues #362, #365)", () => {
     expect(src).toContain('src=[\\"\']?(https?:)?//');
   });
+
+  it("normalizes both sides of the phone allowlist comparison, not just the allowlist entry (issues #362, #365)", () => {
+    // The old digits-only `grep -v "$digits"` compared a normalized allowlist
+    // string against a still-formatted hit and never suppressed anything.
+    expect(src).not.toContain('grep -v "$digits"');
+    expect(src).toContain("grep -qxF");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #362 and #365 — the pre-deploy gate was blocking legitimate deploys with two false positives, and the `.sh` hook (`scripts/pre-deploy-check.sh`) had drifted cruder than the `.ts` scanner (`template/scripts/pre-deploy-check.ts`). Both are now aligned and fixed.

## Bug 1 — phone PII scan matched digit runs inside URLs / IDs / coordinates

The unanchored 3-3-4 pattern matched any 10-digit slice of a longer token. Real content that blocked deploys on `pulletsforever.com`:

| Content | What it is | Matched slice |
|---|---|---|
| `…/articles/s41598-025-97652-6` | Nature DOI in a citation URL | `598-025-9765` |
| `/web/20120120031959/` | Wayback Machine timestamp | `2012012003` |
| `37.3268981241` | decimal geo-coordinate | `3268981241` |

**Fix:** boundary guards that reject a run preceded by a digit, `/`, or a decimal point, and followed by a digit or `/` — while still matching:
- a number that **ends a sentence** (`…555-123-4567.`)
- a number with a **`1-` country-code prefix** (`1-800-662-4357`)

The `.ts` scanner uses lookarounds; the `.sh` hook emulates them with POSIX ERE context classes (no `grep -P`, so it stays cross-platform / works on BSD grep).

## Bug 2 — first-party scripts flagged as third-party

The script scan flagged any `<script src>` not on the allowlist, including a site's own root-relative scripts (`/js/footnote-popup.js`). A third-party gate should only flag **external** origins.

**Fix:** only scheme-qualified (`https://`) or protocol-relative (`//`) srcs are treated as third-party; root-relative (`/…`) and relative srcs are first-party by definition. The `.sh` hook now extracts individual `<script>` tags with `grep -o` so minified one-line HTML can't defeat the exclusion filter (a secondary issue noted in #365).

## Tests

- Regression tests for all three phone false positives, plus the country-code and sentence-ending cases that must keep matching.
- Tests for first-party root-relative/relative scripts (allowed) and protocol-relative external scripts (flagged), including a mixed first+third-party case.
- Light assertions on the `.sh` source so the boundary guards and external-only filter can't silently regress.
- Verified the live `.sh` hook end-to-end: the three false positives now pass; real PII (incl. country code) and external scripts (incl. `//`) are still blocked.

`npx vitest run` — the only failures are 2 pre-existing, unrelated failures in `test/apply-edit-dispatcher.test.js` (confirmed present on a clean tree); all 103 pre-deploy scan tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKuH4bGQjPJ5pZJbd7USJS)_