### PR TITLE
feat(server): add pagination/filtering to list_content and list_annotations

### DIFF
--- a/server/annotations.mjs
+++ b/server/annotations.mjs
@@ -70,12 +70,26 @@ export function addAnnotation(projectRoot, { path, selector, text, sourceFile })
   return annotation;
 }
 
-/** List annotations, optionally filtered by page path. Excludes resolved by default. */
-export function listAnnotations(projectRoot, path) {
+/**
+ * List annotations, optionally filtered by page path. Excludes resolved by default.
+ *
+ * @param {string} projectRoot
+ * @param {string} [path] filter to a single page path
+ * @param {{ resolved?: boolean, limit?: number, offset?: number }} [options]
+ *   `resolved`: include resolved annotations too (default false — unresolved only, #392).
+ *   `limit`/`offset`: paginate the (already-filtered) result (#392).
+ */
+export function listAnnotations(projectRoot, path, { resolved = false, limit, offset = 0 } = {}) {
   let annotations = loadAnnotations(projectRoot);
-  annotations = annotations.filter((a) => !a.resolved);
+  if (!resolved) {
+    annotations = annotations.filter((a) => !a.resolved);
+  }
   if (path !== undefined) {
     annotations = annotations.filter((a) => a.path === path);
+  }
+  annotations = annotations.slice(offset);
+  if (limit !== undefined) {
+    annotations = annotations.slice(0, limit);
   }
   return annotations;
 }

--- a/server/index-tools.mjs
+++ b/server/index-tools.mjs
@@ -75,9 +75,15 @@ export function buildServer(projectRoot) {
     "List unresolved feedback annotations",
     {
       path: z.string().optional().describe("Filter by page path"),
+      resolved: z
+        .boolean()
+        .optional()
+        .describe("Include resolved annotations too. Default false (unresolved only)."),
+      limit: z.number().int().positive().optional().describe("Max annotations to return"),
+      offset: z.number().int().nonnegative().optional().describe("Skip this many before applying limit"),
     },
-    ({ path }) => {
-      const annotations = listAnnotations(projectRoot, path);
+    ({ path, resolved, limit, offset }) => {
+      const annotations = listAnnotations(projectRoot, path, { resolved, limit, offset });
       return { content: [{ type: "text", text: JSON.stringify(annotations) }] };
     },
   );
@@ -139,9 +145,20 @@ export function buildServer(projectRoot) {
   server.tool(
     "list_content",
     "List the site's pages, article-like content-collection entries (posts, notes, episodes, experiments), and images under public/images, as structured JSON. Read-only; the filesystem is the source of truth.",
-    {},
-    () => {
-      const listing = listContent(projectRoot);
+    {
+      type: z
+        .enum(["pages", "posts", "images"])
+        .optional()
+        .describe("Return only this bucket; the other two come back empty. Default: all three."),
+      limit: z.number().int().positive().optional().describe("Max entries to return per bucket"),
+      offset: z.number().int().nonnegative().optional().describe("Skip this many entries per bucket before applying limit"),
+      fields: z
+        .array(z.string())
+        .optional()
+        .describe("Project each entry down to only these field names, e.g. [\"title\", \"filePath\"]"),
+    },
+    ({ type, limit, offset, fields }) => {
+      const listing = listContent(projectRoot, { type, limit, offset, fields });
       return { content: [{ type: "text", text: JSON.stringify(listing) }] };
     },
   );

--- a/server/list-content.mjs
+++ b/server/list-content.mjs
@@ -29,16 +29,38 @@ const IMAGE_EXTENSIONS = new Set([".jpg", ".jpeg", ".png", ".webp", ".gif", ".sv
  */
 const ARTICLE_COLLECTIONS = new Set(["posts", "notes", "episodes", "experiments"]);
 
+const BUCKET_SCANNERS = { pages: scanPages, posts: scanPosts, images: scanImages };
+
 /**
  * @param {string} projectRoot absolute path to the site root
+ * @param {object} [options]
+ * @param {"pages"|"posts"|"images"} [options.type] scan only this bucket; the other two come
+ *   back empty instead of being walked (#392) — saves the filesystem walk, not just the tokens.
+ * @param {number} [options.limit] cap each returned bucket to this many entries
+ * @param {number} [options.offset] skip this many entries per bucket before applying `limit`
+ * @param {string[]} [options.fields] project each entry down to only these keys
  * @returns {{ pages: object[], posts: object[], images: object[] }}
  */
-export function listContent(projectRoot) {
-  return {
-    pages: scanPages(projectRoot),
-    posts: scanPosts(projectRoot),
-    images: scanImages(projectRoot),
-  };
+export function listContent(projectRoot, { type, limit, offset = 0, fields } = {}) {
+  const buckets = type ? [type] : Object.keys(BUCKET_SCANNERS);
+  const result = { pages: [], posts: [], images: [] };
+  for (const bucket of buckets) {
+    let entries = BUCKET_SCANNERS[bucket](projectRoot);
+    entries = entries.slice(offset);
+    if (limit !== undefined) entries = entries.slice(0, limit);
+    if (fields !== undefined) entries = entries.map((e) => pick(e, fields));
+    result[bucket] = entries;
+  }
+  return result;
+}
+
+/** Project `obj` down to only the requested keys. Unknown keys are silently ignored. */
+function pick(obj, keys) {
+  const out = {};
+  for (const key of keys) {
+    if (key in obj) out[key] = obj[key];
+  }
+  return out;
 }
 
 // MARK: - Pages

--- a/test/list-content.test.js
+++ b/test/list-content.test.js
@@ -131,3 +131,62 @@ describe("listContent — empty / missing dirs", () => {
     expect(result).toEqual({ pages: [], posts: [], images: [] });
   });
 });
+
+describe("listContent — pagination and filtering (#392)", () => {
+  beforeEach(() => {
+    write("src/pages/about.astro", `<BaseLayout title="About" description="x" />`);
+    write("src/pages/contact.astro", `<BaseLayout title="Contact" description="x" />`);
+    write(
+      "src/content/posts/a.md",
+      `---\ntitle: A\ndescription: d\npublishDate: 2026-06-01\n---\nbody`,
+    );
+    write(
+      "src/content/posts/b.md",
+      `---\ntitle: B\ndescription: d\npublishDate: 2026-06-02\n---\nbody`,
+    );
+    write("public/images/hero.jpg", "fakejpgbytes");
+  });
+
+  it("with no options, behaves exactly as before (all buckets, unfiltered)", () => {
+    const result = listContent(root);
+    expect(result.pages).toHaveLength(2);
+    expect(result.posts).toHaveLength(2);
+    expect(result.images).toHaveLength(1);
+  });
+
+  it("type filters to a single bucket, leaving the others empty", () => {
+    const result = listContent(root, { type: "posts" });
+    expect(result.posts).toHaveLength(2);
+    expect(result.pages).toEqual([]);
+    expect(result.images).toEqual([]);
+  });
+
+  it("limit caps entries per bucket", () => {
+    const result = listContent(root, { limit: 1 });
+    expect(result.pages).toHaveLength(1);
+    expect(result.posts).toHaveLength(1);
+  });
+
+  it("offset skips entries before applying limit", () => {
+    const all = listContent(root, { type: "posts" });
+    const paged = listContent(root, { type: "posts", offset: 1 });
+    expect(paged.posts).toEqual(all.posts.slice(1));
+  });
+
+  it("offset past the end returns an empty bucket", () => {
+    const result = listContent(root, { type: "posts", offset: 100 });
+    expect(result.posts).toEqual([]);
+  });
+
+  it("fields projects each entry down to the requested keys", () => {
+    const result = listContent(root, { type: "posts", fields: ["title", "slug"] });
+    for (const post of result.posts) {
+      expect(Object.keys(post).sort()).toEqual(["slug", "title"]);
+    }
+  });
+
+  it("fields ignores unknown key names", () => {
+    const result = listContent(root, { type: "posts", fields: ["title", "nonexistent"] });
+    expect(Object.keys(result.posts[0])).toEqual(["title"]);
+  });
+});

--- a/tests/annotations.test.ts
+++ b/tests/annotations.test.ts
@@ -275,6 +275,39 @@ describe("listAnnotations", () => {
     const result = listAnnotations(tmpDir);
     expect(result).toHaveLength(2);
   });
+
+  // ---------------------------------------------------------------------------
+  // pagination / resolved filter (#392)
+  // ---------------------------------------------------------------------------
+
+  it("includes resolved annotations when resolved: true", () => {
+    const all = loadAnnotations(tmpDir);
+    resolveAnnotation(tmpDir, all[0].id);
+    const result = listAnnotations(tmpDir, undefined, { resolved: true });
+    expect(result).toHaveLength(3);
+  });
+
+  it("limit caps the returned annotations", () => {
+    const result = listAnnotations(tmpDir, undefined, { limit: 2 });
+    expect(result).toHaveLength(2);
+  });
+
+  it("offset skips annotations before applying limit", () => {
+    const all = listAnnotations(tmpDir);
+    const paged = listAnnotations(tmpDir, undefined, { offset: 1 });
+    expect(paged).toEqual(all.slice(1));
+  });
+
+  it("offset past the end returns an empty array", () => {
+    const result = listAnnotations(tmpDir, undefined, { offset: 100 });
+    expect(result).toEqual([]);
+  });
+
+  it("combines path filter with limit/offset", () => {
+    const result = listAnnotations(tmpDir, "/about", { limit: 1 });
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe("/about");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #392. `list_content` and `list_annotations` previously returned their entire result set as a single unbounded blob on every call — an agent asking "what blog posts exist?" paid for the whole site inventory (pages + posts + images) every time. Tool results are the dominant token cost in agentic sessions, so this follows the windowed-response pattern `apply_edit` already uses for its before/after diff.

- **`list_content`** (`server/list-content.mjs`, `server/index-tools.mjs`): new optional params
  - `type`: `"pages" | "posts" | "images"` — scan and return only that bucket (skips walking the other two entirely, not just trimming the response)
  - `limit` / `offset`: paginate each returned bucket
  - `fields`: project each entry down to a whitelist of keys (e.g. `["title", "filePath"]`)
- **`list_annotations`** (`server/annotations.mjs`, `server/index-tools.mjs`): new optional params
  - `resolved`: include resolved annotations too (default stays unresolved-only)
  - `limit` / `offset`: paginate

All new params are optional and additive — omitting them reproduces the exact current behavior, so this is not a breaking change for existing callers (including the Anglesite-app's `ContentListing.parse`).

## Test plan

- [x] New unit tests in `test/list-content.test.js` (type filter, per-bucket limit/offset, out-of-range offset, fields projection, unknown-field handling)
- [x] New unit tests in `tests/annotations.test.ts` (resolved filter, limit/offset, combined with existing path filter)
- [x] `npx vitest run test/list-content.test.js tests/annotations.test.ts tests/mcp-server.test.ts test/mcp-http-transport.test.js` — 54/54 passed
- [x] Full `npm test` — 2885/2886 passed (the one failure, `optimize-images-packaging.test.js`, is a pre-existing local environment issue — missing `tsx`/`jsdom` binaries — unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)