### PR TITLE
Add npx skills install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,22 @@ claude
 
 Then type `/anglesite:start` to begin.
 
+### Open Agent Skills (any AI coding agent)
+
+Individual skills can be installed in any agent that supports the [Open Agent Skills](https://agentskills.io) spec ([skills.sh](https://www.skills.sh)):
+
+```sh
+# Install a single skill
+npx skills add Anglesite/anglesite/agent-skills/start
+
+# Examples
+npx skills add Anglesite/anglesite/agent-skills/deploy
+npx skills add Anglesite/anglesite/agent-skills/seo
+npx skills add Anglesite/anglesite/agent-skills/contact
+```
+
+Each skill is self-contained with bundled reference material. See [`agent-skills/README.md`](agent-skills/README.md) for the full list of available skills.
+
 ---
 
 The start command scaffolds your project, learns about your business, designs the site with you, and installs the tools to preview it. When you're ready to go live, `/anglesite:deploy` handles hosting, domains, and publishing.


### PR DESCRIPTION
## Summary
- Adds a third install section ("Open Agent Skills") to the README, alongside the existing Claude Cowork and Claude Code sections
- Shows how to install individual skills via `npx skills add Anglesite/anglesite/agent-skills/<skill>` for any AI coding agent supporting the agentskills.io / skills.sh spec
- Links to `agent-skills/README.md` for the full skill list

## Test plan
- [ ] Verify the new section renders correctly in GitHub's markdown preview
- [ ] Confirm `npx skills add` commands use the correct repo path format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01244XcoZPfQEoMhNpfX8VEE

---
_Generated by [Claude Code](https://claude.ai/code/session_01244XcoZPfQEoMhNpfX8VEE)_