### PR TITLE
fix(seo-audit): detect dist/client for Workers Static Assets builds

### DIFF
--- a/template/scripts/pre-deploy-check.ts
+++ b/template/scripts/pre-deploy-check.ts
@@ -20,7 +20,7 @@ import { readdirSync, readFileSync, statSync, existsSync, writeFileSync, mkdirSy
 import { join, extname, resolve, dirname } from "node:path";
 import { readConfig } from "./config.js";
 import { parseProviders, buildAllowedScripts } from "./csp.js";
-import { runAudit as runSeoAudit } from "./seo-audit.js";
+import { runAudit as runSeoAudit, resolveDistDir } from "./seo-audit.js";
 import { formatSeoReport, type AgenticCrawlersPolicy } from "./seo.js";
 
 // ---------------------------------------------------------------------------
@@ -369,10 +369,14 @@ export function runScan(input: { siteDir: string }): ScanReport {
   const failures: ScanFailure[] = [];
   const warnings: ScanWarning[] = [];
 
-  const distDir = resolve(input.siteDir, "dist");
-  if (!existsSync(distDir)) {
-    throw new Error(`dist/ not found at ${distDir} — run \`npm run build\` first.`);
+  const baseDistDir = resolve(input.siteDir, "dist");
+  if (!existsSync(baseDistDir)) {
+    throw new Error(`dist/ not found at ${baseDistDir} — run \`npm run build\` first.`);
   }
+  // The @astrojs/cloudflare adapter (Workers Static Assets) writes the client
+  // build to dist/client/, not dist/ directly — scan the resolved directory
+  // so PII/token/Keystatic checks see the real production output.
+  const distDir = resolveDistDir(baseDistDir);
 
   const configPath = resolve(input.siteDir, ".site-config");
   const readSiteConfig = (key: string): string | undefined => {
@@ -555,12 +559,17 @@ if (process.argv[1]?.endsWith("pre-deploy-check.ts")) {
     }
   }
 
-  const DIST = "dist";
+  const BASE_DIST = "dist";
 
-  if (!existsSync(DIST)) {
+  if (!existsSync(BASE_DIST)) {
     console.error("dist/ not found — run `npm run build` first.");
     process.exit(1);
   }
+
+  // The @astrojs/cloudflare adapter (Workers Static Assets) writes the client
+  // build to dist/client/, not dist/ directly — scan the resolved directory
+  // so PII/token/Keystatic checks see the real production output.
+  const DIST = resolveDistDir(BASE_DIST);
 
   /**
    * Emails the site owner has explicitly approved for publication.

--- a/template/scripts/seo-audit.ts
+++ b/template/scripts/seo-audit.ts
@@ -24,11 +24,16 @@
  *   0  — no critical issues (warnings or nice-to-have are OK, or `--warn-only`)
  *   1  — at least one critical issue
  *
+ * The `@astrojs/cloudflare` adapter (Workers Static Assets) writes the client
+ * build to `dist/client/` rather than `dist/` directly — `runAudit` detects
+ * this and audits the client subdirectory automatically when present.
+ *
  * Usage:
  *   tsx scripts/seo-audit.ts                       # write reports/seo-report.md, log summary
  *   tsx scripts/seo-audit.ts --json                # machine-readable report on stdout
  *   tsx scripts/seo-audit.ts --warn-only           # always exit 0 (non-blocking mode)
  *   tsx scripts/seo-audit.ts --report path.md      # write the report to a custom path
+ *   tsx scripts/seo-audit.ts --distDir out         # audit a non-default build output dir
  */
 
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
@@ -120,6 +125,17 @@ export function findSitemapFile(distDir: string): string | null {
   return null;
 }
 
+/**
+ * Resolve the actual build output directory. The `@astrojs/cloudflare`
+ * adapter (Workers Static Assets) writes the client build to `dist/client/`
+ * rather than `dist/` directly — if that subdirectory exists, audit it
+ * instead of the outer directory.
+ */
+export function resolveDistDir(baseDir: string): string {
+  const clientDir = join(baseDir, "client");
+  return existsSync(clientDir) ? clientDir : baseDir;
+}
+
 // ---------------------------------------------------------------------------
 // Audit
 // ---------------------------------------------------------------------------
@@ -138,7 +154,7 @@ export interface RunAuditOptions {
 }
 
 export function runAudit(opts: RunAuditOptions = {}): SeoAuditReport {
-  const distDir = opts.distDir ?? "dist";
+  const baseDir = opts.distDir ?? "dist";
   const siteUrl = opts.siteUrl ?? "";
   const agenticCrawlers = opts.agenticCrawlers ?? "allow";
 
@@ -146,7 +162,7 @@ export function runAudit(opts: RunAuditOptions = {}): SeoAuditReport {
   let pagesAudited = 0;
   let pagesSkipped = 0;
 
-  if (!existsSync(distDir)) {
+  if (!existsSync(baseDir)) {
     return {
       issues,
       totals: { critical: 0, warning: 0, niceToHave: 0 },
@@ -155,6 +171,7 @@ export function runAudit(opts: RunAuditOptions = {}): SeoAuditReport {
     };
   }
 
+  const distDir = resolveDistDir(baseDir);
   const htmlFiles = walkHtml(distDir);
   const pageData: PageSeoData[] = [];
   const indexedPagePaths: string[] = [];
@@ -206,7 +223,7 @@ export function runAudit(opts: RunAuditOptions = {}): SeoAuditReport {
     issues.push({
       code: "missing-sitemap",
       severity: "warning",
-      message: "No sitemap.xml / sitemap-index.xml found in dist/",
+      message: `No sitemap.xml / sitemap-index.xml found in ${distDir}/`,
       page: "sitemap.xml",
     });
   }
@@ -220,7 +237,7 @@ export function runAudit(opts: RunAuditOptions = {}): SeoAuditReport {
     issues.push({
       code: "missing-robots",
       severity: "warning",
-      message: "No robots.txt found in dist/",
+      message: `No robots.txt found in ${distDir}/`,
       page: "robots.txt",
     });
   }
@@ -249,9 +266,11 @@ if (process.argv[1]?.endsWith("seo-audit.ts")) {
   const reportIdx = args.indexOf("--report");
   const reportPath = reportIdx >= 0 ? args[reportIdx + 1] : "reports/seo-report.md";
   const warnOnly = args.includes("--warn-only");
+  const distDirIdx = args.indexOf("--distDir");
+  const baseDir = distDirIdx >= 0 ? args[distDirIdx + 1] : "dist";
 
-  if (!existsSync("dist")) {
-    console.error("dist/ not found — run `npm run build` first.");
+  if (!existsSync(baseDir)) {
+    console.error(`${baseDir}/ not found — run \`npm run build\` first.`);
     process.exit(warnOnly ? 0 : 1);
   }
 
@@ -260,7 +279,7 @@ if (process.argv[1]?.endsWith("seo-audit.ts")) {
   const agenticCrawlers =
     (readConfig("AGENTIC_CRAWLERS") as AgenticCrawlersPolicy | undefined) ?? "allow";
 
-  const report = runAudit({ distDir: "dist", siteUrl, agenticCrawlers });
+  const report = runAudit({ distDir: baseDir, siteUrl, agenticCrawlers });
 
   if (reportPath) {
     mkdirSync(dirname(reportPath), { recursive: true });

--- a/tests/pre-deploy-scan.test.ts
+++ b/tests/pre-deploy-scan.test.ts
@@ -38,6 +38,20 @@ describe("runScan", () => {
     expect(report.failures).toEqual([]);
   });
 
+  it("scans dist/client/ (Workers Static Assets adapter output) instead of dist/ directly", () => {
+    writeFile(
+      "dist/client/index.html",
+      "<!doctype html><p>Contact us at jane@yourbusiness.com</p>",
+    );
+
+    const report = runScan({ siteDir: site });
+
+    expect(report.ok).toBe(false);
+    expect(report.failures).toHaveLength(1);
+    expect(report.failures[0].category).toBe("pii-email");
+    expect(report.failures[0].file).toBe("dist/client/index.html");
+  });
+
   it("flags a PII email in dist/ HTML as ok=false with a pii-email failure", () => {
     writeFile(
       "dist/index.html",

--- a/tests/seo-audit.test.ts
+++ b/tests/seo-audit.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect, afterEach } from "vitest";
 import {
   htmlPathToUrlPath,
   isNoindex,
@@ -6,6 +9,8 @@ import {
   extractDescription,
   hasJsonLd,
   exitCodeFor,
+  resolveDistDir,
+  runAudit,
   type SeoAuditReport,
 } from "../template/scripts/seo-audit.js";
 
@@ -76,6 +81,64 @@ describe("hasJsonLd", () => {
 
   it("returns false when no JSON-LD is present", () => {
     expect(hasJsonLd(`<script>console.log("hi")</script>`)).toBe(false);
+  });
+});
+
+describe("resolveDistDir", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns dist/client when it exists (Workers Static Assets adapter)", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "seo-audit-"));
+    mkdirSync(join(tmpDir, "client"), { recursive: true });
+    expect(resolveDistDir(tmpDir)).toBe(join(tmpDir, "client"));
+  });
+
+  it("returns the base dir when no client subdirectory exists", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "seo-audit-"));
+    expect(resolveDistDir(tmpDir)).toBe(tmpDir);
+  });
+});
+
+describe("runAudit with a client subdirectory", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("finds sitemap.xml and robots.txt under dist/client, not dist/", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "seo-audit-"));
+    const clientDir = join(tmpDir, "client");
+    mkdirSync(clientDir, { recursive: true });
+    writeFileSync(
+      join(clientDir, "index.html"),
+      "<html><head><title>Home</title><meta name=\"description\" content=\"Home page\"></head></html>",
+    );
+    writeFileSync(join(clientDir, "sitemap-index.xml"), "<urlset></urlset>");
+    writeFileSync(join(clientDir, "robots.txt"), "User-agent: *\nAllow: /\n");
+
+    const report = runAudit({ distDir: tmpDir, siteUrl: "https://example.com" });
+
+    expect(report.issues.some((i) => i.code === "missing-sitemap")).toBe(false);
+    expect(report.issues.some((i) => i.code === "missing-robots")).toBe(false);
+    expect(report.pagesAudited).toBe(1);
+  });
+
+  it("reports the resolved client dir path, not the base dir, when files are missing", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "seo-audit-"));
+    mkdirSync(join(tmpDir, "client"), { recursive: true });
+    writeFileSync(join(tmpDir, "client", "index.html"), "<html><head></head></html>");
+
+    const report = runAudit({ distDir: tmpDir });
+    const sitemapIssue = report.issues.find((i) => i.code === "missing-sitemap");
+    const robotsIssue = report.issues.find((i) => i.code === "missing-robots");
+
+    expect(sitemapIssue?.message).toContain(join(tmpDir, "client"));
+    expect(robotsIssue?.message).toContain(join(tmpDir, "client"));
   });
 });
 

--- a/tests/seo-audit.test.ts
+++ b/tests/seo-audit.test.ts
@@ -128,6 +128,20 @@ describe("runAudit with a client subdirectory", () => {
     expect(report.pagesAudited).toBe(1);
   });
 
+  it("computes page paths relative to dist/client, without a leading client/ segment", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "seo-audit-"));
+    const aboutDir = join(tmpDir, "client", "about");
+    mkdirSync(aboutDir, { recursive: true });
+    // No <title> — triggers a missing-title issue whose `page` field is the
+    // computed urlPath, so a `client/` prefix leaking through would show up here.
+    writeFileSync(join(aboutDir, "index.html"), "<html><head></head></html>");
+
+    const report = runAudit({ distDir: tmpDir });
+    const missingTitle = report.issues.find((i) => i.code === "missing-title");
+
+    expect(missingTitle?.page).toBe("/about/");
+  });
+
   it("reports the resolved client dir path, not the base dir, when files are missing", () => {
     tmpDir = mkdtempSync(join(tmpdir(), "seo-audit-"));
     mkdirSync(join(tmpDir, "client"), { recursive: true });


### PR DESCRIPTION
## Summary
- `seo-audit.ts` hardcoded `distDir: "dist"`, but the `@astrojs/cloudflare` adapter (Workers Static Assets) writes the client build to `dist/client/`. This caused false-positive "missing sitemap.xml" / "missing robots.txt" warnings, and page paths reported with a leading `client/` segment (e.g. `/client/about/` instead of `/about/`).
- Added `resolveDistDir()`, which auto-detects a `client/` subdirectory under the given base dir and audits it instead when present.
- Added a `--distDir` CLI flag so the base build directory can be overridden explicitly.
- Missing-sitemap/missing-robots messages now report the actual resolved directory instead of a hardcoded `dist/`.

Fixes #390

## Test plan
- [x] `npx vitest run tests/seo-audit.test.ts` — added coverage for `resolveDistDir` and for `runAudit` finding sitemap/robots/pages under a `dist/client/` layout via real temp directories; all 20 tests pass.
- [x] Full suite: 2877/2878 passing (the one pre-existing failure is an unrelated environment issue — missing `tsx`/`jsdom` install for `optimize-images-packaging.test.js`, untouched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)