### PR TITLE
feat(indieweb): close h-feed, h-event, and webmention-sending gaps

### DIFF
--- a/agent-skills/deploy/SKILL.md
+++ b/agent-skills/deploy/SKILL.md
@@ -3,7 +3,7 @@ name: deploy
 description: "Build, security scan, and deploy to Cloudflare Workers"
 license: ISC
 compatibility: "Designed for Claude Code / compatible agents operating inside an Anglesite project (Astro + Keystatic, Node >=22). Deploy/provisioning steps require a Cloudflare account and Wrangler."
-allowed-tools: Bash(npm run build), Bash(npm run deploy *), Bash(npm run preview *), Bash(npm run ai-linkcheck *), Bash(npm run ai-a11y *), Bash(npm run ai-a14y *), Bash(npm run ai-perf *), Bash(npx wrangler *), Bash(grep *), Bash(find dist/ *), Bash(gh *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git checkout *), Bash(git merge *), Bash(git branch *), Bash(kill *), Write, Read, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__search_cloudflare_documentation
+allowed-tools: Bash(npm run build), Bash(npm run deploy *), Bash(npm run preview *), Bash(npm run ai-linkcheck *), Bash(npm run ai-a11y *), Bash(npm run ai-a14y *), Bash(npm run ai-perf *), Bash(npm run ai-webmention-send *), Bash(npx wrangler *), Bash(grep *), Bash(find dist/ *), Bash(gh *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git checkout *), Bash(git merge *), Bash(git branch *), Bash(kill *), Write, Read, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__search_cloudflare_documentation
 metadata:
   author: "David W. Keith"
   version: "1.2.0"
@@ -165,6 +165,18 @@ Read `AGENTIC_CRAWLERS` from `.site-config`. The default (when unset) is `allow`
 - **`block`** — the owner has declared agentic crawlers shouldn't read this site. Skip this step entirely. (`/anglesite:check` still runs a14y informationally — useful for reference even when blocked, but never blocks deploy.)
 
 Translate the choice for the owner the first time you encounter a site where it isn't set: "Your site is open to AI agents (search summaries, chat browsers, content mappers). I'll check that they can actually read it before each deploy. If you'd rather block agentic crawlers entirely, set `AGENTIC_CRAWLERS=block` in `.site-config` and I'll skip this check."
+
+## Step 2a-webmention — Send webmentions (conditional on Webmention being enabled)
+
+Read `INDIEWEB_WEBMENTION` from `.site-config`. If not `true`, skip this step entirely — the site has no Webmention endpoint set up (`/anglesite:indieweb`).
+
+If `true`, run the build-time webmention sender against the built output:
+
+```sh
+npm run ai-webmention-send
+```
+
+This scans blog posts and notes for outbound links in their content, discovers each target's Webmention endpoint, and sends one — closing the loop with the site's own receiving endpoint (ADR-0020) instead of leaving sending to a third-party tool. Each (post, link) pair is attempted once, ever; state is tracked in `webmention-sent.json` at the project root. Never blocks the deploy — it only logs a summary line (e.g. "3 sent, 12 already sent, 1 no endpoint"). If `webmention-sent.json` changed, it needs to be committed along with any other site changes so the next deploy doesn't re-attempt the same pairs.
 
 ### When the gate runs
 

--- a/agent-skills/indieweb/SKILL.md
+++ b/agent-skills/indieweb/SKILL.md
@@ -371,7 +371,7 @@ Tell the owner what's live and what to expect:
 For each enabled endpoint, explain in one sentence:
 
 - **IndieAuth** — "You can now sign in to IndieWeb services (and any IndieAuth-compatible app) with `https://<SITE_DOMAIN>`. Your tokens are issued by your own server."
-- **Webmention** — "Your site can now receive mentions, replies, and likes from other websites. They appear on your posts automatically as cards showing the sender's name, photo, and a snippet of what they wrote."
+- **Webmention** — "Your site can now receive mentions, replies, and likes from other websites. They appear on your posts automatically as cards showing the sender's name, photo, and a snippet of what they wrote. It also sends webmentions of its own — every `/anglesite:deploy` scans new posts for outbound links and notifies the sites you linked to."
 - **Micropub** — "You can publish to your site from Micropub clients (like phone apps). New posts appear as notes — they're committed to your repo and go live after a rebuild (~1–2 minutes)."
 
 Important caveats to surface:
@@ -385,6 +385,7 @@ Suggest next steps:
 - Run `/anglesite:deploy` to publish the changes
 - Test IndieAuth by signing in at `https://indieauth.com` (or any relying party) with their domain
 - Try posting a note from a Micropub client
+- If Webmention is enabled and the owner uses POSSE (recording syndication links on posts), mention Brid.gy (see "Backfeed from social replies" in `docs/indieweb.md`) — it turns likes/replies/reposts on the syndicated copies back into webmentions on the original post. It's the one piece of the loop that still runs through a third-party service (Brid.gy itself), so frame it as optional, not a default step.
 
 ## Notes
 

--- a/agent-skills/indieweb/references/docs/decisions/0020-active-indieweb.md
+++ b/agent-skills/indieweb/references/docs/decisions/0020-active-indieweb.md
@@ -53,6 +53,8 @@ Chosen option: **compose the `@dwk/*` endpoint handlers into `site-entry.js`**, 
 5. **Webmention display:** received mentions are edge-rendered into target pages with `HTMLRewriter` — no client JS, always current.
 6. **Distribution gate:** the `@dwk/*` packages are unpublished (`0.0.0`); the skill installs from npm and stops gracefully until they ship.
 
+> **Update (2026-07-01):** the `@dwk/*` packages are now published (`0.1.0-beta.2`+). The distribution gate in item 6 no longer blocks — the skill's Step 1 import-smoke-test (see `skills/indieweb/SKILL.md`) now runs against a live, loadable package set rather than stopping at "not yet published."
+
 ### Consequences
 
 * Good, because the owner's identity, tokens, and data live only on their own Cloudflare account — no third-party identity host

--- a/agent-skills/update/references/template/package.json
+++ b/agent-skills/update/references/template/package.json
@@ -19,6 +19,7 @@
     "ai-alt": "tsx scripts/draft-alt.ts",
     "ai-qr": "tsx scripts/qr-generate.ts",
     "ai-linkcheck": "tsx scripts/link-check.ts",
+    "ai-webmention-send": "tsx scripts/send-webmentions.ts",
     "ai-forms-build": "tsx scripts/build-forms-catalog.ts",
     "ai-inbox-fetch": "tsx scripts/fetch-submissions.ts",
     "ai-inbox-export": "tsx scripts/export-submissions.ts",

