### PR TITLE
refactor(csp): decouple central CSP builder from optional provider modules (#364)

### DIFF
--- a/skills/booking/SKILL.md
+++ b/skills/booking/SKILL.md
@@ -153,7 +153,7 @@ For floating style (site-wide), add the structured data to the root layout or ho
 
 ### Content Security Policy
 
-Read `public/_headers` and update the CSP to allow the provider's domains. Use `buildBookingCSP()` from `${CLAUDE_PLUGIN_ROOT}/template/scripts/booking.ts` to get the required domains:
+Read `public/_headers` and update the CSP to allow the provider's domains. Use `buildBookingCSP()` from `${CLAUDE_PLUGIN_ROOT}/template/scripts/csp.ts` to get the required domains:
 
 **Cal.com:** Add `app.cal.com` to `script-src`, `style-src`, and `frame-src`.
 

--- a/template/scripts/booking.ts
+++ b/template/scripts/booking.ts
@@ -194,34 +194,3 @@ export function buildCalendlyEmbed(
   // button → popup
   return `${cssLink}\n<button class="booking-button" onclick="Calendly.initPopupWidget({url:'${url}'});return false;">${safeButtonText}</button>\n${jsScript}`;
 }
-
-// ---------------------------------------------------------------------------
-// CSP directives
-// ---------------------------------------------------------------------------
-
-/** CSP directives needed for a booking provider */
-export interface BookingCSP {
-  "script-src": string[];
-  "style-src": string[];
-  "frame-src": string[];
-}
-
-/**
- * Build CSP directives required for a booking provider.
- * @param provider - "cal" or "calendly"
- * @returns Object with arrays of domains to add to each CSP directive
- */
-export function buildBookingCSP(provider: BookingProvider): BookingCSP {
-  if (provider === "cal") {
-    return {
-      "script-src": ["app.cal.com"],
-      "style-src": ["app.cal.com"],
-      "frame-src": ["app.cal.com"],
-    };
-  }
-  return {
-    "script-src": ["assets.calendly.com"],
-    "style-src": ["assets.calendly.com"],
-    "frame-src": ["calendly.com"],
-  };
-}

--- a/template/scripts/csp.ts
+++ b/template/scripts/csp.ts
@@ -8,16 +8,19 @@
  * @module
  */
 
-import { buildSnipcartCSP } from "./snipcart.js";
-import { buildShopifyCSP } from "./shopify-buy-button.js";
-import { buildPaddleCSP } from "./paddle.js";
-import { buildLemonSqueezyCSP } from "./lemon-squeezy.js";
-import { buildBookingCSP, type BookingProvider } from "./booking.js";
 import { readConfigFromString } from "./config.js";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
+
+/**
+ * Supported booking providers. Defined here (rather than imported from
+ * `booking.ts`) so this central CSP module has no runtime or type dependency
+ * on the optional provider helper modules — content-only sites can delete
+ * `booking.ts`, `snipcart.ts`, etc. without having to edit this file (#364).
+ */
+export type BookingProvider = "cal" | "calendly";
 
 /** Parsed provider configuration from .site-config */
 export interface SiteProviders {
@@ -77,6 +80,79 @@ export function buildPolarCSP(): CSPDirectives {
     "script-src": ["cdn.polar.sh"],
     "connect-src": ["api.polar.sh"],
     "frame-src": ["buy.polar.sh"],
+  };
+}
+
+/** CSP directives for Snipcart checkout */
+export function buildSnipcartCSP(): CSPDirectives {
+  return {
+    "script-src": ["cdn.snipcart.com"],
+    "style-src": ["cdn.snipcart.com"],
+    "connect-src": ["app.snipcart.com"],
+    "frame-src": ["app.snipcart.com"],
+  };
+}
+
+/**
+ * CSP directives for the Shopify Buy Button SDK.
+ *
+ * The Buy Button SDK loads from sdks.shopifycdn.com, fetches product data
+ * from the store's myshopify.com domain via the Storefront API, loads images
+ * from cdn.shopify.com, and sends analytics to monorail-edge.shopifysvc.com.
+ */
+export function buildShopifyCSP(): CSPDirectives {
+  return {
+    "script-src": ["cdn.shopify.com", "sdks.shopifycdn.com"],
+    "style-src": ["cdn.shopify.com"],
+    "img-src": ["cdn.shopify.com"],
+    "connect-src": ["*.myshopify.com", "monorail-edge.shopifysvc.com"],
+  };
+}
+
+/**
+ * CSP directives for Paddle.js.
+ *
+ * Paddle.js loads from cdn.paddle.com (production) or sandbox-cdn.paddle.com
+ * (sandbox); the checkout overlay uses checkout.paddle.com /
+ * sandbox-checkout.paddle.com; telemetry goes to log.paddle.com. Both sandbox
+ * and production domains are included so sites work in test mode without CSP
+ * changes.
+ */
+export function buildPaddleCSP(): CSPDirectives {
+  return {
+    "script-src": ["cdn.paddle.com", "sandbox-cdn.paddle.com"],
+    "connect-src": ["log.paddle.com"],
+    "frame-src": ["checkout.paddle.com", "sandbox-checkout.paddle.com"],
+  };
+}
+
+/**
+ * CSP directives for Lemon Squeezy.
+ *
+ * The checkout overlay loads a script from assets.lemonsqueezy.com and opens
+ * the checkout in an iframe on *.lemonsqueezy.com.
+ */
+export function buildLemonSqueezyCSP(): CSPDirectives {
+  return {
+    "script-src": ["assets.lemonsqueezy.com"],
+    "connect-src": ["api.lemonsqueezy.com"],
+    "frame-src": ["*.lemonsqueezy.com"],
+  };
+}
+
+/** CSP directives for a booking provider (Cal.com or Calendly). */
+export function buildBookingCSP(provider: BookingProvider): CSPDirectives {
+  if (provider === "cal") {
+    return {
+      "script-src": ["app.cal.com"],
+      "style-src": ["app.cal.com"],
+      "frame-src": ["app.cal.com"],
+    };
+  }
+  return {
+    "script-src": ["assets.calendly.com"],
+    "style-src": ["assets.calendly.com"],
+    "frame-src": ["calendly.com"],
   };
 }
 

--- a/template/scripts/lemon-squeezy.ts
+++ b/template/scripts/lemon-squeezy.ts
@@ -31,29 +31,3 @@ export function parseLemonSqueezyConfig(
     productSlug: product,
   };
 }
