### PR TITLE
fix(agent-skills): bundle the relative-import closure of copied scripts

### DIFF
--- a/agent-skills/booking/references/template/scripts/config.ts
+++ b/agent-skills/booking/references/template/scripts/config.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared .site-config parser.
+ *
+ * Reads KEY=value pairs from a flat config file (one per line).
+ * Used by setup, cleanup, check-prereqs, pre-deploy-check, and generate-images.
+ *
+ * @module
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/** Default path to the site config file. */
+const DEFAULT_CONFIG_PATH = resolve(process.cwd(), ".site-config");
+
+/**
+ * Read a value from a KEY=value config file.
+ *
+ * @param key - The key to look up
+ * @param configPath - Path to the config file (defaults to `.site-config` in cwd)
+ * @returns The trimmed value, or undefined if not found or file missing
+ */
+export function readConfig(
+  key: string,
+  configPath: string = DEFAULT_CONFIG_PATH,
+): string | undefined {
+  if (!existsSync(configPath)) return undefined;
+  const content = readFileSync(configPath, "utf-8");
+  return readConfigFromString(content, key);
+}
+
+/**
+ * Parse a KEY=value string and return the value for the given key.
+ * Pure function — no I/O.
+ */
+export function readConfigFromString(
+  content: string,
+  key: string,
+): string | undefined {
+  const match = content.match(new RegExp(`^${key}=(.+)$`, "m"));
+  return match?.[1]?.trim();
+}