--- a/docs/decisions/0020-active-indieweb.md
+++ b/docs/decisions/0020-active-indieweb.md
@@ -53,6 +53,8 @@ Chosen option: **compose the `@dwk/*` endpoint handlers into `site-entry.js`**, 
 5. **Webmention display:** received mentions are edge-rendered into target pages with `HTMLRewriter` — no client JS, always current.
 6. **Distribution gate:** the `@dwk/*` packages are unpublished (`0.0.0`); the skill installs from npm and stops gracefully until they ship.
 
+> **Update (2026-07-01):** the `@dwk/*` packages are now published (`0.1.0-beta.2`+). The distribution gate in item 6 no longer blocks — the skill's Step 1 import-smoke-test (see `skills/indieweb/SKILL.md`) now runs against a live, loadable package set rather than stopping at "not yet published."
+
 ### Consequences
 
 * Good, because the owner's identity, tokens, and data live only on their own Cloudflare account — no third-party identity host

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deploy
 description: "Build, security scan, and deploy to Cloudflare Workers"
-allowed-tools: Bash(npm run build), Bash(npm run deploy *), Bash(npm run preview *), Bash(npm run ai-linkcheck *), Bash(npm run ai-a11y *), Bash(npm run ai-a14y *), Bash(npm run ai-perf *), Bash(npx wrangler *), Bash(grep *), Bash(find dist/ *), Bash(gh *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git checkout *), Bash(git merge *), Bash(git branch *), Bash(kill *), Write, Read, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__search_cloudflare_documentation
+allowed-tools: Bash(npm run build), Bash(npm run deploy *), Bash(npm run preview *), Bash(npm run ai-linkcheck *), Bash(npm run ai-a11y *), Bash(npm run ai-a14y *), Bash(npm run ai-perf *), Bash(npm run ai-webmention-send *), Bash(npx wrangler *), Bash(grep *), Bash(find dist/ *), Bash(gh *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git checkout *), Bash(git merge *), Bash(git branch *), Bash(kill *), Write, Read, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__search_cloudflare_documentation
 disable-model-invocation: true
 ---
 
@@ -159,6 +159,18 @@ Read `AGENTIC_CRAWLERS` from `.site-config`. The default (when unset) is `allow`
 - **`block`** — the owner has declared agentic crawlers shouldn't read this site. Skip this step entirely. (`/anglesite:check` still runs a14y informationally — useful for reference even when blocked, but never blocks deploy.)
 
 Translate the choice for the owner the first time you encounter a site where it isn't set: "Your site is open to AI agents (search summaries, chat browsers, content mappers). I'll check that they can actually read it before each deploy. If you'd rather block agentic crawlers entirely, set `AGENTIC_CRAWLERS=block` in `.site-config` and I'll skip this check."
+
+## Step 2a-webmention — Send webmentions (conditional on Webmention being enabled)
+
+Read `INDIEWEB_WEBMENTION` from `.site-config`. If not `true`, skip this step entirely — the site has no Webmention endpoint set up (`/anglesite:indieweb`).
+
+If `true`, run the build-time webmention sender against the built output:
+
+```sh
+npm run ai-webmention-send
+```
+
+This scans blog posts and notes for outbound links in their content, discovers each target's Webmention endpoint, and sends one — closing the loop with the site's own receiving endpoint (ADR-0020) instead of leaving sending to a third-party tool. Each (post, link) pair is attempted once, ever; state is tracked in `webmention-sent.json` at the project root. Never blocks the deploy — it only logs a summary line (e.g. "3 sent, 12 already sent, 1 no endpoint"). If `webmention-sent.json` changed, it needs to be committed along with any other site changes so the next deploy doesn't re-attempt the same pairs.
 
 ### When the gate runs
 

--- a/skills/indieweb/SKILL.md
+++ b/skills/indieweb/SKILL.md
@@ -365,7 +365,7 @@ Tell the owner what's live and what to expect:
 For each enabled endpoint, explain in one sentence:
 
 - **IndieAuth** — "You can now sign in to IndieWeb services (and any IndieAuth-compatible app) with `https://<SITE_DOMAIN>`. Your tokens are issued by your own server."
-- **Webmention** — "Your site can now receive mentions, replies, and likes from other websites. They appear on your posts automatically as cards showing the sender's name, photo, and a snippet of what they wrote."
+- **Webmention** — "Your site can now receive mentions, replies, and likes from other websites. They appear on your posts automatically as cards showing the sender's name, photo, and a snippet of what they wrote. It also sends webmentions of its own — every `/anglesite:deploy` scans new posts for outbound links and notifies the sites you linked to."
 - **Micropub** — "You can publish to your site from Micropub clients (like phone apps). New posts appear as notes — they're committed to your repo and go live after a rebuild (~1–2 minutes)."
 
 Important caveats to surface:
@@ -379,6 +379,7 @@ Suggest next steps:
 - Run `/anglesite:deploy` to publish the changes
 - Test IndieAuth by signing in at `https://indieauth.com` (or any relying party) with their domain
 - Try posting a note from a Micropub client
+- If Webmention is enabled and the owner uses POSSE (recording syndication links on posts), mention Brid.gy (see "Backfeed from social replies" in `docs/indieweb.md`) — it turns likes/replies/reposts on the syndicated copies back into webmentions on the original post. It's the one piece of the loop that still runs through a third-party service (Brid.gy itself), so frame it as optional, not a default step.
 
 ## Notes
 

--- a/template/docs/indieweb.md
+++ b/template/docs/indieweb.md
@@ -14,12 +14,13 @@ These ship with every Anglesite site. No setup needed:
 |---|---|---|
 | `h-card` | Site header (`BaseLayout.astro`) | Machine-readable identity: business name + URL |
 | `h-entry` | Blog posts (`[slug].astro`) | Machine-readable posts: title, date, content, photo, tags |
-| `h-feed` | Blog listing (`/blog/index.astro`) | Machine-readable feed of posts (TODO: add to blog listing page) |
+| `h-feed` | Blog listing (`/blog/index.astro`) | Machine-readable feed of posts |
 | `u-syndication` | Blog posts | Links back to copies on social media |
 | RSS feed | `/rss.xml` | Feed readers and podcast apps |
 | Feed discovery | `<link rel="alternate">` in `<head>` | Feed readers auto-discover the RSS feed |
 | POSSE workflow | Keystatic syndication field | Publish here first, share elsewhere, record the links |
 | Domain ownership | Cloudflare Registrar | Owner controls DNS, email, identity |
+| `h-event` | Events (`/events/index.astro`, `/events/[slug].astro`) | Machine-readable events with `Event` JSON-LD; add entries to the `events` Keystatic collection |
 
 ---
 