-
-// ---------------------------------------------------------------------------
-// CSP directives
-// ---------------------------------------------------------------------------
-
-/** CSP directives needed for Lemon Squeezy */
-export interface LemonSqueezyCSP {
-  "script-src": string[];
-  "connect-src": string[];
-  "frame-src": string[];
-}
-
-/**
- * Build CSP directives required for Lemon Squeezy.
- *
- * Lemon Squeezy's checkout overlay loads a script from
- * assets.lemonsqueezy.com and opens the checkout in an iframe
- * on *.lemonsqueezy.com (e.g., my-store.lemonsqueezy.com).
- */
-export function buildLemonSqueezyCSP(): LemonSqueezyCSP {
-  return {
-    "script-src": ["assets.lemonsqueezy.com"],
-    "connect-src": ["api.lemonsqueezy.com"],
-    "frame-src": ["*.lemonsqueezy.com"],
-  };
-}

--- a/template/scripts/paddle.ts
+++ b/template/scripts/paddle.ts
@@ -34,33 +34,3 @@ export function parsePaddleConfig(
     sandbox: token.startsWith("test_"),
   };
 }
-
-// ---------------------------------------------------------------------------
-// CSP directives
-// ---------------------------------------------------------------------------
-
-/** CSP directives needed for Paddle */
-export interface PaddleCSP {
-  "script-src": string[];
-  "connect-src": string[];
-  "frame-src": string[];
-}
-
-/**
- * Build CSP directives required for Paddle.js.
- *
- * Paddle.js loads from cdn.paddle.com (production) or
- * sandbox-cdn.paddle.com (sandbox). The checkout overlay
- * uses checkout.paddle.com / sandbox-checkout.paddle.com.
- * Paddle sends telemetry to log.paddle.com.
- *
- * Both sandbox and production domains are included so sites
- * work in test mode without CSP changes.
- */
-export function buildPaddleCSP(): PaddleCSP {
-  return {
-    "script-src": ["cdn.paddle.com", "sandbox-cdn.paddle.com"],
-    "connect-src": ["log.paddle.com"],
-    "frame-src": ["checkout.paddle.com", "sandbox-checkout.paddle.com"],
-  };
-}