--- a/agent-skills/design-import/references/scripts/design-import/canva-colors.mjs
+++ b/agent-skills/design-import/references/scripts/design-import/canva-colors.mjs
@@ -1,0 +1,141 @@
+// Color extraction utilities for Canva design import.
+//
+// Canva published sites apply colors as inline rgb()/rgba() on style attributes
+// rather than CSS custom properties. These functions parse, rank, and classify
+// those colors into Anglesite design token roles.
+
+import {
+  rgbToHex,
+  luminance,
+  isGray,
+  isBrowserDefault,
+} from '../import/wix/color-utils.mjs';
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse rgb() and rgba() values from an array of inline style strings.
+ *
+ * - Handles `rgb(R, G, B)` and `rgba(R, G, B, A)`.
+ * - For rgba(), ignores colors with opacity < 0.5 (nearly transparent).
+ * - Returns ALL occurrences including duplicates so that rankColors() can
+ *   count frequency correctly.
+ *
+ * @param {string[]} styles - Array of inline CSS style attribute values.
+ * @returns {string[]} Lowercase hex color strings with duplicates preserved (e.g. ["#ff0000", "#ff0000", "#0080ff"]).
+ */
+export function parseInlineColors(styles) {
+  const result = [];
+
+  // Match both rgb(...) and rgba(...) patterns with optional whitespace.
+  const RGB_RE = /rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+)\s*)?\)/g;
+
+  for (const style of styles) {
+    let match;
+    RGB_RE.lastIndex = 0;
+    while ((match = RGB_RE.exec(style)) !== null) {
+      const r = Number(match[1]);
+      const g = Number(match[2]);
+      const b = Number(match[3]);
+      const alpha = match[4] !== undefined ? Number(match[4]) : 1;
+
+      // Skip colors that are effectively transparent (opacity < 0.5).
+      if (alpha < 0.5) continue;
+
+      const hex = rgbToHex(r, g, b);
+      result.push(hex.toLowerCase());
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Ranking
+// ---------------------------------------------------------------------------
+
+/**
+ * Count occurrences of each hex color and return sorted by frequency descending.
+ *
+ * @param {string[]} hexList - Array of hex color strings (may contain duplicates).
+ * @returns {{ hex: string, count: number }[]} Colors ranked by frequency descending.
+ */
+export function rankColors(hexList) {
+  if (hexList.length === 0) return [];
+
+  const counts = new Map();
+  for (const hex of hexList) {
+    const key = hex.toLowerCase();
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([hex, count]) => ({ hex, count }));
+}
+
+// ---------------------------------------------------------------------------
+// Role inference
+// ---------------------------------------------------------------------------
+
+/**
+ * Infer CSS custom property roles from a ranked color list.
+ *
+ * Roles:
+ * - background: highest-luminance non-browser-default color
+ * - text: darkest gray (low luminance, low saturation)
+ * - primary: most frequent saturated non-gray color
+ * - accent: second most frequent saturated non-gray color
+ *
+ * Returns null for any role that cannot be determined from the input.
+ *
+ * @param {{ hex: string, count: number }[]} rankedColors - Output of rankColors().
+ * @returns {{ background: string|null, text: string|null, primary: string|null, accent: string|null }}
+ */
+export function inferColorRoles(rankedColors) {
+  const roles = {
+    background: null,
+    text: null,
+    primary: null,
+    accent: null,
+  };
+
+  if (rankedColors.length === 0) return roles;
+
+  // Non-browser-default colors for general use.
+  const nonDefault = rankedColors.filter((c) => !isBrowserDefault(c.hex));
+
+  // Background: highest-luminance non-browser-default color.
+  if (nonDefault.length > 0) {
+    const sorted = [...nonDefault].sort(
+      (a, b) => luminance(b.hex) - luminance(a.hex),
+    );
+    roles.background = sorted[0].hex;
+  }
+
+  // Partition into grays and saturated colors (browser defaults already excluded).
+  const grays = nonDefault.filter((c) => isGray(c.hex));
+  const saturated = nonDefault.filter((c) => !isGray(c.hex));
+
+  // Text: darkest gray (lowest luminance among grays).
+  if (grays.length > 0) {
+    const darkest = [...grays].sort(
+      (a, b) => luminance(a.hex) - luminance(b.hex),
+    );
+    roles.text = darkest[0].hex;
+  }
+
+  // Primary: most frequent saturated color (already ranked by frequency).
+  if (saturated.length > 0) {
+    roles.primary = saturated[0].hex;
+  }
+
+  // Accent: second most frequent saturated color.
+  if (saturated.length > 1) {
+    roles.accent = saturated[1].hex;
+  }
+
+  return roles;
+}

--- a/agent-skills/design-import/references/scripts/design-import/canva-fonts.mjs
+++ b/agent-skills/design-import/references/scripts/design-import/canva-fonts.mjs
@@ -1,0 +1,178 @@
+// Font extraction utilities for Canva design import.
+//
+// Canva loads custom web fonts via @font-face declarations, but also injects
+// its own system fonts. These functions filter out Canva system fonts and map
+// user-chosen web fonts to the closest Anglesite system font stack (ADR-0005).
+
+// ---------------------------------------------------------------------------
+// Canva system fonts to filter out
+// ---------------------------------------------------------------------------
+
+const CANVA_SYSTEM_FONTS = new Set([
+  "canva sans",
+  "canva sans text",
+  "canva sans display",
+  "noto sans",
+  "noto serif",
+  "noto color emoji",
+]);
+
+// ---------------------------------------------------------------------------
+// System font stack definitions
+// ---------------------------------------------------------------------------
+
+const STACKS = {
+  "geometric-sans": 'system-ui, -apple-system, "Segoe UI", sans-serif',
+  "humanist-sans": 'system-ui, -apple-system, "Segoe UI", sans-serif',
+  serif: 'Georgia, "Times New Roman", "Noto Serif", serif',
+  "slab-serif": 'Georgia, "Rockwell", "Times New Roman", serif',
+  monospace: '"SFMono-Regular", "Cascadia Code", "Fira Code", monospace',
+  "default-sans": 'system-ui, -apple-system, "Segoe UI", sans-serif',
+};
+
+// ---------------------------------------------------------------------------
+// Font-to-category map
+// ---------------------------------------------------------------------------
+
+/** @type {Record<string, string>} */
+const FONT_CATEGORIES = {};
+
+/** @param {string[]} fonts @param {string} category */
+function register(fonts, category) {
+  for (const font of fonts) {
+    FONT_CATEGORIES[font.toLowerCase()] = category;
+  }
+}
+
+register(
+  [
+    "Montserrat",
+    "Poppins",
+    "Raleway",
+    "Josefin Sans",
+    "Quicksand",
+    "Comfortaa",
+    "Nunito",
+    "Nunito Sans",
+    "Outfit",
+    "Space Grotesk",
+    "DM Sans",
+    "Lexend",
+  ],
+  "geometric-sans",
+);
+
+register(
+  [
+    "Open Sans",
+    "Lato",
+    "Roboto",
+    "Inter",
+    "Arimo",
+    "Source Sans Pro",
+    "Source Sans 3",
+    "Work Sans",
+    "Barlow",
+    "Cabin",
+    "Ubuntu",
+    "Fira Sans",
+    "Karla",
+    "Rubik",
+    "Manrope",
+    "Plus Jakarta Sans",
+    "Be Vietnam Pro",
+  ],
+  "humanist-sans",
+);
+
+register(
+  [
+    "Playfair Display",
+    "Merriweather",
+    "Lora",
+    "EB Garamond",
+    "Libre Baskerville",
+    "Cormorant Garamond",
+    "Crimson Text",
+    "Bitter",
+    "Frank Ruhl Libre",
+    "DM Serif Display",
+    "DM Serif Text",
+    "Source Serif Pro",
+    "Source Serif 4",
+    "PT Serif",
+    "Spectral",
+    "Vollkorn",
+  ],
+  "serif",
+);
+
+register(
+  [
+    "Roboto Slab",
+    "Arvo",
+    "Zilla Slab",
+    "Crete Round",
+    "Rokkitt",
+    "Josefin Slab",
+    "Slabo 27px",
+  ],
+  "slab-serif",
+);
+
+register(
+  [
+    "Fira Code",
+    "Fira Mono",
+    "Source Code Pro",
+    "JetBrains Mono",
+    "Roboto Mono",
+    "IBM Plex Mono",
+    "Space Mono",
+    "Courier Prime",
+    "DM Mono",
+  ],
+  "monospace",
+);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter @font-face rules to remove Canva system fonts, deduplicate, and
+ * return user-chosen font family names.
+ *
+ * @param {{ family: string }[]} fontFaceRules - Array of objects with a `family` property.
+ * @returns {string[]} Deduplicated user font family names.
+ */
+export function parseCanvaFonts(fontFaceRules) {
+  const seen = new Set();
+  const result = [];
+
+  for (const rule of fontFaceRules) {
+    const family = rule.family;
+    const lower = family.toLowerCase();
+    if (CANVA_SYSTEM_FONTS.has(lower)) continue;
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    result.push(family);
+  }
+
+  return result;
+}
+
+/**
+ * Map a web font family name to the closest system font stack.
+ *
+ * @param {string} fontFamily - The web font family name (e.g. "Montserrat").
+ * @returns {{ stack: string, category: string, original: string }}
+ */
+export function mapToSystemStack(fontFamily) {
+  const category = FONT_CATEGORIES[fontFamily.toLowerCase()] ?? "default-sans";
+  return {
+    stack: STACKS[category],
+    category,
+    original: fontFamily,
+  };
+}

--- a/agent-skills/design-import/references/scripts/import/wix/color-utils.mjs
+++ b/agent-skills/design-import/references/scripts/import/wix/color-utils.mjs
@@ -1,0 +1,171 @@
+// Color analysis utilities for Wix style extraction.
+//
+// These pure functions convert, classify, and rank colors sampled from
+// a rendered Wix page via getComputedStyle(). They power the design-token
+// extraction in wix-playwright.js.
+
+// ---------------------------------------------------------------------------
+// Conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert RGB to hex. Accepts either (r, g, b) numbers or an "rgb(r, g, b)" string.
+ */
+export function rgbToHex(rOrStr, g, b) {
+  let r;
+  if (typeof rOrStr === 'string') {
+    const m = rOrStr.match(/rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)/);
+    if (!m) return rOrStr;
+    r = Number(m[1]);
+    g = Number(m[2]);
+    b = Number(m[3]);
+  } else {
+    r = rOrStr;
+  }
+  return '#' + [r, g, b].map((c) => c.toString(16).padStart(2, '0')).join('');
+}
+
+// ---------------------------------------------------------------------------
+// Perceptual metrics
+// ---------------------------------------------------------------------------
+
+/** Relative luminance per WCAG 2.1 (0 = black, 1 = white). */
+export function luminance(hex) {
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  const toLinear = (c) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+}
+
+/** HSL saturation (0–1). */
+export function saturation(hex) {
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  if (max === min) return 0;
+  const l = (max + min) / 2;
+  return l > 0.5
+    ? (max - min) / (2 - max - min)
+    : (max - min) / (max + min);
+}
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+/** True if a color is perceptually gray (saturation < 0.15). */
+export function isGray(hex) {
+  return saturation(hex) < 0.15;
+}
+
+/** True if a color is a browser default (not a brand color). */
+export function isBrowserDefault(hex) {
+  const defaults = new Set([
+    '#0000ee', // default link blue
+    '#551a8b', // default visited purple
+    '#000000', // pure black
+    '#ffffff', // pure white
+  ]);
+  return defaults.has(hex.toLowerCase());
+}
+
+// ---------------------------------------------------------------------------
+// Ranking
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the top N colors by frequency, excluding browser defaults.
+ */
+export function topColors(samples, n) {
+  const counts = new Map();
+  for (const c of samples) {
+    const hex = c.toLowerCase();
+    if (isBrowserDefault(hex)) continue;
+    counts.set(hex, (counts.get(hex) || 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n)
+    .map(([hex]) => hex);
+}
+
+// ---------------------------------------------------------------------------
+// Token classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify raw color and font samples into Anglesite design tokens.
+ *
+ * @param {Object} colorSamples - { bg: string[], text: string[], heading: string[] }
+ * @param {Object} fontSamples  - { heading: string[], body: string[] }
+ * @returns {Object} Token map: { '--color-bg': '#f3f3f3', '--font-heading': '"Open Sans"', ... }
+ */
+export function classifyTokens(colorSamples, fontSamples) {
+  const tokens = {
+    '--color-bg': null,
+    '--color-text': null,
+    '--color-primary': null,
+    '--color-accent': null,
+    '--color-muted': null,
+    '--font-heading': null,
+    '--font-body': null,
+  };
+
+  // Background: lightest non-default bg sample (page backgrounds are nearly
+  // always light; brand-colored header sections should not win here)
+  const bgCandidates = colorSamples.bg
+    .map((c) => c.toLowerCase())
+    .filter((c) => !isBrowserDefault(c));
+  if (bgCandidates.length > 0) {
+    tokens['--color-bg'] = [...new Set(bgCandidates)]
+      .sort((a, b) => luminance(b) - luminance(a))[0];
+  }
+
+  // Text: most frequent gray from text samples
+  const textGrays = colorSamples.text.filter((c) => isGray(c) && !isBrowserDefault(c));
+  const textTop = topColors(textGrays, 1);
+  tokens['--color-text'] = textTop[0] || null;
+
+  // Heading text: most frequent gray from heading samples (fallback to text)
+  const headingGrays = colorSamples.heading.filter((c) => isGray(c) && !isBrowserDefault(c));
+  if (headingGrays.length === 0 && textTop[0]) {
+    // heading color defaults to text color
+  }
+
+  // Brand colors: saturated colors from text samples
+  const allTextColors = [...colorSamples.text, ...colorSamples.heading];
+  const brandColors = allTextColors.filter((c) => !isGray(c) && !isBrowserDefault(c));
+  const brandTop = topColors(brandColors, 2);
+  tokens['--color-primary'] = brandTop[0] || null;
+  tokens['--color-accent'] = brandTop[1] || null;
+
+  // Muted: second-most-frequent gray (after text color), or first gray that differs
+  const allGrays = [...colorSamples.text, ...colorSamples.heading]
+    .filter((c) => isGray(c) && !isBrowserDefault(c));
+  const grayTop = topColors(allGrays, 2);
+  tokens['--color-muted'] = grayTop.find((c) => c !== tokens['--color-text']) || null;
+
+  // Fonts
+  const quoteFont = (name) => {
+    if (!name) return null;
+    return name.includes(' ') ? `"${name}"` : name;
+  };
+
+  const headingFontTop = topColors(fontSamples.heading.map((f) => f.toLowerCase()), 1);
+  const bodyFontTop = topColors(fontSamples.body.map((f) => f.toLowerCase()), 1);
+
+  // Font names need original casing — find the first match
+  if (headingFontTop[0]) {
+    const original = fontSamples.heading.find((f) => f.toLowerCase() === headingFontTop[0]);
+    tokens['--font-heading'] = quoteFont(original || headingFontTop[0]);
+  }
+  if (bodyFontTop[0]) {
+    const original = fontSamples.body.find((f) => f.toLowerCase() === bodyFontTop[0]);
+    tokens['--font-body'] = quoteFont(original || bodyFontTop[0]);
+  }
+
+  return tokens;
+}

--- a/agent-skills/import/references/scripts/import/wix/color-utils.mjs
+++ b/agent-skills/import/references/scripts/import/wix/color-utils.mjs
@@ -1,0 +1,171 @@
+// Color analysis utilities for Wix style extraction.
+//
+// These pure functions convert, classify, and rank colors sampled from
+// a rendered Wix page via getComputedStyle(). They power the design-token
+// extraction in wix-playwright.js.
+
+// ---------------------------------------------------------------------------
+// Conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert RGB to hex. Accepts either (r, g, b) numbers or an "rgb(r, g, b)" string.
+ */
+export function rgbToHex(rOrStr, g, b) {
+  let r;
+  if (typeof rOrStr === 'string') {
+    const m = rOrStr.match(/rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)/);
+    if (!m) return rOrStr;
+    r = Number(m[1]);
+    g = Number(m[2]);
+    b = Number(m[3]);
+  } else {
+    r = rOrStr;
+  }
+  return '#' + [r, g, b].map((c) => c.toString(16).padStart(2, '0')).join('');
+}
+
+// ---------------------------------------------------------------------------
+// Perceptual metrics
+// ---------------------------------------------------------------------------
+
+/** Relative luminance per WCAG 2.1 (0 = black, 1 = white). */
+export function luminance(hex) {
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  const toLinear = (c) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+}
+
+/** HSL saturation (0–1). */
+export function saturation(hex) {
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  if (max === min) return 0;
+  const l = (max + min) / 2;
+  return l > 0.5
+    ? (max - min) / (2 - max - min)
+    : (max - min) / (max + min);
+}
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+/** True if a color is perceptually gray (saturation < 0.15). */
+export function isGray(hex) {
+  return saturation(hex) < 0.15;
+}
+
+/** True if a color is a browser default (not a brand color). */
+export function isBrowserDefault(hex) {
+  const defaults = new Set([
+    '#0000ee', // default link blue
+    '#551a8b', // default visited purple
+    '#000000', // pure black
+    '#ffffff', // pure white
+  ]);
+  return defaults.has(hex.toLowerCase());
+}
+
+// ---------------------------------------------------------------------------
+// Ranking
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the top N colors by frequency, excluding browser defaults.
+ */
+export function topColors(samples, n) {
+  const counts = new Map();
+  for (const c of samples) {
+    const hex = c.toLowerCase();
+    if (isBrowserDefault(hex)) continue;
+    counts.set(hex, (counts.get(hex) || 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n)
+    .map(([hex]) => hex);
+}
+
+// ---------------------------------------------------------------------------
+// Token classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify raw color and font samples into Anglesite design tokens.
+ *
+ * @param {Object} colorSamples - { bg: string[], text: string[], heading: string[] }
+ * @param {Object} fontSamples  - { heading: string[], body: string[] }
+ * @returns {Object} Token map: { '--color-bg': '#f3f3f3', '--font-heading': '"Open Sans"', ... }
+ */
+export function classifyTokens(colorSamples, fontSamples) {
+  const tokens = {
+    '--color-bg': null,
+    '--color-text': null,
+    '--color-primary': null,
+    '--color-accent': null,
+    '--color-muted': null,
+    '--font-heading': null,
+    '--font-body': null,
+  };
+
+  // Background: lightest non-default bg sample (page backgrounds are nearly
+  // always light; brand-colored header sections should not win here)
+  const bgCandidates = colorSamples.bg
+    .map((c) => c.toLowerCase())
+    .filter((c) => !isBrowserDefault(c));
+  if (bgCandidates.length > 0) {
+    tokens['--color-bg'] = [...new Set(bgCandidates)]
+      .sort((a, b) => luminance(b) - luminance(a))[0];
+  }
+
+  // Text: most frequent gray from text samples
+  const textGrays = colorSamples.text.filter((c) => isGray(c) && !isBrowserDefault(c));
+  const textTop = topColors(textGrays, 1);
+  tokens['--color-text'] = textTop[0] || null;
+
+  // Heading text: most frequent gray from heading samples (fallback to text)
+  const headingGrays = colorSamples.heading.filter((c) => isGray(c) && !isBrowserDefault(c));
+  if (headingGrays.length === 0 && textTop[0]) {
+    // heading color defaults to text color
+  }
+
+  // Brand colors: saturated colors from text samples
+  const allTextColors = [...colorSamples.text, ...colorSamples.heading];
+  const brandColors = allTextColors.filter((c) => !isGray(c) && !isBrowserDefault(c));
+  const brandTop = topColors(brandColors, 2);
+  tokens['--color-primary'] = brandTop[0] || null;
+  tokens['--color-accent'] = brandTop[1] || null;
+
+  // Muted: second-most-frequent gray (after text color), or first gray that differs
+  const allGrays = [...colorSamples.text, ...colorSamples.heading]
+    .filter((c) => isGray(c) && !isBrowserDefault(c));
+  const grayTop = topColors(allGrays, 2);
+  tokens['--color-muted'] = grayTop.find((c) => c !== tokens['--color-text']) || null;
+
+  // Fonts
+  const quoteFont = (name) => {
+    if (!name) return null;
+    return name.includes(' ') ? `"${name}"` : name;
+  };
+
+  const headingFontTop = topColors(fontSamples.heading.map((f) => f.toLowerCase()), 1);
+  const bodyFontTop = topColors(fontSamples.body.map((f) => f.toLowerCase()), 1);
+
+  // Font names need original casing — find the first match
+  if (headingFontTop[0]) {
+    const original = fontSamples.heading.find((f) => f.toLowerCase() === headingFontTop[0]);
+    tokens['--font-heading'] = quoteFont(original || headingFontTop[0]);
+  }
+  if (bodyFontTop[0]) {
+    const original = fontSamples.body.find((f) => f.toLowerCase() === bodyFontTop[0]);
+    tokens['--font-body'] = quoteFont(original || bodyFontTop[0]);
+  }
+
+  return tokens;
+}

--- a/bin/build-agent-skills.ts
+++ b/bin/build-agent-skills.ts
@@ -28,7 +28,7 @@ import {
   cpSync,
   rmSync,
 } from "node:fs";
-import { join, resolve, dirname } from "node:path";
+import { join, resolve, dirname, relative } from "node:path";
 
 const PLUGIN_VAR = "${CLAUDE_PLUGIN_ROOT}";
 
@@ -266,6 +266,40 @@ export function buildSkill(content: string, version: string): BuildResult {
 }
 
 // ---------------------------------------------------------------------------
+// Relative-import walking — bundled scripts must be runnable, so every copied
+// script file drags its relative-import closure into references/ with it.
+// ---------------------------------------------------------------------------
+
+const SCRIPT_FILE_RE = /\.(mjs|cjs|js|ts|mts)$/;
+
+// import/export ... from './x' · side-effect import './x' · dynamic import('./x')
+const RELATIVE_IMPORT_RES = [
+  /(?:import|export)\s[^'"()]*?from\s*['"](\.[^'"]+)['"]/g,
+  /import\s*['"](\.[^'"]+)['"]/g,
+  /import\(\s*['"](\.[^'"]+)['"]\s*\)/g,
+];
+
+/** Static relative import specifiers ('./x.mjs', '../y/z.mjs') in a script. */
+export function relativeImports(source: string): string[] {
+  const specs = new Set<string>();
+  for (const re of RELATIVE_IMPORT_RES) {
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(source)) !== null) specs.add(m[1]);
+  }
+  return [...specs].sort();
+}
+
+/** All script files under a path (the file itself, or a directory walk). */
+function scriptFilesUnder(path: string): string[] {
+  const st = statSync(path);
+  if (st.isFile()) return SCRIPT_FILE_RE.test(path) ? [path] : [];
+  return readdirSync(path, { withFileTypes: true }).flatMap((e) =>
+    scriptFilesUnder(join(path, e.name)),
+  );
+}
+
+// ---------------------------------------------------------------------------
 // emitSkill — write the result + bundled references to disk
 // ---------------------------------------------------------------------------
 
@@ -321,6 +355,26 @@ export function emitSkill(
     // matches on later ones.
     if (st.isFile() && /\$\{CLAUDE_PLUGIN_ROOT\}/.test(readFileSync(src, "utf-8"))) {
       warnings.push(`NESTED REF: references/${relPath} still contains \${CLAUDE_PLUGIN_ROOT}`);
+    }
+    // Follow relative imports so bundled scripts stay runnable: references/
+    // preserves the plugin-root-relative layout, so each import target lands
+    // exactly where the importing file expects it.
+    for (const scriptFile of scriptFilesUnder(src)) {
+      const scriptRel = relative(pluginRoot, scriptFile);
+      for (const spec of relativeImports(readFileSync(scriptFile, "utf-8"))) {
+        let target = resolve(dirname(scriptFile), spec);
+        if (!existsSync(target) && spec.endsWith(".js")) {
+          // TS ESM convention: './x.js' in a .ts file compiles from './x.ts'.
+          const tsTarget = target.replace(/\.js$/, ".ts");
+          if (existsSync(tsTarget)) target = tsTarget;
+        }
+        const targetRel = relative(pluginRoot, target);
+        if (targetRel.startsWith("..") || !existsSync(target)) {
+          warnings.push(`MISSING IMPORT: ${scriptRel} imports ${spec} (${targetRel} not found)`);
+          continue;
+        }
+        copyInto(targetRel);
+      }
     }
   };
 

--- a/docs/dev/agent-skills.md
+++ b/docs/dev/agent-skills.md
@@ -39,6 +39,13 @@ Per `skills/<name>/SKILL.md` it emits `agent-skills/<name>/`:
   (e.g. `references/docs/decisions/0003-...md`). Runtime-computed paths
   (`docs/smb/<BUSINESS_TYPE>.md`) bundle their static parent directory so the path
   resolves at runtime.
+- **Relative JS imports are followed.** Every bundled script (`.mjs`/`.cjs`/`.js`/
+  `.ts`/`.mts`) has its static relative imports (`import … from './x.mjs'`,
+  `export … from`, side-effect and dynamic imports) walked transitively, and the
+  whole closure is copied into `references/` at plugin-root-relative paths — so
+  bundled scripts stay runnable in a standalone install. The TS ESM convention
+  (`./x.js` importing a `./x.ts` source) is resolved. Imports that don't resolve
+  inside the plugin root are surfaced as `MISSING IMPORT` build warnings.
 
 `agent-skills/README.md` is a generated index with per-skill install commands.
 

--- a/tests/build-agent-skills.test.ts
+++ b/tests/build-agent-skills.test.ts
@@ -201,6 +201,89 @@ describe("emitSkill", () => {
     const warnings = emitSkill(result("demo", ["scripts/does-not-exist.mjs"]), pluginRoot, outRoot);
     expect(warnings.some((w) => w.startsWith("MISSING REFERENCE:") && w.includes("does-not-exist"))).toBe(true);
   });
+
+  it("bundles the transitive relative-import closure of a copied script", () => {
+    writePlugin(
+      "scripts/a/entry.mjs",
+      "import { x } from './sibling.mjs';\nimport { y } from '../b/dep.mjs';\nexport const z = x + y;\n",
+    );
+    writePlugin("scripts/a/sibling.mjs", "export { s } from './deep.mjs';\nexport const x = 1;\n");
+    writePlugin("scripts/a/deep.mjs", "export const s = 2;\n");
+    writePlugin("scripts/b/dep.mjs", "export const y = 3;\n");
+    const warnings = emitSkill(result("demo", ["scripts/a/entry.mjs"]), pluginRoot, outRoot);
+    // Direct imports, a re-export chain, and a parent-directory import all land
+    // in references/ at their plugin-root-relative paths.
+    expect(existsSync(join(outRoot, "demo", "references/scripts/a/sibling.mjs"))).toBe(true);
+    expect(existsSync(join(outRoot, "demo", "references/scripts/a/deep.mjs"))).toBe(true);
+    expect(existsSync(join(outRoot, "demo", "references/scripts/b/dep.mjs"))).toBe(true);
+    expect(warnings).toEqual([]);
+  });
+
+  it("warns when a copied script imports a relative path that does not exist", () => {
+    writePlugin("scripts/a/entry.mjs", "import { x } from './gone.mjs';\n");
+    const warnings = emitSkill(result("demo", ["scripts/a/entry.mjs"]), pluginRoot, outRoot);
+    expect(
+      warnings.some((w) => w.startsWith("MISSING IMPORT:") && w.includes("scripts/a/gone.mjs")),
+    ).toBe(true);
+  });
+
+  it("follows relative imports of scripts inside a bundled directory", () => {
+    writePlugin("scripts/dir/tool.mjs", "import { u } from '../shared/util.mjs';\n");
+    writePlugin("scripts/shared/util.mjs", "export const u = 1;\n");
+    const warnings = emitSkill(result("demo", ["scripts/dir"]), pluginRoot, outRoot);
+    expect(existsSync(join(outRoot, "demo", "references/scripts/shared/util.mjs"))).toBe(true);
+    expect(warnings).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bundled scripts must be runnable: every relative import inside a bundled
+// .mjs/.js/.ts file must resolve within the same references/ tree.
+// ---------------------------------------------------------------------------
+
+describe("bundled scripts resolve their relative imports", () => {
+  const SCRIPT_EXT_RE = /\.(mjs|cjs|js|ts|mts)$/;
+  const IMPORT_RES = [
+    /(?:import|export)\s[^'"()]*?from\s*['"](\.[^'"]+)['"]/g, // import/export ... from './x'
+    /import\s*['"](\.[^'"]+)['"]/g, // side-effect: import './x'
+    /import\(\s*['"](\.[^'"]+)['"]\s*\)/g, // dynamic: import('./x')
+  ];
+
+  const walkScripts = (dir: string): string[] => {
+    if (!existsSync(dir)) return [];
+    return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) return walkScripts(p);
+      return SCRIPT_EXT_RE.test(e.name) ? [p] : [];
+    });
+  };
+
+  const bundledSkills = readdirSync(OUT_DIR, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && walkScripts(join(OUT_DIR, e.name, "references")).length > 0)
+    .map((e) => e.name);
+
+  it("covers the skills known to bundle scripts", () => {
+    expect(bundledSkills).toEqual(expect.arrayContaining(["design-import", "import"]));
+  });
+
+  it.each(bundledSkills)("agent-skills/%s bundles the relative-import closure", (name) => {
+    for (const file of walkScripts(join(OUT_DIR, name, "references"))) {
+      const src = readFileSync(file, "utf-8");
+      for (const re of IMPORT_RES) {
+        re.lastIndex = 0;
+        let m: RegExpExecArray | null;
+        while ((m = re.exec(src)) !== null) {
+          const target = resolve(join(file, ".."), m[1]);
+          // TS ESM convention: './x.js' in a .ts file resolves to './x.ts'.
+          const tsTarget = target.replace(/\.js$/, ".ts");
+          expect(
+            existsSync(target) || existsSync(tsTarget),
+            `${file} imports ${m[1]} which is not bundled`,
+          ).toBe(true);
+        }
+      }
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/build-agent-skills.test.ts
+++ b/tests/build-agent-skills.test.ts
@@ -13,6 +13,7 @@ import {
   validateSkill,
   inferCompatibility,
   renderIndex,
+  relativeImports,
 } from "../bin/build-agent-skills.ts";
 
 const ROOT = resolve(__dirname, "..");
@@ -243,11 +244,6 @@ describe("emitSkill", () => {
 
 describe("bundled scripts resolve their relative imports", () => {
   const SCRIPT_EXT_RE = /\.(mjs|cjs|js|ts|mts)$/;
-  const IMPORT_RES = [
-    /(?:import|export)\s[^'"()]*?from\s*['"](\.[^'"]+)['"]/g, // import/export ... from './x'
-    /import\s*['"](\.[^'"]+)['"]/g, // side-effect: import './x'
-    /import\(\s*['"](\.[^'"]+)['"]\s*\)/g, // dynamic: import('./x')
-  ];
 
   const walkScripts = (dir: string): string[] => {
     if (!existsSync(dir)) return [];
@@ -269,18 +265,14 @@ describe("bundled scripts resolve their relative imports", () => {
   it.each(bundledSkills)("agent-skills/%s bundles the relative-import closure", (name) => {
     for (const file of walkScripts(join(OUT_DIR, name, "references"))) {
       const src = readFileSync(file, "utf-8");
-      for (const re of IMPORT_RES) {
-        re.lastIndex = 0;
-        let m: RegExpExecArray | null;
-        while ((m = re.exec(src)) !== null) {
-          const target = resolve(join(file, ".."), m[1]);
-          // TS ESM convention: './x.js' in a .ts file resolves to './x.ts'.
-          const tsTarget = target.replace(/\.js$/, ".ts");
-          expect(
-            existsSync(target) || existsSync(tsTarget),
-            `${file} imports ${m[1]} which is not bundled`,
-          ).toBe(true);
-        }
+      for (const spec of relativeImports(src)) {
+        const target = resolve(join(file, ".."), spec);
+        // TS ESM convention: './x.js' in a .ts file resolves to './x.ts'.
+        const tsTarget = target.replace(/\.js$/, ".ts");
+        expect(
+          existsSync(target) || existsSync(tsTarget),
+          `${file} imports ${spec} which is not bundled`,
+        ).toBe(true);
       }
     }
   });


### PR DESCRIPTION
## Summary

- `bin/build-agent-skills.ts` copied scripts referenced from SKILL.md `${CLAUDE_PLUGIN_ROOT}` paths into `references/` but ignored the scripts' own relative `import` statements, so bundled scripts crashed on import in a standalone agent-skills install (e.g. `design-import`'s `canva-playwright.mjs` imports `./canva-colors.mjs` / `./canva-fonts.mjs`, `import`'s `wix-playwright.mjs` imports `./color-utils.mjs` — none were bundled).
- The emitter now statically walks each copied script's relative import graph (`import`/`export … from`, side-effect, and dynamic imports) and copies the transitive closure into `references/` at plugin-root-relative paths, so imports resolve unchanged. It also resolves the TS ESM convention (`./x.js` compiled from `./x.ts`), which additionally fixes `booking`'s bundled `csp.ts` → `config.ts`. Unresolvable imports surface as `MISSING IMPORT` build warnings instead of silently broken bundles.
- Adds unit tests for the closure walk (re-export chains, parent-directory imports, directory bundles, missing-import warning) plus a sync guard asserting every committed bundled script's relative imports resolve; regenerates `agent-skills/` (5 new bundled files). Documents the behavior in `docs/dev/agent-skills.md`.

## Paired PR check

- [x] This change is **self-contained** to the plugin (skills / hooks / template / docs / MCP server with no consumer-visible contract change).
- [ ] This change **needs a paired PR** in [`Anglesite/Anglesite-app`](https://github.com/Anglesite/Anglesite-app) (MCP message schema, template fields the app reads, hook surface, anything the native app embeds or shells out to). Link it here:

## Test plan

- [x] `npm test` — 126 files, 2832 tests passing (includes the new closure tests and the `agent-skills` sync guards)
- [x] `npm run build:agent-skills` re-run on top of the commit produces zero diff, so CI's `agent-skills-export` job stays green
- [ ] If touching the template: `scripts/scaffold.sh` produces a buildable site (template not touched)
- [ ] If touching the MCP server: paired app PR exercises the new/changed messages (MCP server not touched)

## Reviewer notes

- The bug report also mentioned `canva-safari.mjs` and `../browser/page-functions.mjs`; those files don't exist on `main`/this branch (likely from unlanded work). When they land, the closure walk picks them up automatically and the new sync-guard test enforces it.
- Likewise, the `docs/dev/agent-skills.md` "Relative JS imports are not followed" limitation bullet to remove didn't exist here; the doc now documents the closure-walking behavior in "What the transformer does" instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)