@@ -133,35 +134,23 @@ On the blog listing page. Wraps the collection of `h-entry` items so machines ca
 
 ### h-event (events)
 
-For businesses that host events — venues, theaters, farms, fitness studios, breweries, museums, houses of worship. Add `h-event` markup when creating event pages or event listings.
+For businesses that host events — venues, theaters, farms, fitness studios, breweries, museums, houses of worship. Ships as a real feature, not just markup guidance: `/events/index.astro` lists upcoming entries from the `events` Keystatic collection, and `/events/[slug].astro` renders each one with both `h-event` microformats and `Event` JSON-LD (the two serve different audiences — microformats for IndieWeb tools, JSON-LD for search engines).
 
-Properties:
+To add an event, create an entry in the **Events** collection in Keystatic (`title`, `date`, `time`, `endTime`, `location`, `description`, `recurring`, `image`) — the page and both markup formats are generated automatically. No page-authoring needed.
+
+Properties rendered:
 
 - `p-name` — event name
-- `dt-start` — start date/time (ISO 8601)
-- `dt-end` — end date/time (ISO 8601)
+- `dt-start` — start date (ISO 8601, day-level — the schema stores time-of-day as free text, not a timezone-aware value, so only the date is encoded in the datetime attribute; the human-readable time is shown alongside it)
+- `dt-end` — present when `endTime` is set
 - `p-location` — venue name or address
 - `p-summary` — short description
-- `e-content` — full description
+- `e-content` — full description (Markdoc body)
 - `u-url` — link to event page
 
-Example:
+The index page filters one-time events whose `date` has passed; events with a `recurring` value (e.g. "weekly") always stay listed — keep `date` pointed at the next occurrence.
 
-```html
-<article class="h-event">
-  <h2 class="p-name">Fall Harvest Festival</h2>
-  <time class="dt-start" datetime="2025-10-11T10:00:00-05:00">Oct 11, 10am</time> –
-  <time class="dt-end" datetime="2025-10-11T16:00:00-05:00">4pm</time>
-  <span class="p-location">Green Acres Farm, Springfield, IL</span>
-  <div class="e-content">
-    <p>Apple picking, corn maze, hayrides, and cider donuts.</p>
-  </div>
-</article>
-```
-
-Use `h-event` alongside the `Event` JSON-LD structured data that SMB files already recommend. They serve different audiences — microformats for IndieWeb tools, JSON-LD for search engines.
-
-Business types that commonly need events: `event-venue`, `community-theater`, `farm`, `brewery`, `fitness`, `museum`, `house-of-worship`, `bookshop`, `entertainment`, `dance-studio`, `marina`, `tour-guide`.
+Business types that commonly need events: `event-venue`, `community-theater`, `farm`, `brewery`, `fitness`, `museum`, `house-of-worship`, `bookshop`, `entertainment`, `dance-studio`, `marina`, `tour-guide`. Suggest enabling it (adding a link to `/events/`) for these types during `/anglesite:start`.
 
 ---
 
@@ -177,7 +166,7 @@ When to reach for it:
 - The site is on a **custom domain** (identity must be HTTPS-rooted there — the skill refuses on a bare `*.workers.dev` address)
 - It's an opt-in enhancement — don't offer it during `/anglesite:start`
 
-> The `@dwk/*` packages aren't published to npm yet, so `/anglesite:indieweb` reports "not available yet" until they ship. Plugin maintainers: see `docs/platforms/dwk-workers.md` and ADR-0020 for the integration design.
+> The `@dwk/*` packages are published on npm (`0.1.0-beta.2`+). `/anglesite:indieweb`'s Step 1 still runs a live install-and-import smoke test before proceeding — a published version alone isn't a guarantee the compiled build loads cleanly under Node ESM — and reports "not available yet" only if that check fails. Plugin maintainers: see `docs/platforms/dwk-workers.md` and ADR-0020 for the integration design.
 
 ---
 
@@ -221,10 +210,29 @@ Fetch webmentions during `npm run build` and bake them into the HTML. No client-
 
 ### Sending webmentions
 
-When the owner publishes a post that links to another website, the site can notify that website. This is done at build time or deploy time:
+Ships as a real feature when Webmention is enabled — not a third-party pointer. `scripts/send-webmentions.ts` runs as part of `/anglesite:deploy` (gated on `INDIEWEB_WEBMENTION=true`): it scans the built blog posts and notes for external links inside `e-content`, discovers each target's Webmention endpoint (HTTP `Link` header, then `<link rel="webmention">`), and sends one. This closes the loop with the site's own receiving endpoint instead of falling back to `webmention.io` or a manual tool — the self-owned story is complete on both directions.
 
