### PR TITLE
fix(indieweb): harden Step 1 gate to verify @dwk/* packages import, not just exist (#363)

### DIFF
--- a/skills/indieweb/SKILL.md
+++ b/skills/indieweb/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: indieweb
 description: "Deploy self-owned IndieAuth, Webmention, and Micropub endpoints on your domain"
-allowed-tools: Bash(npm run build), Bash(npm install *), Bash(npm view *), Bash(npx wrangler *), Bash(openssl *), Bash(grep *), Bash(gh *), Write, Read, Edit, Glob, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__d1_database_create, mcp__cloudflare__d1_databases_list, mcp__cloudflare__d1_database_get, mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_buckets_list
+allowed-tools: Bash(npm run build), Bash(npm install *), Bash(npm view *), Bash(npx wrangler *), Bash(openssl *), Bash(grep *), Bash(gh *), Bash(node *), Bash(mktemp *), Bash(printf *), Bash(rm *), Write, Read, Edit, Glob, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__d1_database_create, mcp__cloudflare__d1_databases_list, mcp__cloudflare__d1_database_get, mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_buckets_list
 disable-model-invocation: true
 ---
 
@@ -33,25 +33,28 @@ If `INDIEWEB_ENABLED=true` is already set in `.site-config`, the endpoints are a
 
 ## Step 1 — Check package availability
 
-The `@dwk/*` packages must be published on npm before the endpoints can be installed. Check each one:
+The `@dwk/*` packages must be published on npm **and actually load under Node ESM** before the endpoints can be installed. A published version is not enough: a broken build whose compiled `dist/` re-exports omit file extensions passes `npm view` but throws `ERR_MODULE_NOT_FOUND` the moment it's imported (issue #363). Composing such a package into `site-entry.js` produces a Worker that can't boot — and the breakage is invisible until deploy because the repo's tests alias `@dwk/*` to stubs. So the gate must **import** each package, not just confirm it exists.
+
+Run this combined gate. It installs the four packages into a throwaway directory (never touching the site) and dynamically imports each one, failing closed on any error:
 
 ```sh
-npm view @dwk/indieauth version
+PKGS="@dwk/indieauth @dwk/webmention @dwk/micropub @dwk/webauthn"
+SMOKE=$(mktemp -d) && printf '{"type":"module","private":true}' > "$SMOKE/package.json"
+( cd "$SMOKE" \
+  && npm install $PKGS >/dev/null 2>&1 \
+  && for p in $PKGS; do \
+       node -e "import('$p').then(()=>console.log('ok   '+process.argv[1])).catch(e=>{console.error('FAIL '+process.argv[1]+': '+(e.code||e.message));process.exit(1)})" "$p" || exit 1; \
+     done )
+GATE=$?
+rm -rf "$SMOKE"
+echo "gate exit: $GATE"
 ```
 
-```sh
-npm view @dwk/webmention version
-```
+If `gate exit` is non-zero — any package is unpublished, reports version `0.0.0`, fails to install, or prints a `FAIL` line (does not import) — stop and tell the owner:
 
-```sh
-npm view @dwk/micropub version
-```
+"The IndieWeb endpoint packages aren't ready yet — this feature isn't available right now. It's being built by an open-source project and will be ready soon. I'll let you know when it ships. In the meantime, your site already supports the passive IndieWeb (microformats, `rel="me"`, RSS) — see `docs/indieweb.md` for what's already working."
 
-If **any** package returns an error (not found) or reports version `0.0.0`, stop and tell the owner:
-
-"The IndieWeb endpoint packages aren't published yet — this feature isn't available right now. It's being built by an open-source project and will be ready soon. I'll let you know when it ships. In the meantime, your site already supports the passive IndieWeb (microformats, `rel="me"`, RSS) — see `docs/indieweb.md` for what's already working."
-
-Do not attempt git installs, forks, or workarounds. The gate is intentional.
+Do not attempt git installs, forks, version pins to a broken build, or workarounds. The gate is intentional: a package that imports cleanly is the contract the rest of this skill depends on.
 
 ## Step 2 — Choose endpoints
 

--- a/skills/indieweb/SKILL.md
+++ b/skills/indieweb/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash(npm run build), Bash(npm install *), Bash(npx wrangler *), B
 disable-model-invocation: true
 ---
 
-Set up self-owned IndieWeb endpoints on the owner's primary domain using the `@dwk/*` worker packages. Deploys IndieAuth (sign in with your domain), Webmention (receive cross-site mentions), and Micropub (publish from third-party clients) — each independently gated and composed into the site's existing `site-entry.js` Worker.
+Set up self-owned IndieWeb endpoints on the owner's primary domain using the `@dwk/*` worker packages. Deploys IndieAuth (sign in with your domain), Webmention (receive cross-site mentions), and Micropub (publish from third-party clients) — each independently selectable, runtime-guarded by its own bindings, and composed into the site's existing `site-entry.js` Worker.
 
 The owner's identity, tokens, and data stay on their own Cloudflare account. No third-party identity or mention hosts.
 
@@ -35,7 +35,7 @@ If `INDIEWEB_ENABLED=true` is already set in `.site-config`, the endpoints are a
 
 The `@dwk/*` packages must be published on npm **and actually load under Node ESM** before the endpoints can be installed. A published version is not enough: a broken build whose compiled `dist/` re-exports omit file extensions passes `npm view` but throws `ERR_MODULE_NOT_FOUND` the moment it's imported (issue #363). Composing such a package into `site-entry.js` produces a Worker that can't boot — and the breakage is invisible until deploy because the repo's tests alias `@dwk/*` to stubs. So the gate must **import** each package, not just confirm it exists.
 
-Run this combined gate. It installs the four packages into a throwaway directory (never touching the site) and dynamically imports each one, failing closed on any error:
+Run this combined gate. It installs the four packages into a throwaway directory (never touching the site) and dynamically imports each one, failing closed on any error. The check is all-or-nothing across the four `@dwk/*` packages: they're published from one monorepo at a shared version, so a broken build breaks them together — gating them as a set keeps this step simple. (Endpoint *selection* in Step 2 and runtime guarding remain per-endpoint.)
 
 ```sh
 PKGS="@dwk/indieauth @dwk/webmention @dwk/micropub @dwk/webauthn"

--- a/skills/indieweb/SKILL.md
+++ b/skills/indieweb/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: indieweb
 description: "Deploy self-owned IndieAuth, Webmention, and Micropub endpoints on your domain"
-allowed-tools: Bash(npm run build), Bash(npm install *), Bash(npm view *), Bash(npx wrangler *), Bash(openssl *), Bash(grep *), Bash(gh *), Bash(node *), Bash(mktemp *), Bash(printf *), Bash(rm *), Write, Read, Edit, Glob, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__d1_database_create, mcp__cloudflare__d1_databases_list, mcp__cloudflare__d1_database_get, mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_buckets_list
+allowed-tools: Bash(npm run build), Bash(npm install *), Bash(npx wrangler *), Bash(openssl *), Bash(grep *), Bash(gh *), Bash(node *), Bash(mktemp *), Bash(printf *), Bash(rm *), Write, Read, Edit, Glob, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__d1_database_create, mcp__cloudflare__d1_databases_list, mcp__cloudflare__d1_database_get, mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_buckets_list
 disable-model-invocation: true
 ---
 
@@ -39,18 +39,26 @@ Run this combined gate. It installs the four packages into a throwaway directory
 
 ```sh
 PKGS="@dwk/indieauth @dwk/webmention @dwk/micropub @dwk/webauthn"
-SMOKE=$(mktemp -d) && printf '{"type":"module","private":true}' > "$SMOKE/package.json"
-( cd "$SMOKE" \
-  && npm install $PKGS >/dev/null 2>&1 \
-  && for p in $PKGS; do \
-       node -e "import('$p').then(()=>console.log('ok   '+process.argv[1])).catch(e=>{console.error('FAIL '+process.argv[1]+': '+(e.code||e.message));process.exit(1)})" "$p" || exit 1; \
-     done )
-GATE=$?
-rm -rf "$SMOKE"
+SMOKE=$(mktemp -d)
+GATE=1
+if [ -n "$SMOKE" ]; then
+  printf '{"type":"module","private":true}' > "$SMOKE/package.json"
+  ( cd "$SMOKE" \
+    && { INSTALL_ERR=$(npm install $PKGS 2>&1 >/dev/null) \
+         || { echo "INSTALL FAILED (network/registry issue or unavailable package):"; echo "$INSTALL_ERR"; exit 1; }; } \
+    && for p in $PKGS; do \
+         node -e "import('$p').then(()=>console.log('ok   $p')).catch(e=>{console.error('FAIL $p: '+(e.code||e.message));process.exit(1)})" || exit 1; \
+       done )
+  GATE=$?
+  rm -rf "$SMOKE"
+fi
 echo "gate exit: $GATE"
 ```
 
-If `gate exit` is non-zero — any package is unpublished, reports version `0.0.0`, fails to install, or prints a `FAIL` line (does not import) — stop and tell the owner:
+If `gate exit` is **0**, every package installed and imported cleanly — proceed. Otherwise stop. Read the captured output to tell the two failure modes apart:
+
+- An `INSTALL FAILED` block means the install itself errored — most often a transient network/registry hiccup, occasionally an unavailable package. Tell the owner: "I couldn't install the IndieWeb endpoint packages just now — this is usually a temporary network issue. Try again in a minute. If it keeps failing, the packages may not be ready yet."
+- A `FAIL <pkg>: …` line (e.g. `ERR_MODULE_NOT_FOUND`) means a package is published but doesn't load — a broken build. Tell the owner:
 
 "The IndieWeb endpoint packages aren't ready yet — this feature isn't available right now. It's being built by an open-source project and will be ready soon. I'll let you know when it ships. In the meantime, your site already supports the passive IndieWeb (microformats, `rel="me"`, RSS) — see `docs/indieweb.md` for what's already working."
 


### PR DESCRIPTION
## What

Hardens the `skills/indieweb/SKILL.md` **Step 1 — Check package availability** gate so it verifies the `@dwk/*` packages actually **import under Node ESM**, not merely that they're published.

## Why (issue #363, note 1)

The previous gate ran only `npm view <pkg> version`, which confirms existence. The `0.1.0-beta.*` `@dwk/*` builds pass that check but throw `ERR_MODULE_NOT_FOUND` on import — their compiled `dist/` re-exports omit file extensions, which Node ESM can't resolve. Composing such a package into `site-entry.js` produces a Worker that can't boot, and the breakage stays invisible because the repo's tests alias `@dwk/*` to stubs (`tests/__stubs__/dwk-*.ts`) and wrangler bundling can paper over it at build time. Net effect: a fresh `/anglesite:indieweb` run today would wave broken packages straight through the gate.

## What changed

- Step 1 now installs the four packages (`@dwk/indieauth`, `@dwk/webmention`, `@dwk/micropub`, `@dwk/webauthn`) into a throwaway `mktemp` directory — never touching the site — and dynamically imports each one, **failing closed** on any install or import error. A published-but-broken build no longer passes; the owner gets the existing "not available yet" message.
- `allowed-tools` gains `Bash(node *)`, `Bash(mktemp *)`, `Bash(printf *)`, `Bash(rm *)` so the smoke test runs without prompting the (often non-technical) owner.

## Verification

- Gate **fails closed** (exit 1 + `FAIL @dwk/indieauth: ERR_MODULE_NOT_FOUND`) against the current published `0.1.0-beta.2` packages.
- Gate **passes** (exit 0, `ok`) for packages that import cleanly.
- `tests/build-instructions.test.ts` — 21/21 green (SKILL.md still validates).
- Full suite: only 2 pre-existing, unrelated `test/apply-edit-dispatcher.test.js` failures (a root-in-container filesystem-permission quirk; fail identically on clean `HEAD`).

## Scope note

This addresses the **in-repo** half of #363 note 1. The upstream root cause — the `@dwk/*` `dist/` re-exports needing `.js` extensions — lives in the separate `@dwk/*` package repo and is still unfixed (verified: `0.1.0-beta.2` still fails to import). Issue #363 notes 2 (API realignment) and 3 (webmention render XSS) were already fixed by #370 and #369 respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTFyxU3zyrr3QauRU2Tmkv)_