### PR TITLE
test: skip fm alt pass in optimize-images e2e so it doesn't time out locally

### DIFF
--- a/test/optimize-images-packaging.test.js
+++ b/test/optimize-images-packaging.test.js
@@ -118,8 +118,12 @@ describe.skipIf(!hasZsh)('ai-optimize in a scaffolded site (#320)', () => {
     // Run the CLI exactly as `npm run ai-optimize` would, resolving tsx from
     // the plugin's own node_modules (the scaffolded site isn't `npm install`ed
     // in this sandbox, but the script + module are what we're exercising).
+    // --no-alt: on machines where the on-device `fm` model is installed, the
+    // alt-text pass would do a real inference call whose cold model load can
+    // exceed the vitest timeout. Module resolution — what #320 is about — is
+    // unaffected by skipping it.
     const tsx = join(REPO_ROOT, 'node_modules', '.bin', 'tsx');
-    const out = execFileSync(tsx, ['scripts/optimize-images.ts'], {
+    const out = execFileSync(tsx, ['scripts/optimize-images.ts', '--no-alt'], {
       cwd: tmpDir,
       stdio: 'pipe',
       encoding: 'utf-8',


### PR DESCRIPTION
## Summary

- The #320 e2e (`test/optimize-images-packaging.test.js` › "runs the optimize script against a fixture JPEG without ERR_MODULE_NOT_FOUND") ran the CLI without `--no-alt`, so on machines with the on-device `fm` model installed (ADR-0021) the alt-text pass performed a real inference call — a cold model load takes 10–20s, blowing past vitest's 10s default. CI lacks `fm`, so `isFmAvailable()` fails fast there and the test only flaked locally.
- Fix: pass the CLI's existing `--no-alt` flag in the test. Module resolution — what the #320 guard actually protects — is unaffected, and every assertion (`sample.webp` emitted, `originals/sample.jpg` preserved) still holds. The test drops from ~23s to ~0.4s and no longer depends on ambient host tooling.
- Chosen over raising the per-test timeout: `execFileSync` blocks the event loop, so vitest can't interrupt the child anyway (the failure reported 23.5s against a 10s limit) — a bigger timeout would just leave the test hostage to model-load latency.

## Paired PR check

- [x] This change is **self-contained** to the plugin (skills / hooks / template / docs / MCP server with no consumer-visible contract change).
- [ ] This change **needs a paired PR** in [`Anglesite/Anglesite-app`](https://github.com/Anglesite/Anglesite-app) (MCP message schema, template fields the app reads, hook surface, anything the native app embeds or shells out to). Link it here:

## Test plan

- [x] `npx vitest run test/optimize-images-packaging.test.js` — 5/5 pass in ~0.8s (previously the e2e timed out at ~23s on a machine with `fm` installed)
- [x] Full suite: `npm test` — 126 files, 2819 tests, all green
- [x] Verified by isolated timing that the fm alt pass was the slow component: scaffold ~115ms, tsx run 15–23s with the alt pass vs 0.28s with `--no-alt`, and `--no-alt` still produces the WebP variant + preserved original the test asserts on

🤖 Generated with [Claude Code](https://claude.com/claude-code)