-- Use a tool like `webmention.app` or a build script that scans the post for external links and sends webmentions
-- This is advanced and optional — most SMB sites receive more than they send
+Each `(post, link)` pair is attempted once, ever; the outcome is tracked in `webmention-sent.json` at the project root, which is committed to the repo like `.site-config` so state survives across deploys. Targets are checked against a private/loopback-address guard before any request goes out. Run it directly with `npm run ai-webmention-send`.
+
+### Backfeed from social replies (Brid.gy)
+
+The POSSE workflow (see above) records where a post was syndicated — the `syndication` field, rendered as `u-syndication` links. Those social copies still collect their own likes, replies, and reposts on the silo (X, Mastodon, Bluesky) — none of that activity reaches the canonical post automatically.
+
+[Brid.gy](https://brid.gy) closes that loop: it polls the owner's connected social accounts, matches activity on syndicated posts back to the original via the `u-syndication` link, and sends a webmention to the site for each one — likes, replies, and reposts all show up as regular webmentions in the site's inbox, no different from a mention sent directly. It's a free, well-established IndieWeb community service (not a paid SaaS), but it **is** a third-party dependency — the one piece of the loop that doesn't run entirely on the owner's own infrastructure. Mention it as optional, not a default step.
+
+Prerequisites (all already true for a site with Webmention enabled and POSSE in use):
+
+- `rel="me"` links to the social profiles being connected (passive layer, ships by default)
+- A Webmention receiving endpoint on the owner's domain (`/anglesite:indieweb`, Webmention selected)
+- Syndication links recorded on posts (the owner's normal POSSE habit — see `/anglesite:syndicate`)
+
+Setup (owner-facing, not something the skill automates — Brid.gy account linking happens on brid.gy's own site):
+
+1. Go to `https://brid.gy` and sign in with the site's domain (IndieAuth, since the site already has an endpoint)
+2. Connect each social account Brid.gy supports that the owner posts to
+3. Brid.gy starts polling; new likes/replies/reposts on syndicated copies arrive as webmentions within its normal poll interval — no further setup on the Anglesite side
+
+If the owner later disables Webmention or removes `/anglesite:indieweb`, backfeed simply stops arriving (the receiving endpoint is gone) — nothing to clean up on Brid.gy's side beyond disconnecting the account there.
 
 ---
 
@@ -300,10 +308,10 @@ The owner doesn't need to understand IndieWeb terminology. Here's what matters t
 - [ ] RSS feed at `/rss.xml` with discovery link in `<head>`
 - [ ] Syndication links render as `u-syndication` with `rel="syndication"`
 
-### When creating event pages
+### When creating an event
 
-- [ ] `h-event` markup with dt-start, dt-end, p-name, p-location
-- [ ] Corresponding `Event` JSON-LD structured data
+- [ ] Entry added to the `events` Keystatic collection (title, date, description at minimum)
+- [ ] `/events/[slug].astro` renders `h-event` markup and `Event` JSON-LD automatically — no manual markup needed
 
 ### When owner is ready for advanced features
 

--- a/template/package.json
+++ b/template/package.json
@@ -19,6 +19,7 @@
     "ai-alt": "tsx scripts/draft-alt.ts",
     "ai-qr": "tsx scripts/qr-generate.ts",
     "ai-linkcheck": "tsx scripts/link-check.ts",
+    "ai-webmention-send": "tsx scripts/send-webmentions.ts",
     "ai-forms-build": "tsx scripts/build-forms-catalog.ts",
     "ai-inbox-fetch": "tsx scripts/fetch-submissions.ts",
     "ai-inbox-export": "tsx scripts/export-submissions.ts",

--- a/template/scripts/send-webmentions.ts
+++ b/template/scripts/send-webmentions.ts
@@ -1,0 +1,328 @@
+/**
+ * Build-time webmention sender.
+ *
+ * ADR-0020 composes a receiving @dwk/webmention endpoint into the site
+ * Worker, but a site never sent webmentions for its own outbound links —
+ * the one spot where the self-owned IndieWeb story fell back to "use a
+ * third-party tool" (template/docs/indieweb.md). This script closes that
+ * gap at deploy time: it scans built h-entry pages (blog posts, notes) for
+ * external links in their e-content, discovers each target's webmention
+ * endpoint, and sends one.
+ *
+ * Runs against `dist/` after `astro build`, not against source Markdoc —
+ * `microformats-parser` (already a dependency once Webmention is enabled;
+ * see worker/webmention-inbox.js) scopes extraction to the actual h-entry
+ * content instead of nav/footer boilerplate that a raw regex would also
+ * catch.
+ *
+ * A (source, target) pair is attempted at most once, ever — tracked in a
+ * ledger file committed to the repo (same precedent as `.site-config`:
+ * cross-deploy state lives in a project file, not a Cloudflare binding).
+ * This bounds the number of outbound network calls per deploy and avoids
+ * hammering targets that don't support webmentions.
+ *
+ * Usage: tsx scripts/send-webmentions.ts [--dist dist] [--ledger webmention-sent.json]
+ *
+ * @module
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import dns from "node:dns";
+import { mf2 } from "microformats-parser";
+import { extractLinks, isExternalLink } from "./link-check.js";
+import { readConfig } from "./config.js";
+
+// ---------------------------------------------------------------------------
+// Outbound link extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts external links from the `e-content` of the first `h-entry` in
+ * `html`, resolved to absolute URLs and deduped. Returns `[]` if there's no
+ * h-entry or e-content — links in the nav, footer, or other page chrome are
+ * never included even though they're on the same page.
+ */
+export function extractOutboundLinksFromEntry(html: string, permalink: string): string[] {
+  let items;
+  try {
+    ({ items } = mf2(html, { baseUrl: permalink }));
+  } catch {
+    return [];
+  }
+
+  const entry = items.find((item: { type?: string[] }) => item.type?.includes("h-entry"));
+  const contentHtml: string | undefined =
+    entry?.properties?.content?.[0]?.html ?? entry?.properties?.content?.[0]?.value;
+  if (!contentHtml) return [];
+
+  const siteOrigin = new URL(permalink).origin;
+  const seen = new Set<string>();
+  const links: string[] = [];
+  for (const href of extractLinks(contentHtml)) {
+    let absolute: string;
+    try {
+      absolute = new URL(href, permalink).toString();
+    } catch {
+      continue;
+    }
+    if (!isExternalLink(absolute)) continue;
+    if (new URL(absolute).origin === siteOrigin) continue;
+    if (seen.has(absolute)) continue;
+    seen.add(absolute);
+    links.push(absolute);
+  }
+  return links;
+}
+
+// ---------------------------------------------------------------------------
+// Webmention endpoint discovery
+// ---------------------------------------------------------------------------
+
+const LINK_HEADER_WEBMENTION =
+  /<([^>]+)>\s*;\s*rel\s*=\s*"?(?:[^"]*\s)?webmention(?:\s[^"]*)?"?/i;
+const HTML_LINK_WEBMENTION =
+  /<(?:link|a)\b[^>]*\brel\s*=\s*["'][^"']*\bwebmention\b[^"']*["'][^>]*\bhref\s*=\s*["']([^"']+)["'][^>]*>/i;
+const HTML_LINK_WEBMENTION_ALT =
+  /<(?:link|a)\b[^>]*\bhref\s*=\s*["']([^"']+)["'][^>]*\brel\s*=\s*["'][^"']*\bwebmention\b[^"']*["'][^>]*>/i;
+
+/** Follows the webmention discovery algorithm: HTTP Link header, then HTML `<link>`/`<a rel=webmention>`. */
+export async function discoverWebmentionEndpoint(
+  targetUrl: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<string | null> {
+  let response: Response;
+  try {
+    response = await fetchImpl(targetUrl, {
+      headers: { "User-Agent": "Anglesite-WebmentionSender/1.0" },
+    } as RequestInit);
+  } catch {
+    return null;
+  }
+
+  const linkHeader = response.headers?.get?.("link");
+  if (linkHeader) {
+    const match = LINK_HEADER_WEBMENTION.exec(linkHeader);
+    if (match) return new URL(match[1], targetUrl).toString();
+  }
+
+  let html: string;
+  try {
+    html = await response.text();
+  } catch {
+    return null;
+  }
+
+  const bodyMatch = HTML_LINK_WEBMENTION.exec(html) ?? HTML_LINK_WEBMENTION_ALT.exec(html);
+  if (bodyMatch) return new URL(bodyMatch[1], targetUrl).toString();
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// SSRF guard
+// ---------------------------------------------------------------------------
+
+/** True if `ip` falls in a loopback, private, link-local, or unique-local range. */
+export function isPrivateAddress(ip: string): boolean {
+  if (ip.includes(":")) {
+    const lower = ip.toLowerCase();
+    if (lower === "::1" || lower === "::") return true;
+    if (/^fe80:/i.test(lower)) return true; // link-local
+    if (/^f[cd][0-9a-f]{2}:/i.test(lower)) return true; // unique-local fc00::/7
+    return false;
+  }
+  const parts = ip.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n))) return false;
+  const [a, b] = parts;
+  if (a === 127) return true; // loopback
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  if (a === 169 && b === 254) return true; // link-local
+  if (a === 0) return true; // "this network"
+  return false;
+}
+
+type LookupImpl = (hostname: string) => Promise<{ address: string; family: number }>;
+
+/** Rejects non-http(s) URLs and URLs that resolve to a private/loopback address. Fails closed on lookup error. */
+export async function isSafeUrl(
+  url: string,
+  lookupImpl: LookupImpl = (h) => dns.promises.lookup(h),
+): Promise<boolean> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+
+  try {
+    const { address } = await lookupImpl(parsed.hostname);
+    return !isPrivateAddress(address);
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sending
+// ---------------------------------------------------------------------------
+
+export async function sendWebmention(
+  endpoint: string,
+  source: string,
+  target: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ ok: boolean; status?: number }> {
+  try {
+    const response = await fetchImpl(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ source, target }).toString(),
+    } as RequestInit);
+    return { ok: response.ok, status: response.status };
+  } catch {
+    return { ok: false };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ledger
+// ---------------------------------------------------------------------------
+
+export interface LedgerEntry {
+  status: "sent" | "no-endpoint" | "failed";
+  at: string;
+}
+export type SentLedger = Record<string, LedgerEntry>;
+
+export function loadLedger(path: string): SentLedger {
+  if (!existsSync(path)) return {};
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return {};
+  }
+}
+
+export function saveLedger(path: string, ledger: SentLedger): void {
+  const dir = dirname(path);
+  if (dir && !existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(path, JSON.stringify(ledger, null, 2) + "\n", "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Site scan
+// ---------------------------------------------------------------------------
+
+const SCAN_DIRS = ["blog", "notes"];
+
+/** Permalink pages under blog/ and notes/: `<dir>/<slug>/index.html`, excluding the collection index and archive. */
+function findEntryPages(distDir: string): { file: string; permalink: string }[] {
+  const pages: { file: string; permalink: string }[] = [];
+  for (const collection of SCAN_DIRS) {
+    const collDir = join(distDir, collection);
+    if (!existsSync(collDir)) continue;
+    for (const entry of readdirSync(collDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const file = join(collDir, entry.name, "index.html");
+      if (!existsSync(file)) continue;
+      pages.push({ file, permalink: `/${collection}/${entry.name}/` });
+    }
+  }
+  return pages;
+}
+
+export interface SendSummary {
+  sent: number;
+  skipped: number;
+  noEndpoint: number;
+  failed: number;
+  blocked: number;
+}
+
+export async function sendWebmentionsForSite(options: {
+  distDir: string;
+  siteUrl: string;
+  ledgerPath: string;
+  fetchImpl?: typeof fetch;
+  lookupImpl?: LookupImpl;
+}): Promise<SendSummary> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const lookupImpl = options.lookupImpl;
+  const ledger = loadLedger(options.ledgerPath);
+  const summary: SendSummary = { sent: 0, skipped: 0, noEndpoint: 0, failed: 0, blocked: 0 };
+
+  const siteUrl = options.siteUrl.replace(/\/$/, "");
+  for (const { file, permalink: relPermalink } of findEntryPages(options.distDir)) {
+    const permalink = `${siteUrl}${relPermalink}`;
+    const html = readFileSync(file, "utf-8");
+    const targets = extractOutboundLinksFromEntry(html, permalink);
+
+    for (const target of targets) {
+      const key = `${permalink}|${target}`;
+      if (ledger[key]) {
+        summary.skipped++;
+        continue;
+      }
+
+      const safe = await isSafeUrl(target, lookupImpl);
+      if (!safe) {
+        ledger[key] = { status: "failed", at: new Date().toISOString() };
+        summary.blocked++;
+        continue;
+      }
+
+      const endpoint = await discoverWebmentionEndpoint(target, fetchImpl);
+      if (!endpoint) {
+        ledger[key] = { status: "no-endpoint", at: new Date().toISOString() };
+        summary.noEndpoint++;
+        continue;
+      }
+
+      const result = await sendWebmention(endpoint, permalink, target, fetchImpl);
+      ledger[key] = { status: result.ok ? "sent" : "failed", at: new Date().toISOString() };
+      if (result.ok) summary.sent++;
+      else summary.failed++;
+    }
+  }
+
+  saveLedger(options.ledgerPath, ledger);
+  return summary;
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+if (process.argv[1]?.endsWith("send-webmentions.ts")) {
+  const distArgIdx = process.argv.indexOf("--dist");
+  const distDir = distArgIdx !== -1 ? process.argv[distArgIdx + 1] : "dist";
+  const ledgerArgIdx = process.argv.indexOf("--ledger");
+  const ledgerPath = ledgerArgIdx !== -1 ? process.argv[ledgerArgIdx + 1] : "webmention-sent.json";
+
+  if (!existsSync(distDir)) {
+    console.error(`${distDir} not found — run \`npm run build\` first.`);
+    process.exit(1);
+  }
+
+  const siteDomain = readConfig("SITE_DOMAIN");
+  if (!siteDomain) {
+    console.error("SITE_DOMAIN not set in .site-config — cannot build permalinks.");
+    process.exit(1);
+  }
+
+  sendWebmentionsForSite({
+    distDir,
+    siteUrl: `https://${siteDomain}`,
+    ledgerPath,
+  }).then((summary) => {
+    console.log(
+      `Webmentions: ${summary.sent} sent, ${summary.skipped} already sent, ` +
+        `${summary.noEndpoint} no endpoint, ${summary.failed} failed, ${summary.blocked} blocked (unsafe target)`,
+    );
+  });
+}

--- a/template/src/pages/blog/index.astro
+++ b/template/src/pages/blog/index.astro
@@ -25,32 +25,34 @@ const hasOlderPosts = allPosts.some(
   title="Blog — Latest News, Updates, and Announcements"
   description="Recent posts from the blog with news, updates, and announcements from us."
 >
-  <h1>Blog</h1>
+  <div class="h-feed">
+    <h1 class="p-name">Blog</h1>
 
-  {recentPosts.length === 0 && <p>No recent posts. Check back soon!</p>}
+    {recentPosts.length === 0 && <p>No recent posts. Check back soon!</p>}
 
-  <ul class="post-list">
-    {
-      recentPosts.map((post) => (
-        <li class="h-entry">
-          <a href={`/blog/${post.id}/`} class="u-url">
-            <h2 class="p-name">{post.data.title}</h2>
-          </a>
-          <time
-            class="dt-published"
-            datetime={post.data.publishDate.toISOString()}
-          >
-            {post.data.publishDate.toLocaleDateString("en-US", {
-              year: "numeric",
-              month: "long",
-              day: "numeric",
-            })}
-          </time>
-          <p class="p-summary">{post.data.description}</p>
-        </li>
-      ))
-    }
-  </ul>
+    <ul class="post-list">
+      {
+        recentPosts.map((post) => (
+          <li class="h-entry">
+            <a href={`/blog/${post.id}/`} class="u-url">
+              <h2 class="p-name">{post.data.title}</h2>
+            </a>
+            <time
+              class="dt-published"
+              datetime={post.data.publishDate.toISOString()}
+            >
+              {post.data.publishDate.toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            </time>
+            <p class="p-summary">{post.data.description}</p>
+          </li>
+        ))
+      }
+    </ul>
 
-  {hasOlderPosts && <p><a href="/blog/archive/">View older posts</a></p>}
+    {hasOlderPosts && <p><a href="/blog/archive/">View older posts</a></p>}
+  </div>
 </BaseLayout>

--- a/template/src/pages/events/[slug].astro
+++ b/template/src/pages/events/[slug].astro
@@ -1,0 +1,85 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { getCollection, render } from "astro:content";
+
+export const prerender = true;
+
+export async function getStaticPaths() {
+  const events = await getCollection("events");
+  return events.map((event) => ({
+    params: { slug: event.id },
+    props: { event },
+  }));
+}
+
+const { event } = Astro.props;
+const { Content } = await render(event);
+
+// The schema stores time-of-day as free text (e.g. "7:00 PM"), not a
+// timezone-aware value, so `date` (day-level ISO) is the only value
+// precise enough to encode in dt-start/dt-end and JSON-LD startDate —
+// the human-readable time is shown alongside it, not folded into the
+// datetime attribute.
+const isoDate = event.data.date.toISOString();
+
+const eventJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Event",
+  name: event.data.title,
+  startDate: isoDate,
+  ...(event.data.endTime && { endDate: isoDate }),
+  description: event.data.description,
+  url: new URL(`/events/${event.id}/`, Astro.site).toString(),
+  ...(event.data.location && {
+    location: { "@type": "Place", name: event.data.location },
+  }),
+  eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+  eventStatus: "https://schema.org/EventScheduled",
+};
+---
+
+<BaseLayout
+  title={event.data.title}
+  description={event.data.description}
+  image={event.data.image}
+  jsonLd={eventJsonLd}
+>
+  <article class="h-event">
+    <header>
+      <h1 class="p-name">{event.data.title}</h1>
+      <p class="event__meta">
+        <time class="dt-start" datetime={isoDate}>
+          {event.data.date.toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          })}
+        </time>
+        {event.data.time && <span> · {event.data.time}</span>}
+        {event.data.endTime && (
+          <span>
+            {" "}
+            – <time class="dt-end" datetime={isoDate}>{event.data.endTime}</time>
+          </span>
+        )}
+        {event.data.recurring && <span> · Recurs {event.data.recurring}</span>}
+      </p>
+      {event.data.location && (
+        <p class="p-location">{event.data.location}</p>
+      )}
+    </header>
+
+    <p class="p-summary">{event.data.description}</p>
+
+    <div class="e-content">
+      <Content />
+    </div>
+  </article>
+</BaseLayout>
+
+<style>
+  .event__meta {
+    color: var(--color-muted, #666);
+    font-size: 0.875rem;
+  }
+</style>

--- a/template/src/pages/events/index.astro
+++ b/template/src/pages/events/index.astro
@@ -1,0 +1,82 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { getCollection } from "astro:content";
+
+const today = new Date();
+today.setHours(0, 0, 0, 0);
+
+const allEvents = await getCollection("events");
+
+// One-time events drop off the listing once their date has passed.
+// Recurring events (e.g. "weekly", "monthly") stay listed regardless of
+// `date` — the owner is expected to keep `date` pointing at the next
+// occurrence, but an out-of-date recurring entry shouldn't just vanish.
+const upcomingEvents = allEvents
+  .filter((event) => event.data.recurring || event.data.date >= today)
+  .sort((a, b) => a.data.date.getTime() - b.data.date.getTime());
+
+const eventsJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  itemListElement: upcomingEvents.map((event, index) => ({
+    "@type": "ListItem",
+    position: index + 1,
+    url: new URL(`/events/${event.id}/`, Astro.site).toString(),
+  })),
+};
+---
+
+<BaseLayout
+  title="Events"
+  description="Upcoming events."
+  jsonLd={eventsJsonLd}
+>
+  <h1>Events</h1>
+
+  {upcomingEvents.length === 0 && <p>No upcoming events. Check back soon!</p>}
+
+  <ul class="event-list">
+    {
+      upcomingEvents.map((event) => (
+        <li class="h-event event-list__item">
+          <a href={`/events/${event.id}/`} class="u-url">
+            <h2 class="p-name">{event.data.title}</h2>
+          </a>
+          <p class="event-list__meta">
+            <time class="dt-start" datetime={event.data.date.toISOString()}>
+              {event.data.date.toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            </time>
+            {event.data.time && <span> · {event.data.time}</span>}
+            {event.data.location && (
+              <span>
+                {" "}
+                · <span class="p-location">{event.data.location}</span>
+              </span>
+            )}
+          </p>
+          <p class="p-summary">{event.data.description}</p>
+        </li>
+      ))
+    }
+  </ul>
+</BaseLayout>
+
+<style>
+  .event-list {
+    list-style: none;
+    padding: 0;
+  }
+  .event-list__item {
+    border-bottom: 1px solid var(--color-border, #ddd);
+    padding: 1.5rem 0;
+  }
+  .event-list__meta {
+    color: var(--color-muted, #666);
+    font-size: 0.875rem;
+    margin: 0.25rem 0 0.5rem;
+  }
+</style>

--- a/tests/send-webmentions.test.ts
+++ b/tests/send-webmentions.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Build-time webmention sender (template/scripts/send-webmentions.ts). Closes
+ * the receive-only gap: ADR-0020 composes a receiving @dwk/webmention endpoint,
+ * but nothing sent webmentions for outbound links in the owner's own posts.
+ *
+ * Endpoint discovery and outbound-link extraction are pure functions tested
+ * against canned HTML/mf2 fixtures with an injected `fetchImpl`, mirroring the
+ * pattern in webmention-inbox.test.ts. `isSafeUrl` guards against SSRF via an
+ * injected DNS `lookupImpl` rather than real network resolution.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  discoverWebmentionEndpoint,
+  extractOutboundLinksFromEntry,
+  isPrivateAddress,
+  isSafeUrl,
+  loadLedger,
+  saveLedger,
+  sendWebmention,
+  sendWebmentionsForSite,
+} from "../template/scripts/send-webmentions.ts";
+
+describe("extractOutboundLinksFromEntry()", () => {
+  const PERMALINK = "https://mysite.example/blog/hello/";
+
+  it("extracts only external links from e-content, ignoring nav/footer", () => {
+    const html = `
+      <nav><a href="https://mysite.example/other-post/">nav link</a></nav>
+      <article class="h-entry">
+        <h1 class="p-name">Hello</h1>
+        <div class="e-content">
+          <p>Check out <a href="https://alice.example/post">Alice's post</a>
+          and <a href="/blog/another-post/">my other post</a>.</p>
+        </div>
+      </article>
+      <footer><a href="https://mysite.example/privacy/">Privacy</a></footer>`;
+    const links = extractOutboundLinksFromEntry(html, PERMALINK);
+    expect(links).toEqual(["https://alice.example/post"]);
+  });
+
+  it("dedupes repeated links and resolves relative URLs against the permalink", () => {
+    const html = `
+      <article class="h-entry">
+        <div class="e-content">
+          <a href="https://bob.example/x">one</a>
+          <a href="https://bob.example/x">two</a>
+        </div>
+      </article>`;
+    expect(extractOutboundLinksFromEntry(html, PERMALINK)).toEqual([
+      "https://bob.example/x",
+    ]);
+  });
+
+  it("returns an empty array when there is no h-entry or e-content", () => {
+    expect(extractOutboundLinksFromEntry("<p>no entry here</p>", PERMALINK)).toEqual([]);
+  });
+});
+
+describe("discoverWebmentionEndpoint()", () => {
+  it("prefers the HTTP Link header", async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response("<html></html>", {
+        status: 200,
+        headers: {
+          "content-type": "text/html",
+          link: '<https://target.example/webmention>; rel="webmention"',
+        },
+      }),
+    );
+    const endpoint = await discoverWebmentionEndpoint("https://target.example/post", fetchImpl);
+    expect(endpoint).toBe("https://target.example/webmention");
+  });
+
+  it("falls back to a <link rel=webmention> tag in the HTML body", async () => {
+    const html = `<html><head><link rel="webmention" href="/wm-endpoint"></head></html>`;
+    const fetchImpl = vi.fn(async () => new Response(html, { status: 200 }));
+    const endpoint = await discoverWebmentionEndpoint("https://target.example/post", fetchImpl);
+    expect(endpoint).toBe("https://target.example/wm-endpoint");
+  });
+
+  it("falls back to an <a rel=webmention> tag", async () => {
+    const html = `<html><body><a rel="webmention" href="https://target.example/wm">send</a></body></html>`;
+    const fetchImpl = vi.fn(async () => new Response(html, { status: 200 }));
+    const endpoint = await discoverWebmentionEndpoint("https://target.example/post", fetchImpl);
+    expect(endpoint).toBe("https://target.example/wm");
+  });
+
+  it("returns null when no endpoint is advertised", async () => {
+    const fetchImpl = vi.fn(async () => new Response("<html></html>", { status: 200 }));
+    expect(await discoverWebmentionEndpoint("https://target.example/post", fetchImpl)).toBeNull();
+  });
+
+  it("returns null when the fetch fails", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network error");
+    });
+    expect(await discoverWebmentionEndpoint("https://target.example/post", fetchImpl)).toBeNull();
+  });
+});
+
+describe("isPrivateAddress()", () => {
+  it("flags loopback, private, and link-local ranges", () => {
+    expect(isPrivateAddress("127.0.0.1")).toBe(true);
+    expect(isPrivateAddress("10.1.2.3")).toBe(true);
+    expect(isPrivateAddress("172.16.0.5")).toBe(true);
+    expect(isPrivateAddress("192.168.1.1")).toBe(true);
+    expect(isPrivateAddress("169.254.1.1")).toBe(true);
+    expect(isPrivateAddress("::1")).toBe(true);
+    expect(isPrivateAddress("fc00::1")).toBe(true);
+  });
+
+  it("allows public addresses", () => {
+    expect(isPrivateAddress("93.184.216.34")).toBe(false);
+    expect(isPrivateAddress("2606:2800:220:1::")).toBe(false);
+  });
+});
+
+describe("isSafeUrl()", () => {
+  it("rejects non-http(s) protocols without a DNS lookup", async () => {
+    const lookupImpl = vi.fn();
+    expect(await isSafeUrl("file:///etc/passwd", lookupImpl)).toBe(false);
+    expect(lookupImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects a target that resolves to a private address", async () => {
+    const lookupImpl = vi.fn(async () => ({ address: "127.0.0.1", family: 4 }));
+    expect(await isSafeUrl("https://internal.example/", lookupImpl)).toBe(false);
+  });
+
+  it("allows a target that resolves to a public address", async () => {
+    const lookupImpl = vi.fn(async () => ({ address: "93.184.216.34", family: 4 }));
+    expect(await isSafeUrl("https://public.example/", lookupImpl)).toBe(true);
+  });
+
+  it("fails closed when DNS lookup errors", async () => {
+    const lookupImpl = vi.fn(async () => {
+      throw new Error("ENOTFOUND");
+    });
+    expect(await isSafeUrl("https://nowhere.example/", lookupImpl)).toBe(false);
+  });
+});
+
+describe("sendWebmention()", () => {
+  it("POSTs source and target form-encoded and reports success on 2xx", async () => {
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      expect(init?.method).toBe("POST");
+      expect(String(init?.body)).toBe(
+        "source=https%3A%2F%2Fmy.example%2Fp&target=https%3A%2F%2Fyou.example%2Fq",
+      );
+      return new Response("", { status: 202 });
+    });
+    const result = await sendWebmention(
+      "https://you.example/webmention",
+      "https://my.example/p",
+      "https://you.example/q",
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(result).toEqual({ ok: true, status: 202 });
+  });
+
+  it("reports failure on non-2xx and on network error", async () => {
+    const fetchImpl = vi.fn(async () => new Response("", { status: 400 }));
+    expect(
+      await sendWebmention("https://x/wm", "https://a", "https://b", fetchImpl as unknown as typeof fetch),
+    ).toEqual({ ok: false, status: 400 });
+
+    const throwing = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    expect(
+      await sendWebmention("https://x/wm", "https://a", "https://b", throwing as unknown as typeof fetch),
+    ).toEqual({ ok: false });
+  });
+});
+
+describe("ledger persistence", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "wm-ledger-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("loads an empty ledger when the file does not exist", () => {
+    expect(loadLedger(join(dir, "missing.json"))).toEqual({});
+  });
+
+  it("round-trips through save and load", () => {
+    const path = join(dir, "webmention-sent.json");
+    const ledger = { "https://a|https://b": { status: "sent" as const, at: "2026-07-01T00:00:00.000Z" } };
+    saveLedger(path, ledger);
+    expect(existsSync(path)).toBe(true);
+    expect(loadLedger(path)).toEqual(ledger);
+    expect(readFileSync(path, "utf-8")).toContain("\n");
+  });
+});
+
+describe("sendWebmentionsForSite()", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "wm-site-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writePost(relPath: string, html: string) {
+    const { mkdirSync, writeFileSync } = require("node:fs") as typeof import("node:fs");
+    const { dirname } = require("node:path") as typeof import("node:path");
+    const full = join(dir, "dist", relPath);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, html, "utf-8");
+  }
+
+  it("sends new mentions, skips already-sent ones, and records the outcome", async () => {
+    writePost(
+      "blog/hello/index.html",
+      `<article class="h-entry"><div class="e-content">
+         <a href="https://alice.example/post">Alice</a>
+         <a href="https://bob.example/post">Bob</a>
+       </div></article>`,
+    );
+
+    const ledgerPath = join(dir, "webmention-sent.json");
+    saveLedger(ledgerPath, {
+      "https://mysite.example/blog/hello/|https://bob.example/post": {
+        status: "sent",
+        at: "2026-01-01T00:00:00.000Z",
+      },
+    });
+
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      const u = String(url);
+      if (u === "https://alice.example/post" && init?.method !== "POST") {
+        return new Response("<html></html>", {
+          status: 200,
+          headers: { link: '<https://alice.example/wm>; rel="webmention"' },
+        });
+      }
+      if (u === "https://alice.example/wm" && init?.method === "POST") {
+        return new Response("", { status: 202 });
+      }
+      throw new Error(`unexpected fetch: ${u}`);
+    });
+
+    const result = await sendWebmentionsForSite({
+      distDir: join(dir, "dist"),
+      siteUrl: "https://mysite.example",
+      ledgerPath,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      lookupImpl: vi.fn(async () => ({ address: "93.184.216.34", family: 4 })),
+    });
+
+    expect(result).toEqual({ sent: 1, noEndpoint: 0, failed: 0, blocked: 0, skipped: 1 });
+
+    const ledger = loadLedger(ledgerPath);
+    expect(ledger["https://mysite.example/blog/hello/|https://alice.example/post"].status).toBe(
+      "sent",
+    );
+    // Bob was already recorded and must not have been re-fetched.
+    expect(fetchImpl).not.toHaveBeenCalledWith(
+      expect.stringContaining("bob.example"),
+      expect.anything(),
+    );
+  });
+
+  it("blocks a target that resolves to a private address without sending", async () => {
+    writePost(
+      "notes/abc/index.html",
+      `<article class="h-entry"><div class="e-content"><a href="https://internal.example/x">x</a></div></article>`,
+    );
+    const ledgerPath = join(dir, "webmention-sent.json");
+    const fetchImpl = vi.fn();
+
+    const result = await sendWebmentionsForSite({
+      distDir: join(dir, "dist"),
+      siteUrl: "https://mysite.example",
+      ledgerPath,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      lookupImpl: vi.fn(async () => ({ address: "127.0.0.1", family: 4 })),
+    });
+
+    expect(result.blocked).toBe(1);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(loadLedger(ledgerPath)["https://mysite.example/notes/abc/|https://internal.example/x"].status).toBe(
+      "failed",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Blog listing page was missing the `h-feed` wrapper `/anglesite:check`'s own checklist already expects — every scaffolded site was failing its own audit. Wrapped `template/src/pages/blog/index.astro` to match the pattern already shipped for `/notes`.
- The `events` Keystatic collection had a content schema but no pages — h-event markup was documentation-only. Added `/events/index.astro` and `/events/[slug].astro` rendering `h-event` microformats + `Event` JSON-LD, following the podcast episode page pattern (`jsonLd` prop on `BaseLayout`).
- Webmention was receive-only. Added `template/scripts/send-webmentions.ts`: scans built posts/notes for outbound links via `microformats-parser` (already a dependency once Webmention is enabled), discovers each target's webmention endpoint (`Link` header, then `<link rel="webmention">`), and sends. Wired into `/anglesite:deploy` behind `INDIEWEB_WEBMENTION=true`. Includes a DNS-resolved SSRF guard (blocks private/loopback targets before any request) and a `webmention-sent.json` ledger committed to the repo so a given `(post, link)` pair is attempted once, ever.
- Documented Brid.gy as an optional backfeed path (likes/replies/reposts on syndicated social copies flowing back as webmentions) — framed explicitly as the one third-party piece in an otherwise self-owned stack, not a default step.
- Corrected two stale "`@dwk/*` packages unpublished" notes in ADR-0020 and `template/docs/indieweb.md` — confirmed via `npm view` that they're live at `0.1.0-beta.2`+.

## Paired PR check

- [x] This change is **self-contained** to the plugin (skills / template / docs, no MCP message schema or hook surface change).

## Test plan

- [x] `npm test` — 2812/2813 passing (the one failure is a pre-existing missing `tsx` binary in `node_modules/.bin`, unrelated to this change and reproducible on `main`)
- [x] `npm run build:agent-skills` — regenerated, no longer stale
- [x] `scripts/scaffold.sh`-equivalent (`rsync` copy of `template/`) produces a buildable site; verified via `astro dev` that:
  - `/blog/` renders `<div class="h-feed">` wrapping `h-entry` items
  - `/events/` and `/events/[slug]/` render `h-event` microformats and valid `Event` JSON-LD
  - `send-webmentions.ts` runs end-to-end against real external domains (example.com, iana.org), correctly reports "no endpoint" for both, and is idempotent on re-run (skips already-attempted pairs)
- [x] New test file `tests/send-webmentions.test.ts` — 20 tests covering link extraction, endpoint discovery, the SSRF guard, sending, ledger persistence, and full-site orchestration