### PR TITLE
fix(apply-edit): accept op=apply-instruction with structured needs-agent refusal

### DIFF
--- a/server/apply-edit-dispatcher.mjs
+++ b/server/apply-edit-dispatcher.mjs
@@ -184,6 +184,13 @@ async function processImageDrop(projectRoot, edit) {
  * @param {{ onApplied?: (info: {file:string, range:{start:number,end:number}, projectRoot:string}) => Promise<string|undefined> | string | undefined }} [opts]
  */
 export async function applyEdit(projectRoot, edit, opts = {}) {
+  // The app's Foundation Models chat path (ApplyEditTool, #251) forwards NL instructions
+  // as op="apply-instruction" expecting plugin-side interpretation. The MCP server is
+  // deterministic (no LLM), so return a structured refusal the app can route to its agent.
+  if (edit.op === "apply-instruction") {
+    return failed(edit.id, "needs-agent", "apply-instruction requires LLM interpretation; route to the agent");
+  }
+
   // dry_run is read-only. Image edits can't be previewed without writing optimized
   // bytes to disk, so refuse rather than violate the no-write invariant.
   if (edit.dry_run && edit.op === "replace-image-src") {

--- a/server/apply-edit-schema.mjs
+++ b/server/apply-edit-schema.mjs
@@ -61,12 +61,12 @@ export const applyEditInputShape = {
   op: z
     .enum(editOps)
     .describe(
-      "Edit operation: replace-text (innerText), replace-attr (value is {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>), apply-instruction (NL instruction forwarded by the app's Foundation Models chat — returns needs-agent for app-side routing)",
+      "Edit operation: replace-text (innerText), replace-attr (value is {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>), apply-instruction (reserved: sent only by the Anglesite-app Foundation Models chat path; always returns edit-failed/needs-agent — do not use from external callers)",
     ),
   value: z
     .unknown()
     .describe(
-      "Operation payload; varies by op (string for replace-text, {name, value} for replace-attr, {filename, mimeType, dataURL} for replace-image-src, {property, value} for edit-style)",
+      "Operation payload; varies by op (string for replace-text, {name, value} for replace-attr, {filename, mimeType, dataURL} for replace-image-src, {property, value} for edit-style, string for apply-instruction — the NL instruction text)",
     ),
   dry_run: z
     .boolean()

--- a/server/apply-edit-schema.mjs
+++ b/server/apply-edit-schema.mjs
@@ -8,7 +8,7 @@
  *   - `selector: ElementInfo` (drops `element/tagName/textFingerprint/domPath`; matches
  *     selector.mjs's existing typedef).
  *   - `path` (drops `url`; the app already uses `path` on its side).
- *   - `op` is the closed enum {replace-text, replace-attr, replace-image-src, edit-style}.
+ *   - `op` is the closed enum {replace-text, replace-attr, replace-image-src, edit-style, apply-instruction}.
  *   - No `site` field — the MCP server already knows its `projectRoot`.
  *   - `type` is accepted-and-ignored — the app uses it as a WKWebView-side boundary tag.
  */
@@ -36,9 +36,10 @@ export const elementInfoSchema = z.object({
   textContent: z.string().optional(),
 });
 
-/** Edit operations the patcher knows how to apply. Phase 5's patcher (#295) implements these;
- *  new ops require an explicit enum addition + a resolver update. */
-export const editOps = ["replace-text", "replace-attr", "replace-image-src", "edit-style"];
+/** Edit operations the server accepts. The patcher resolves the first four; `apply-instruction`
+ *  is an NL-forwarding op the app's Foundation Models chat path sends — the server returns a
+ *  structured `needs-agent` refusal so the app can route it to its agent. */
+export const editOps = ["replace-text", "replace-attr", "replace-image-src", "edit-style", "apply-instruction"];
 
 /** The MCP tool's input shape, as passed to `server.tool(name, description, shape, handler)`. */
 export const applyEditInputShape = {
@@ -60,7 +61,7 @@ export const applyEditInputShape = {
   op: z
     .enum(editOps)
     .describe(
-      "Edit operation: replace-text (innerText), replace-attr (op needs value to be {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>)",
+      "Edit operation: replace-text (innerText), replace-attr (value is {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>), apply-instruction (NL instruction forwarded by the app's Foundation Models chat — returns needs-agent for app-side routing)",
     ),
   value: z
     .unknown()

--- a/test/apply-edit-dispatcher.test.js
+++ b/test/apply-edit-dispatcher.test.js
@@ -140,6 +140,31 @@ describe("applyEdit — write-failed surface", () => {
   });
 });
 
+describe("applyEdit — apply-instruction (needs-agent refusal)", () => {
+  it("returns edit-failed with reason needs-agent instead of crashing", async () => {
+    const response = await applyEdit(root, makeEdit({
+      op: "apply-instruction",
+      value: "Make the heading more welcoming",
+    }));
+    expect(response.isError).toBe(true);
+    const body = parseContent(response);
+    expect(body.type).toBe("anglesite:edit-failed");
+    expect(body.id).toBe("e-1");
+    expect(body.reason).toBe("needs-agent");
+  });
+
+  it("does not touch the filesystem", async () => {
+    const indexPath = join(root, "src/pages/index.astro");
+    const before = readFileSync(indexPath, "utf-8");
+    await applyEdit(root, makeEdit({
+      op: "apply-instruction",
+      value: "Change the hero text",
+    }));
+    const after = readFileSync(indexPath, "utf-8");
+    expect(after).toBe(before);
+  });
+});
+
 describe("replace-image-src", () => {
   let projectRoot;
 

--- a/test/apply-edit-dispatcher.test.js
+++ b/test/apply-edit-dispatcher.test.js
@@ -151,6 +151,7 @@ describe("applyEdit — apply-instruction (needs-agent refusal)", () => {
     expect(body.type).toBe("anglesite:edit-failed");
     expect(body.id).toBe("e-1");
     expect(body.reason).toBe("needs-agent");
+    expect(body.detail).toBeTruthy();
   });
 
   it("does not touch the filesystem", async () => {

--- a/test/apply-edit-schema.test.js
+++ b/test/apply-edit-schema.test.js
@@ -55,6 +55,12 @@ describe("applyEditInputShape", () => {
     }
   });
 
+  it("accepts op=apply-instruction (Foundation Models chat forward)", () => {
+    expect(
+      applyEditSchema.safeParse({ ...validPayload, op: "apply-instruction" }).success,
+    ).toBe(true);
+  });
+
   it("rejects op values outside the enum", () => {
     expect(applyEditSchema.safeParse({ ...validPayload, op: "set-text" }).success).toBe(false);
     expect(applyEditSchema.safeParse({ ...validPayload, op: "delete" }).success).toBe(false);


### PR DESCRIPTION
## Summary

- Adds `apply-instruction` to the `apply_edit` op enum so the Anglesite-app's Foundation Models chat path (#251) no longer gets a Zod validation crash
- Returns a structured `edit-failed` response with `reason: "needs-agent"` instead, so the app can cleanly route the NL instruction to its agent/chat path
- Fixes the stale op-enum comment in `apply-edit-schema.mjs` (from #380)

## Test plan

- [x] New schema test: `apply-instruction` accepted by Zod enum
- [x] New dispatcher test: returns `edit-failed` with `reason: "needs-agent"` and `isError: true`
- [x] New dispatcher test: filesystem untouched (no patcher invocation)
- [x] All existing `editOps` enum tests still pass (including `accepts every enum op`)
- [x] Full test suite passes (2 pre-existing `write-failed` failures due to root user in CI container — unrelated)

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqrLR2UQuzRNVXphAoQbmF

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqrLR2UQuzRNVXphAoQbmF)_