--- a/template/scripts/shopify-buy-button.ts
+++ b/template/scripts/shopify-buy-button.ts
@@ -41,39 +41,3 @@ export function parseShopifyEmbed(embedCode: string): ShopifyEmbedData | null {
     productId: idMatch[1],
   };
 }
-
-// ---------------------------------------------------------------------------
-// CSP directives
-// ---------------------------------------------------------------------------
-
-/** CSP directives needed for Shopify Buy Button */
-export interface ShopifyCSP {
-  "script-src": string[];
-  "style-src": string[];
-  "img-src": string[];
-  "connect-src": string[];
-  "frame-src": string[];
-}
-
-/**
- * Build CSP directives required for the Shopify Buy Button SDK.
- *
- * The Buy Button SDK loads from sdks.shopifycdn.com, fetches product
- * data from the store's myshopify.com domain via the Storefront API,
- * loads images from cdn.shopify.com, and sends analytics to
- * monorail-edge.shopifysvc.com.
- *
- * @returns Object with arrays of domains to add to each CSP directive
- */
-export function buildShopifyCSP(): ShopifyCSP {
-  return {
-    "script-src": ["cdn.shopify.com", "sdks.shopifycdn.com"],
-    "style-src": ["cdn.shopify.com"],
-    "img-src": ["cdn.shopify.com"],
-    "connect-src": [
-      "*.myshopify.com",
-      "monorail-edge.shopifysvc.com",
-    ],
-    "frame-src": [],
-  };
-}

