### PR TITLE
feat(#377): typed content scaffolding in create-content.mjs

### DIFF
--- a/server/content-types.mjs
+++ b/server/content-types.mjs
@@ -1,0 +1,177 @@
+/**
+ * Built-in typed content objects (V-1 / epic #334), mirrored from the app's
+ * `AnglesiteCore/ContentTypeRegistry.swift` built-in catalog.
+ *
+ * **Source of truth is Swift.** This is the scaffolding-relevant projection only — each
+ * descriptor's `id`, `displayName`, `storage`, and ordered `fields` (name + kind). The
+ * microformats2 / schema.org projections that the Swift descriptors also carry are NOT
+ * mirrored here: scaffolding (`renderEntry`) never reads them, and the template/JSON-LD
+ * layers that do live app-side. Keep this list byte-faithful to the Swift catalog so the
+ * native and MCP create paths produce identical files (no git churn when the backend swaps).
+ *
+ * Field `kind` values match `ContentTypeField.Kind`: string, text, markdown, bool, date,
+ * datetime, url, image, number, stringArray, imageArray.
+ *
+ * @module
+ */
+
+/**
+ * @typedef {{ name: string, kind: string }} ContentTypeField
+ * @typedef {{ id: string, displayName: string, collection: string | null, fields: ContentTypeField[] }} ContentTypeDescriptor
+ */
+
+/** @type {ContentTypeDescriptor[]} */
+const PERSONAL_TYPES = [
+  {
+    id: "note",
+    displayName: "Note",
+    collection: "notes",
+    fields: [
+      { name: "body", kind: "markdown" },
+      { name: "publishDate", kind: "datetime" },
+      { name: "tags", kind: "stringArray" },
+    ],
+  },
+  {
+    id: "article",
+    displayName: "Article",
+    collection: "articles",
+    fields: [
+      { name: "title", kind: "string" },
+      { name: "summary", kind: "text" },
+      { name: "body", kind: "markdown" },
+      { name: "publishDate", kind: "datetime" },
+      { name: "updated", kind: "datetime" },
+      { name: "tags", kind: "stringArray" },
+    ],
+  },
+  {
+    id: "photo",
+    displayName: "Photo",
+    collection: "photos",
+    fields: [
+      { name: "image", kind: "image" },
+      { name: "caption", kind: "text" },
+      { name: "publishDate", kind: "datetime" },
+      { name: "tags", kind: "stringArray" },
+    ],
+  },
+  {
+    id: "album",
+    displayName: "Album",
+    collection: "albums",
+    fields: [
+      { name: "title", kind: "string" },
+      { name: "images", kind: "imageArray" },
+      { name: "body", kind: "markdown" },
+      { name: "publishDate", kind: "datetime" },
+      { name: "tags", kind: "stringArray" },
+    ],
+  },
+  {
+    id: "bookmark",
+    displayName: "Bookmark",
+    collection: "bookmarks",
+    fields: [
+      { name: "bookmarkOf", kind: "url" },
+      { name: "title", kind: "string" },
+      { name: "body", kind: "markdown" },
+      { name: "publishDate", kind: "datetime" },
+      { name: "tags", kind: "stringArray" },
+    ],
+  },
+  {
+    id: "reply",
+    displayName: "Reply",
+    collection: "replies",
+    fields: [
+      { name: "inReplyTo", kind: "url" },
+      { name: "body", kind: "markdown" },
+      { name: "publishDate", kind: "datetime" },
+    ],
+  },
+  {
+    id: "like",
+    displayName: "Like",
+    collection: "likes",
+    fields: [
+      { name: "likeOf", kind: "url" },
+      { name: "publishDate", kind: "datetime" },
+    ],
+  },
+];
+
+/** @type {ContentTypeDescriptor[]} */
+const BUSINESS_TYPES = [
+  {
+    id: "businessProfile",
+    displayName: "Business Profile",
+    collection: null, // page-stored (#345); not scaffoldable via createTyped yet
+    fields: [
+      { name: "name", kind: "string" },
+      { name: "description", kind: "text" },
+      { name: "telephone", kind: "string" },
+      { name: "email", kind: "string" },
+      { name: "streetAddress", kind: "string" },
+      { name: "locality", kind: "string" },
+      { name: "region", kind: "string" },
+      { name: "postalCode", kind: "string" },
+      { name: "hours", kind: "stringArray" },
+      { name: "url", kind: "url" },
+    ],
+  },
+  {
+    id: "announcement",
+    displayName: "Announcement",
+    collection: "announcements",
+    fields: [
+      { name: "title", kind: "string" },
+      { name: "body", kind: "markdown" },
+      { name: "publishDate", kind: "datetime" },
+    ],
+  },
+  {
+    id: "event",
+    displayName: "Event",
+    collection: "events",
+    fields: [
+      { name: "name", kind: "string" },
+      { name: "body", kind: "markdown" },
+      { name: "start", kind: "datetime" },
+      { name: "end", kind: "datetime" },
+      { name: "location", kind: "string" },
+    ],
+  },
+  {
+    id: "review",
+    displayName: "Review",
+    collection: "reviews",
+    fields: [
+      { name: "itemReviewed", kind: "string" },
+      { name: "rating", kind: "number" },
+      { name: "body", kind: "markdown" },
+      { name: "publishDate", kind: "datetime" },
+    ],
+  },
+];
+
+/**
+ * All built-in content types in registration order (personal h-entry family, then business),
+ * mirroring `ContentTypeRegistry.builtIns`.
+ * @type {ContentTypeDescriptor[]}
+ */
+export const contentTypes = [...PERSONAL_TYPES, ...BUSINESS_TYPES];
+
+/** All built-in content-type ids, in order. */
+export const contentTypeIds = contentTypes.map((t) => t.id);
+
+const byID = new Map(contentTypes.map((t) => [t.id, t]));
+
+/**
+ * Look up a content-type descriptor by its stable `id` (e.g. `note`, `businessProfile`).
+ * @param {string} id
+ * @returns {ContentTypeDescriptor | undefined}
+ */
+export function descriptorById(id) {
+  return byID.get(id);
+}

--- a/server/content-types.mjs
+++ b/server/content-types.mjs
@@ -3,7 +3,7 @@
  * `AnglesiteCore/ContentTypeRegistry.swift` built-in catalog.
  *
  * **Source of truth is Swift.** This is the scaffolding-relevant projection only — each
- * descriptor's `id`, `displayName`, `storage`, and ordered `fields` (name + kind). The
+ * descriptor's `id`, `displayName`, `collection`, and ordered `fields` (name + kind). The
  * microformats2 / schema.org projections that the Swift descriptors also carry are NOT
  * mirrored here: scaffolding (`renderEntry`) never reads them, and the template/JSON-LD
  * layers that do live app-side. Keep this list byte-faithful to the Swift catalog so the
@@ -164,6 +164,13 @@ export const contentTypes = [...PERSONAL_TYPES, ...BUSINESS_TYPES];
 
 /** All built-in content-type ids, in order. */
 export const contentTypeIds = contentTypes.map((t) => t.id);
+
+/**
+ * Ids of types that `createTyped` can actually scaffold: collection-stored only. Page-stored
+ * types (e.g. `businessProfile`, #345) are excluded so the MCP `create_content` schema never
+ * advertises an input the backend will reject.
+ */
+export const creatableContentTypeIds = contentTypes.filter((t) => t.collection !== null).map((t) => t.id);
 
 const byID = new Map(contentTypes.map((t) => [t.id, t]));
 

--- a/server/create-content.mjs
+++ b/server/create-content.mjs
@@ -1,17 +1,20 @@
 /**
- * `create_page` / `create_post` MCP tool backends (#140 / A.6).
+ * `create_page` / `create_post` / `create_content` MCP tool backends (#140 / A.6; typed: #377).
  *
- * Both scaffold a minimal, valid source file from a fixed template and commit it onto the
+ * Each scaffolds a minimal, valid source file from a fixed template and commits it onto the
  * project's current branch (best-effort — the filesystem is the source of truth, so a missing
  * git repo or a rejecting hook leaves the file on disk and reports `commit: null` rather than
- * failing). Neither overwrites an existing file. These back the App Intents Add-Page / Add-Post
- * flows (A.5) and feed the same content graph `list_content` reports.
+ * failing). None overwrites an existing file. `create_page`/`create_post` back the App Intents
+ * Add-Page / Add-Post flows (A.5); `create_content` scaffolds a typed entry (note, article,
+ * event, …) from the shared content-type registry. All feed the content graph `list_content`
+ * reports.
  *
  * @module
  */
 import { mkdirSync, writeFileSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { execFileSync } from "node:child_process";
+import { descriptorById } from "./content-types.mjs";
 
 /**
  * Scaffold a new Astro page under `src/pages/`.
@@ -76,6 +79,42 @@ export function createPost(projectRoot, { title, collection, slug }) {
   };
 }
 
+/**
+ * Scaffold a typed content entry (V-1.2 / #377) from the shared content-type registry. Mirrors the
+ * app's `NativeContentOperations.createTyped`: looks the type up by id, derives a slug from `title`,
+ * renders frontmatter via `renderEntry`, writes the `.md`, and commits — the same write/commit path
+ * as `createPost`. Collection-stored types only; page-stored types (e.g. `businessProfile`) are #345.
+ *
+ * @param {string} projectRoot
+ * @param {{ type: string, title?: string }} input
+ * @returns {{ filePath: string, slug: string, collection: string, type: string, commit: string | null }}
+ */
+export function createTyped(projectRoot, { type, title }) {
+  const descriptor = descriptorById(type);
+  if (!descriptor) throw new Error(`Unknown content type: ${type}`);
+  const collection = descriptor.collection;
+  if (!collection) {
+    throw new Error(`Page-stored type ${type} is not supported by createTyped yet`);
+  }
+
+  const cleanTitle = (title ?? "").trim();
+  const finalSlug = slugify(cleanTitle || descriptor.id);
+  if (!finalSlug) throw new Error("createTyped could not derive a slug");
+
+  const relPath = `src/content/${collection}/${finalSlug}.md`;
+  const abs = join(projectRoot, relPath);
+  if (existsSync(abs)) throw new Error(`A ${collection} entry already exists at ${relPath}`);
+
+  writeFile(abs, renderEntry(descriptor, cleanTitle || null));
+  return {
+    filePath: relPath,
+    slug: finalSlug,
+    collection,
+    type,
+    commit: commitFile(projectRoot, relPath, `anglesite: add ${collection} ${finalSlug}`),
+  };
+}
+
 // MARK: - Templates
 
 function pageTemplate({ title, layoutImport }) {
@@ -105,6 +144,60 @@ tags: []
 
 Write your post here.
 `;
+}
+
+/**
+ * Render a typed entry's file contents from its descriptor: a YAML frontmatter block (one line per
+ * non-markdown field, in declaration order) followed by a placeholder body for the type's `markdown`
+ * field, if any. Pure; byte-faithful to the app's `ContentScaffold.renderEntry` — same ISO 8601
+ * date format (`Date#toISOString`) as `postTemplate`, same field-kind defaults.
+ *
+ * @param {import("./content-types.mjs").ContentTypeDescriptor} descriptor
+ * @param {string | null} title  Value for a `title`/`name` field; other string fields stay empty.
+ * @param {Date} [now]
+ * @returns {string}
+ */
+function renderEntry(descriptor, title, now = new Date()) {
+  const dateTime = now.toISOString();
+
+  const lines = ["---"];
+  let bodyPlaceholder = null;
+  for (const field of descriptor.fields) {
+    switch (field.kind) {
+      case "markdown":
+        bodyPlaceholder = `Write your ${descriptor.displayName.toLowerCase()} here.`;
+        break;
+      case "datetime":
+        lines.push(`${field.name}: ${dateTime}`);
+        break;
+      case "date":
+        lines.push(`${field.name}: ${dateTime.slice(0, 10)}`);
+        break;
+      case "bool":
+        lines.push(`${field.name}: false`);
+        break;
+      case "number":
+        lines.push(`${field.name}: 0`);
+        break;
+      case "stringArray":
+      case "imageArray":
+        lines.push(`${field.name}: []`);
+        break;
+      case "string":
+      case "text":
+      case "url":
+      case "image": {
+        const value = field.name === "title" || field.name === "name" ? (title ?? "") : "";
+        lines.push(`${field.name}: "${escapeYaml(value)}"`);
+        break;
+      }
+    }
+  }
+  lines.push("---");
+
+  let output = lines.join("\n") + "\n";
+  if (bodyPlaceholder) output += `\n${bodyPlaceholder}\n`;
+  return output;
 }
 
 // MARK: - Git (best-effort, commits to HEAD on the current branch)

--- a/server/create-content.mjs
+++ b/server/create-content.mjs
@@ -96,6 +96,11 @@ export function createTyped(projectRoot, { type, title }) {
   if (!collection) {
     throw new Error(`Page-stored type ${type} is not supported by createTyped yet`);
   }
+  // Defence-in-depth: `collection` comes from the hardcoded registry today, but keep the same
+  // path-segment contract `createPost` enforces so a future bad descriptor can't escape src/content.
+  if (!/^[A-Za-z0-9_-]+$/.test(collection)) {
+    throw new Error(`Internal error: invalid collection name in registry: ${collection}`);
+  }
 
   const cleanTitle = (title ?? "").trim();
   const finalSlug = slugify(cleanTitle || descriptor.id);
@@ -191,6 +196,10 @@ function renderEntry(descriptor, title, now = new Date()) {
         lines.push(`${field.name}: "${escapeYaml(value)}"`);
         break;
       }
+      default:
+        // A field kind the Swift catalog added (or a registry typo) would otherwise be silently
+        // dropped from the frontmatter; fail loudly instead. `createTyped` catches and surfaces it.
+        throw new Error(`renderEntry: unhandled field kind "${field.kind}" on field "${field.name}"`);
     }
   }
   lines.push("---");

--- a/server/index-tools.mjs
+++ b/server/index-tools.mjs
@@ -12,7 +12,7 @@ import { recordEdit } from "./edit-history.mjs";
 import { undoEdit } from "./undo-edit.mjs";
 import { listContent } from "./list-content.mjs";
 import { createPage, createPost, createTyped } from "./create-content.mjs";
-import { contentTypeIds } from "./content-types.mjs";
+import { creatableContentTypeIds } from "./content-types.mjs";
 
 /**
  * Build the Anglesite MCP server with every tool registered against `projectRoot`.
@@ -171,7 +171,7 @@ export function buildServer(projectRoot) {
     "Scaffold a typed content entry (e.g. note, article, photo, event, review) as a draft from the shared content-type registry and commit it. Collection-stored types only; does not overwrite an existing entry.",
     {
       type: z
-        .enum(contentTypeIds)
+        .enum(creatableContentTypeIds)
         .describe("Content type id, e.g. note, article, event. Determines the collection and frontmatter."),
       title: z
         .string()

--- a/server/index-tools.mjs
+++ b/server/index-tools.mjs
@@ -11,7 +11,8 @@ import { applyEdit } from "./apply-edit-dispatcher.mjs";
 import { recordEdit } from "./edit-history.mjs";
 import { undoEdit } from "./undo-edit.mjs";
 import { listContent } from "./list-content.mjs";
-import { createPage, createPost } from "./create-content.mjs";
+import { createPage, createPost, createTyped } from "./create-content.mjs";
+import { contentTypeIds } from "./content-types.mjs";
 
 /**
  * Build the Anglesite MCP server with every tool registered against `projectRoot`.
@@ -156,6 +157,30 @@ export function buildServer(projectRoot) {
     ({ title, collection, slug }) => {
       try {
         const result = createPost(projectRoot, { title, collection, slug });
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
+      } catch (error) {
+        return { content: [{ type: "text", text: error.message }], isError: true };
+      }
+    },
+  );
+
+  // Typed content objects (#377 / V-1). Scaffolds an h-entry-family or business entry from the
+  // shared content-type registry, byte-faithful to the app's native createTyped path.
+  server.tool(
+    "create_content",
+    "Scaffold a typed content entry (e.g. note, article, photo, event, review) as a draft from the shared content-type registry and commit it. Collection-stored types only; does not overwrite an existing entry.",
+    {
+      type: z
+        .enum(contentTypeIds)
+        .describe("Content type id, e.g. note, article, event. Determines the collection and frontmatter."),
+      title: z
+        .string()
+        .optional()
+        .describe("Entry title. Used for the title/name field (when the type has one) and as the slug source."),
+    },
+    ({ type, title }) => {
+      try {
+        const result = createTyped(projectRoot, { type, title });
         return { content: [{ type: "text", text: JSON.stringify(result) }] };
       } catch (error) {
         return { content: [{ type: "text", text: error.message }], isError: true };

--- a/test/create-content.test.js
+++ b/test/create-content.test.js
@@ -186,6 +186,12 @@ describe("createTyped", () => {
     expect(() => createTyped(repo, { type: "nope", title: "x" })).toThrow(/unknown content type/i);
   });
 
+  it("a title with path separators cannot escape the collection dir", () => {
+    const result = createTyped(repo, { type: "note", title: "../../../etc/evil" });
+    expect(existsSync(join(repo, "..", "..", "..", "etc", "evil.md"))).toBe(false);
+    expect(result.filePath).toMatch(/^src\/content\/notes\//);
+  });
+
   it("rejects a page-stored type (not yet supported)", () => {
     expect(() => createTyped(repo, { type: "businessProfile", title: "Acme" })).toThrow(/page-stored/i);
   });

--- a/test/create-content.test.js
+++ b/test/create-content.test.js
@@ -3,8 +3,11 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
-import { createPage, createPost } from "../server/create-content.mjs";
+import { createPage, createPost, createTyped } from "../server/create-content.mjs";
 import { parseFrontmatter } from "../server/content-frontmatter.mjs";
+
+/** ISO 8601 date-time with millisecond fraction + Z — must match Swift's `.withFractionalSeconds`. */
+const ISO_MS = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
 let repo;
 
@@ -106,5 +109,100 @@ describe("createPost", () => {
     expect(() => createPost(repo, { title: "Evil", collection: "../../../etc" })).toThrow(/invalid collection/i);
     // Nothing was written outside the project.
     expect(existsSync(join(repo, "..", "..", "..", "etc", "evil.md"))).toBe(false);
+  });
+});
+
+describe("createTyped", () => {
+  /** Pull the raw `publishDate:` (or other dt) value from a frontmatter line. */
+  function dtValue(content, field) {
+    const m = content.match(new RegExp(`^${field}: (.+)$`, "m"));
+    return m && m[1];
+  }
+
+  it("scaffolds a note into its collection, omits the markdown field from frontmatter, and commits", () => {
+    const result = createTyped(repo, { type: "note", title: "Quick thought" });
+
+    expect(result.type).toBe("note");
+    expect(result.collection).toBe("notes");
+    expect(result.slug).toBe("quick-thought");
+    expect(result.filePath).toBe("src/content/notes/quick-thought.md");
+    expect(result.commit).toMatch(/^[0-9a-f]{40}$/);
+
+    // Byte-faithful to ContentScaffold.renderEntry: a note has no title field, body (markdown)
+    // becomes the placeholder body, datetime uses ISO-8601 with milliseconds + Z.
+    const content = readFileSync(join(repo, result.filePath), "utf-8");
+    const publishDate = dtValue(content, "publishDate");
+    expect(publishDate).toMatch(ISO_MS);
+    expect(content).toBe(`---\npublishDate: ${publishDate}\ntags: []\n---\n\nWrite your note here.\n`);
+
+    expect(git(["status", "--porcelain"])).toBe("");
+  });
+
+  it("renders an article: title/name fields take the title, other strings stay empty, dt fields share one timestamp", () => {
+    const result = createTyped(repo, { type: "article", title: 'He said "hi"' });
+
+    expect(result.slug).toBe("he-said-hi");
+    const content = readFileSync(join(repo, result.filePath), "utf-8");
+    const publishDate = dtValue(content, "publishDate");
+    const updated = dtValue(content, "updated");
+    expect(publishDate).toMatch(ISO_MS);
+    expect(updated).toBe(publishDate); // single `now` for every datetime field
+    expect(content).toBe(
+      `---\ntitle: "He said \\"hi\\""\nsummary: ""\npublishDate: ${publishDate}\nupdated: ${updated}\ntags: []\n---\n\nWrite your article here.\n`,
+    );
+  });
+
+  it("uses the `name` field (not `title`) for types that declare it", () => {
+    const result = createTyped(repo, { type: "event", title: "Launch Party" });
+    const content = readFileSync(join(repo, result.filePath), "utf-8");
+    const start = dtValue(content, "start");
+    const end = dtValue(content, "end");
+    expect(content).toBe(
+      `---\nname: "Launch Party"\nstart: ${start}\nend: ${end}\nlocation: ""\n---\n\nWrite your event here.\n`,
+    );
+  });
+
+  it("emits frontmatter-only (no body) for a type without a markdown field", () => {
+    const result = createTyped(repo, { type: "like", title: "" });
+    // Empty title → slug falls back to the descriptor id, matching NativeContentOperations.
+    expect(result.slug).toBe("like");
+    const content = readFileSync(join(repo, result.filePath), "utf-8");
+    const publishDate = dtValue(content, "publishDate");
+    expect(content).toBe(`---\nlikeOf: ""\npublishDate: ${publishDate}\n---\n`);
+  });
+
+  it("renders number fields as 0 and leaves non-title string fields empty even when a title is given", () => {
+    // `review.itemReviewed` is a plain string field (not `title`/`name`), so it stays empty;
+    // `rating` (number) renders as 0.
+    const result = createTyped(repo, { type: "review", title: "My Gadget" });
+    const content = readFileSync(join(repo, result.filePath), "utf-8");
+    const publishDate = dtValue(content, "publishDate");
+    expect(content).toBe(
+      `---\nitemReviewed: ""\nrating: 0\npublishDate: ${publishDate}\n---\n\nWrite your review here.\n`,
+    );
+  });
+
+  it("rejects an unknown content type", () => {
+    expect(() => createTyped(repo, { type: "nope", title: "x" })).toThrow(/unknown content type/i);
+  });
+
+  it("rejects a page-stored type (not yet supported)", () => {
+    expect(() => createTyped(repo, { type: "businessProfile", title: "Acme" })).toThrow(/page-stored/i);
+  });
+
+  it("refuses to overwrite an existing typed entry", () => {
+    createTyped(repo, { type: "note", title: "Dup" });
+    expect(() => createTyped(repo, { type: "note", title: "Dup" })).toThrow(/exists/i);
+  });
+
+  it("still writes the file when the project is not a git repo (commit is null)", () => {
+    const plain = mkdtempSync(join(tmpdir(), "create-content-nogit-"));
+    try {
+      const result = createTyped(plain, { type: "note", title: "Solo" });
+      expect(existsSync(join(plain, result.filePath))).toBe(true);
+      expect(result.commit).toBeNull();
+    } finally {
+      rmSync(plain, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -181,6 +181,7 @@ describe("MCP annotation server", () => {
       expect(names).toEqual([
         "add_annotation",
         "apply_edit",
+        "create_content",
         "create_page",
         "create_post",
         "list_annotations",


### PR DESCRIPTION
Closes #377.

Mirrors the app's `ContentScaffold.renderEntry` / `NativeContentOperations.createTyped` (V-1.2, #344) into the Node MCP sidecar so the MCP create backend reaches typed-content parity with the native path. Until now the MCP path could only scaffold page/post; external MCP consumers (chat assistant, Claude Code CLI) couldn't create typed entries.

## Changes
- **`server/content-types.mjs`** (new) — built-in content-type registry mirrored from the Swift `ContentTypeRegistry` catalog (scaffolding-relevant subset: `id`, `displayName`, `storage`, ordered `fields`). Swift remains the source of truth; mf2/schema.org projections are intentionally not mirrored (scaffolding never reads them).
- **`server/create-content.mjs`** — `createTyped` + `renderEntry`, byte-faithful to the Swift scaffolder: same ISO-8601 date format (`Date#toISOString` ≡ `.withFractionalSeconds`), field-kind defaults, `title`/`name` special-case, markdown-as-body, and the page-stored-type guard (`businessProfile` → not supported yet, #345).
- **`server/index-tools.mjs`** — register the `create_content` MCP tool (`z.enum` over the registry ids).

## Tests
9 new `createTyped` cases in `test/create-content.test.js`:
- Byte-exact frontmatter for note / article / event / like / review (covers markdown-as-body, `name` vs `title` fields, frontmatter-only types, number defaults, YAML escaping, shared `now` across datetime fields).
- Slug fallback to descriptor id on empty title; unknown-type, page-stored, overwrite, and no-git paths.
- Updated the `mcp-server` tool-list assertion to include `create_content`.

Full plugin suite green except one **pre-existing, unrelated** failure (`optimize-images-packaging.test.js` — a sharp/tsx environment issue that fails identically on clean `main`).

## Two-repo follow-on
Per the two-repo protocol, this is the plugin half. The app-side step (bump the bundled-plugin pointer to consume `create_content`) lands separately after this ships in a tagged plugin release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)