--- a/template/scripts/snipcart.ts
+++ b/template/scripts/snipcart.ts
@@ -50,28 +50,3 @@ export function buildSnipcartAttrs(product: SnipcartProduct): SnipcartAttrs {
 export function formatPrice(cents: number): string {
   return (cents / 100).toFixed(2);
 }
-
-// ---------------------------------------------------------------------------
-// CSP directives
-// ---------------------------------------------------------------------------
-
-/** CSP directives needed for Snipcart */
-export interface SnipcartCSP {
-  "script-src": string[];
-  "style-src": string[];
-  "connect-src": string[];
-  "frame-src": string[];
-}
-
-/**
- * Build CSP directives required for Snipcart.
- * @returns Object with arrays of domains to add to each CSP directive
- */
-export function buildSnipcartCSP(): SnipcartCSP {
-  return {
-    "script-src": ["cdn.snipcart.com"],
-    "style-src": ["cdn.snipcart.com"],
-    "connect-src": ["app.snipcart.com"],
-    "frame-src": ["app.snipcart.com"],
-  };
-}

--- a/tests/booking.test.ts
+++ b/tests/booking.test.ts
@@ -6,7 +6,6 @@ import {
   extractBrandColor,
   buildCalEmbed,
   buildCalendlyEmbed,
-  buildBookingCSP,
 } from "../template/scripts/booking.js";
 
 // ---------------------------------------------------------------------------
@@ -237,32 +236,5 @@ describe("buildCalendlyEmbed", () => {
     const html = buildCalendlyEmbed("janedoe", "30min", "floating", "#000", "It's Free");
     expect(html).toContain("It\\'s Free");
     expect(html).not.toContain("text:'It's");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// buildBookingCSP
-// ---------------------------------------------------------------------------
-
-describe("buildBookingCSP", () => {
-  it("returns Cal.com script-src for cal provider", () => {
-    const csp = buildBookingCSP("cal");
-    expect(csp["script-src"]).toContain("app.cal.com");
-  });
-
-  it("returns Calendly domains for calendly provider", () => {
-    const csp = buildBookingCSP("calendly");
-    expect(csp["script-src"]).toContain("assets.calendly.com");
-    expect(csp["style-src"]).toContain("assets.calendly.com");
-  });
-
-  it("includes frame-src for cal", () => {
-    const csp = buildBookingCSP("cal");
-    expect(csp["frame-src"]).toContain("app.cal.com");
-  });
-
-  it("includes frame-src for calendly", () => {
-    const csp = buildBookingCSP("calendly");
-    expect(csp["frame-src"]).toContain("calendly.com");
   });
 });

--- a/tests/csp.test.ts
+++ b/tests/csp.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import {
   buildPolarCSP,
+  buildSnipcartCSP,
+  buildShopifyCSP,
+  buildPaddleCSP,
+  buildLemonSqueezyCSP,
+  buildBookingCSP,
   buildTurnstileCSP,
   buildGiscusCSP,
   buildTrackingCSP,
@@ -34,6 +41,121 @@ describe("buildPolarCSP", () => {
     const csp = buildPolarCSP();
     expect(csp["style-src"] ?? []).toEqual([]);
     expect(csp["img-src"] ?? []).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSnipcartCSP
+// ---------------------------------------------------------------------------
+
+describe("buildSnipcartCSP", () => {
+  it("includes cdn.snipcart.com in script-src", () => {
+    expect(buildSnipcartCSP()["script-src"]).toContain("cdn.snipcart.com");
+  });
+
+  it("includes cdn.snipcart.com in style-src", () => {
+    expect(buildSnipcartCSP()["style-src"]).toContain("cdn.snipcart.com");
+  });
+
+  it("includes app.snipcart.com in connect-src", () => {
+    expect(buildSnipcartCSP()["connect-src"]).toContain("app.snipcart.com");
+  });
+
+  it("includes app.snipcart.com in frame-src", () => {
+    expect(buildSnipcartCSP()["frame-src"]).toContain("app.snipcart.com");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildShopifyCSP
+// ---------------------------------------------------------------------------
+
+describe("buildShopifyCSP", () => {
+  it("includes cdn.shopify.com and sdks.shopifycdn.com in script-src", () => {
+    const csp = buildShopifyCSP();
+    expect(csp["script-src"]).toContain("cdn.shopify.com");
+    expect(csp["script-src"]).toContain("sdks.shopifycdn.com");
+  });
+
+  it("includes monorail-edge.shopifysvc.com and *.myshopify.com in connect-src", () => {
+    const csp = buildShopifyCSP();
+    expect(csp["connect-src"]).toContain("monorail-edge.shopifysvc.com");
+    expect(csp["connect-src"]).toContain("*.myshopify.com");
+  });
+
+  it("includes cdn.shopify.com in img-src", () => {
+    expect(buildShopifyCSP()["img-src"]).toContain("cdn.shopify.com");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPaddleCSP
+// ---------------------------------------------------------------------------
+
+describe("buildPaddleCSP", () => {
+  it("includes production and sandbox script-src domains", () => {
+    const csp = buildPaddleCSP();
+    expect(csp["script-src"]).toContain("cdn.paddle.com");
+    expect(csp["script-src"]).toContain("sandbox-cdn.paddle.com");
+  });
+
+  it("includes production and sandbox checkout frames", () => {
+    const csp = buildPaddleCSP();
+    expect(csp["frame-src"]).toContain("checkout.paddle.com");
+    expect(csp["frame-src"]).toContain("sandbox-checkout.paddle.com");
+  });
+
+  it("includes log.paddle.com in connect-src for analytics", () => {
+    expect(buildPaddleCSP()["connect-src"]).toContain("log.paddle.com");
+  });
+
+  it("does not include style-src or img-src", () => {
+    const csp = buildPaddleCSP();
+    expect(csp["style-src"] ?? []).toEqual([]);
+    expect(csp["img-src"] ?? []).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildLemonSqueezyCSP
+// ---------------------------------------------------------------------------
+
+describe("buildLemonSqueezyCSP", () => {
+  it("includes assets.lemonsqueezy.com in script-src", () => {
+    expect(buildLemonSqueezyCSP()["script-src"]).toContain("assets.lemonsqueezy.com");
+  });
+
+  it("includes api.lemonsqueezy.com in connect-src", () => {
+    expect(buildLemonSqueezyCSP()["connect-src"]).toContain("api.lemonsqueezy.com");
+  });
+
+  it("includes *.lemonsqueezy.com in frame-src for the checkout overlay", () => {
+    expect(buildLemonSqueezyCSP()["frame-src"]).toContain("*.lemonsqueezy.com");
+  });
+
+  it("does not include style-src or img-src", () => {
+    const csp = buildLemonSqueezyCSP();
+    expect(csp["style-src"] ?? []).toEqual([]);
+    expect(csp["img-src"] ?? []).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildBookingCSP
+// ---------------------------------------------------------------------------
+
+describe("buildBookingCSP", () => {
+  it("returns Cal.com domains for the cal provider", () => {
+    const csp = buildBookingCSP("cal");
+    expect(csp["script-src"]).toContain("app.cal.com");
+    expect(csp["frame-src"]).toContain("app.cal.com");
+  });
+
+  it("returns Calendly domains for the calendly provider", () => {
+    const csp = buildBookingCSP("calendly");
+    expect(csp["script-src"]).toContain("assets.calendly.com");
+    expect(csp["style-src"]).toContain("assets.calendly.com");
+    expect(csp["frame-src"]).toContain("calendly.com");
   });
 });
 
@@ -540,4 +662,29 @@ describe("generateHeadersContent", () => {
     expect(content).toContain("challenges.cloudflare.com");
     expect(content).not.toContain("cdn.shopify.com");
   });
+});
+
+// ---------------------------------------------------------------------------
+// Decoupling guard (#364): csp.ts must not statically import the optional
+// commerce / booking provider helper modules, so content-only sites can
+// delete them without editing csp.ts.
+// ---------------------------------------------------------------------------
+
+describe("csp.ts provider-module decoupling (#364)", () => {
+  const source = readFileSync(
+    resolve(import.meta.dirname!, "../template/scripts/csp.ts"),
+    "utf-8",
+  );
+
+  for (const mod of [
+    "./snipcart.js",
+    "./shopify-buy-button.js",
+    "./paddle.js",
+    "./lemon-squeezy.js",
+    "./booking.js",
+  ]) {
+    it(`does not import ${mod}`, () => {
+      expect(source).not.toContain(mod);
+    });
+  }
 });

--- a/tests/lemon-squeezy.test.ts
+++ b/tests/lemon-squeezy.test.ts
@@ -3,7 +3,6 @@ import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   parseLemonSqueezyConfig,
-  buildLemonSqueezyCSP,
 } from "../template/scripts/lemon-squeezy.js";
 
 const templateDir = resolve(import.meta.dirname!, "..", "template");
@@ -33,33 +32,6 @@ describe("parseLemonSqueezyConfig", () => {
 
   it("returns null for empty product slug", () => {
     expect(parseLemonSqueezyConfig("my-store", "")).toBeNull();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// buildLemonSqueezyCSP
-// ---------------------------------------------------------------------------
-
-describe("buildLemonSqueezyCSP", () => {
-  it("includes assets.lemonsqueezy.com in script-src", () => {
-    const csp = buildLemonSqueezyCSP();
-    expect(csp["script-src"]).toContain("assets.lemonsqueezy.com");
-  });
-
-  it("includes api.lemonsqueezy.com in connect-src", () => {
-    const csp = buildLemonSqueezyCSP();
-    expect(csp["connect-src"]).toContain("api.lemonsqueezy.com");
-  });
-
-  it("includes *.lemonsqueezy.com in frame-src for checkout overlay", () => {
-    const csp = buildLemonSqueezyCSP();
-    expect(csp["frame-src"]).toContain("*.lemonsqueezy.com");
-  });
-
-  it("does not include style-src or img-src", () => {
-    const csp = buildLemonSqueezyCSP();
-    expect(csp["style-src"] ?? []).toEqual([]);
-    expect(csp["img-src"] ?? []).toEqual([]);
   });
 });
 

--- a/tests/paddle.test.ts
+++ b/tests/paddle.test.ts
@@ -3,7 +3,6 @@ import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   parsePaddleConfig,
-  buildPaddleCSP,
 } from "../template/scripts/paddle.js";
 
 const templateDir = resolve(import.meta.dirname!, "..", "template");
@@ -42,43 +41,6 @@ describe("parsePaddleConfig", () => {
 
   it("returns null for empty price ID", () => {
     expect(parsePaddleConfig("test_abc123", "")).toBeNull();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// buildPaddleCSP
-// ---------------------------------------------------------------------------
-
-describe("buildPaddleCSP", () => {
-  it("includes cdn.paddle.com in script-src", () => {
-    const csp = buildPaddleCSP();
-    expect(csp["script-src"]).toContain("cdn.paddle.com");
-  });
-
-  it("includes checkout.paddle.com in frame-src", () => {
-    const csp = buildPaddleCSP();
-    expect(csp["frame-src"]).toContain("checkout.paddle.com");
-  });
-
-  it("includes sandbox-cdn.paddle.com in script-src for sandbox coverage", () => {
-    const csp = buildPaddleCSP();
-    expect(csp["script-src"]).toContain("sandbox-cdn.paddle.com");
-  });
-
-  it("includes sandbox-checkout.paddle.com in frame-src for sandbox coverage", () => {
-    const csp = buildPaddleCSP();
-    expect(csp["frame-src"]).toContain("sandbox-checkout.paddle.com");
-  });
-
-  it("includes log.paddle.com in connect-src for analytics", () => {
-    const csp = buildPaddleCSP();
-    expect(csp["connect-src"]).toContain("log.paddle.com");
-  });
-
-  it("does not include style-src or img-src", () => {
-    const csp = buildPaddleCSP();
-    expect(csp["style-src"] ?? []).toEqual([]);
-    expect(csp["img-src"] ?? []).toEqual([]);
   });
 });
 

--- a/tests/shopify-buy-button.test.ts
+++ b/tests/shopify-buy-button.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import {
-  buildShopifyCSP,
   parseShopifyEmbed,
 } from "../template/scripts/shopify-buy-button.js";
 
@@ -82,37 +81,6 @@ describe("parseShopifyEmbed", () => {
     expect(result!.domain).toBe("another-shop.myshopify.com");
     expect(result!.storefrontAccessToken).toBe("tokenABC");
     expect(result!.productId).toBe("9876543210987");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// buildShopifyCSP
-// ---------------------------------------------------------------------------
-
-describe("buildShopifyCSP", () => {
-  it("includes cdn.shopify.com in script-src", () => {
-    const csp = buildShopifyCSP();
-    expect(csp["script-src"]).toContain("cdn.shopify.com");
-  });
-
-  it("includes sdks.shopifycdn.com in script-src", () => {
-    const csp = buildShopifyCSP();
-    expect(csp["script-src"]).toContain("sdks.shopifycdn.com");
-  });
-
-  it("includes monorail-edge.shopifysvc.com in connect-src", () => {
-    const csp = buildShopifyCSP();
-    expect(csp["connect-src"]).toContain("monorail-edge.shopifysvc.com");
-  });
-
-  it("includes cdn.shopify.com in img-src", () => {
-    const csp = buildShopifyCSP();
-    expect(csp["img-src"]).toContain("cdn.shopify.com");
-  });
-
-  it("includes *.myshopify.com in connect-src for storefront API", () => {
-    const csp = buildShopifyCSP();
-    expect(csp["connect-src"]).toContain("*.myshopify.com");
   });
 });
 

--- a/tests/snipcart.test.ts
+++ b/tests/snipcart.test.ts
@@ -3,7 +3,6 @@ import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   buildSnipcartAttrs,
-  buildSnipcartCSP,
   formatPrice,
 } from "../template/scripts/snipcart.js";
 
@@ -121,32 +120,6 @@ describe("formatPrice", () => {
 
   it("formats prices with one cent digit", () => {
     expect(formatPrice(1050)).toBe("10.50");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// buildSnipcartCSP
-// ---------------------------------------------------------------------------
-
-describe("buildSnipcartCSP", () => {
-  it("includes cdn.snipcart.com in script-src", () => {
-    const csp = buildSnipcartCSP();
-    expect(csp["script-src"]).toContain("cdn.snipcart.com");
-  });
-
-  it("includes cdn.snipcart.com in style-src", () => {
-    const csp = buildSnipcartCSP();
-    expect(csp["style-src"]).toContain("cdn.snipcart.com");
-  });
-
-  it("includes app.snipcart.com in connect-src", () => {
-    const csp = buildSnipcartCSP();
-    expect(csp["connect-src"]).toContain("app.snipcart.com");
-  });
-
-  it("includes app.snipcart.com in frame-src", () => {
-    const csp = buildSnipcartCSP();
-    expect(csp["frame-src"]).toContain("app.snipcart.com");
   });
 });
 


### PR DESCRIPTION
Fixes #364.

## Problem

`template/scripts/csp.ts` statically imported five commerce/booking provider helper modules just to call their `build*CSP()` helpers:

```ts
import { buildSnipcartCSP } from "./snipcart.js";
import { buildShopifyCSP } from "./shopify-buy-button.js";
import { buildPaddleCSP } from "./paddle.js";
import { buildLemonSqueezyCSP } from "./lemon-squeezy.js";
import { buildBookingCSP, type BookingProvider } from "./booking.js";
```

That made all five modules **load-bearing for the module graph** even on content-only sites (blogs, docs, personal sites) with no checkout or booking. A site owner couldn't delete the dead helpers without also hand-editing `csp.ts` — a manual fork that drifts from upstream on every update.

## Fix

Centralize the five CSP builders into `csp.ts`, alongside the ones that **already** live there inline (`buildPolarCSP`, `buildTurnstileCSP`, `buildGiscusCSP`, `buildPodcastYouTubeCSP`, `buildTrackingCSP`), and drop the static imports. `BookingProvider` is now defined locally in `csp.ts` so there's no type dependency on `booking.ts` either.

- **CSP output is byte-for-byte unchanged** — `buildCSP`'s branches call the same-named builders, now local.
- **`buildCSP` stays synchronous** — chose centralization over the dynamic-import option in the issue specifically to avoid an `async` ripple across its ~30 call sites and the skill snippets.
- Nothing in the site build graph imports the provider helper modules anymore, so `snipcart.ts` / `shopify-buy-button.ts` / `paddle.ts` / `lemon-squeezy.ts` / `booking.ts` can be deleted on a content-only site **without touching `csp.ts`** — exactly the outcome the issue asked for.

## Changes

- Removed `build*CSP` + their per-provider CSP interfaces from the five provider modules. `booking.ts` keeps the `BookingProvider` type (still used by its embed helpers).
- Moved the builder unit tests into `csp.test.ts`; added a **guard test** asserting `csp.ts` never re-imports a provider module (prevents regression of #364).
- Repointed `skills/booking/SKILL.md` to `csp.ts` for `buildBookingCSP()`.

## Tests

Full suite green except the 2 pre-existing, unrelated `test/apply-edit-dispatcher.test.js` failures (present on `main`). The CSP + all five provider suites pass (86 + 196 across the touched files).

### Note on default vendoring

This resolves the issue's core grievance (the modules are no longer load-bearing / no `csp.ts` fork needed to remove them). The issue also floated *gating vendoring* so the files aren't scaffolded at all unless a provider is configured — that's a separate `scaffold.sh`/`update.sh` change and can be a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKuH4bGQjPJ5pZJbd7USJS)_