### PR TITLE
feat(mcp): get_component_model tool (Component Editor slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+- `get_component_model` MCP tool: structured read-only model of an `.astro`
+  component (template tree, Props interface, style rules, client script) for
+  the app's Component Editor (Slice 1).
+
 ## [1.0.0-beta.7] — 2026-05-07
 
 Big beta. Nine new user-invocable skills round out the 1.0 commerce, community, and ops surface; analytics gets honest about what it's measuring; deploy learns about agent readability and performance budgets.

--- a/agent-skills/update/references/package.json
+++ b/agent-skills/update/references/package.json
@@ -47,7 +47,9 @@
     "playwright": "^1.52.0"
   },
   "dependencies": {
+    "@astrojs/compiler": "^4.0.0",
     "@modelcontextprotocol/sdk": "^1.28.0",
+    "css-tree": "^3.2.1",
     "sharp": "^0.33.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
+        "@astrojs/compiler": "^4.0.0",
         "@modelcontextprotocol/sdk": "^1.28.0",
+        "css-tree": "^3.2.1",
         "sharp": "^0.33.0"
       },
       "devDependencies": {
@@ -82,6 +84,12 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@astrojs/compiler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
+      "integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
@@ -2362,7 +2370,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.27.1",
@@ -3811,7 +3818,6 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
@@ -5441,7 +5447,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "playwright": "^1.52.0"
   },
   "dependencies": {
+    "@astrojs/compiler": "^4.0.0",
     "@modelcontextprotocol/sdk": "^1.28.0",
+    "css-tree": "^3.2.1",
     "sharp": "^0.33.0"
   }
 }

--- a/server/component-model.mjs
+++ b/server/component-model.mjs
@@ -7,6 +7,7 @@ import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { parse } from "@astrojs/compiler";
 import { parse as parseCss, generate, walk } from "css-tree";
+import { parseProps } from "./props-interface.mjs";
 
 export class ComponentModelError extends Error {
   constructor(reason, message) {
@@ -57,13 +58,34 @@ export async function buildComponentModel(projectRoot, relPath) {
   collectElements(ast, "style", styleElements);
   const styles = styleElements.flatMap((el) => extractRules(el));
 
+  const fmNode = topLevel.find((n) => n.type === "frontmatter");
+  const frontmatter = fmNode
+    ? {
+        source: fmNode.value ?? "",
+        span: [fmNode.position?.start?.offset ?? null, fmNode.position?.end?.offset ?? null],
+        props: parseProps(fmNode.value ?? ""),
+      }
+    : null;
+
+  const scriptElements = [];
+  collectElements(ast, "script", scriptElements);
+  const scriptText = scriptElements
+    .map((el) => (el.children ?? []).find((c) => c.type === "text"))
+    .find((t) => t?.value);
+  const clientScript = scriptText
+    ? {
+        source: scriptText.value,
+        span: [scriptText.position?.start?.offset ?? null, scriptText.position?.end?.offset ?? null],
+      }
+    : null;
+
   return {
     version: fileVersion(projectRoot, source),
     path: relPath,
     template,
-    frontmatter: null, // Task 3
+    frontmatter,
     styles,
-    clientScript: null, // Task 3
+    clientScript,
   };
 }
 

--- a/server/component-model.mjs
+++ b/server/component-model.mjs
@@ -4,7 +4,6 @@
 import { readFileSync } from "node:fs";
 import { join, normalize } from "node:path";
 import { createHash } from "node:crypto";
-import { execFileSync } from "node:child_process";
 import { parse } from "@astrojs/compiler";
 import { parse as parseCss, generate, walk } from "css-tree";
 import { parseProps } from "./props-interface.mjs";
@@ -80,7 +79,7 @@ export async function buildComponentModel(projectRoot, relPath) {
     : null;
 
   return {
-    version: fileVersion(projectRoot, source),
+    version: fileVersion(source),
     path: relPath,
     template,
     frontmatter,
@@ -192,10 +191,10 @@ class NodeBuilder {
   }
 }
 
-function fileVersion(projectRoot, source) {
-  try {
-    return execFileSync("git", ["rev-parse", "HEAD"], { cwd: projectRoot, encoding: "utf-8" }).trim();
-  } catch {
-    return "sha256:" + createHash("sha256").update(source).digest("hex").slice(0, 12);
-  }
+// Content hash, not a git SHA: apply_edit commits land on the hidden
+// anglesite/edits branch without moving HEAD, so a repo-level SHA would stay
+// constant across edits — useless as a staleness token. Hashing the file
+// content means the version changes exactly when the model's source does.
+function fileVersion(source) {
+  return "sha256:" + createHash("sha256").update(source).digest("hex").slice(0, 12);
 }

--- a/server/component-model.mjs
+++ b/server/component-model.mjs
@@ -6,6 +6,7 @@ import { join, normalize } from "node:path";
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { parse } from "@astrojs/compiler";
+import { parse as parseCss, generate, walk } from "css-tree";
 
 export class ComponentModelError extends Error {
   constructor(reason, message) {
@@ -52,14 +53,70 @@ export async function buildComponentModel(projectRoot, relPath) {
       .filter(Boolean),
   };
 
+  const styleElements = [];
+  collectElements(ast, "style", styleElements);
+  const styles = styleElements.flatMap((el) => extractRules(el));
+
   return {
     version: fileVersion(projectRoot, source),
     path: relPath,
     template,
     frontmatter: null, // Task 3
-    styles: [], // Task 2
+    styles,
     clientScript: null, // Task 3
   };
+}
+
+function collectElements(node, name, out) {
+  if (node.type === "element" && node.name === name) out.push(node);
+  for (const child of node.children ?? []) collectElements(child, name, out);
+}
+
+function extractRules(styleElement) {
+  const textChild = (styleElement.children ?? []).find((c) => c.type === "text");
+  if (!textChild?.value) return [];
+  const baseOffset = textChild.position?.start?.offset ?? 0;
+  let cssAst;
+  try {
+    cssAst = parseCss(textChild.value, {
+      positions: true,
+      parseValue: false,
+      parseAtrulePrelude: false,
+    });
+  } catch {
+    return []; // unparseable CSS: styles stay empty; template/props still usable
+  }
+  const rules = [];
+  walk(cssAst, {
+    visit: "Rule",
+    enter(node) {
+      const media =
+        this.atrule && this.atrule.name === "media" && this.atrule.prelude
+          ? generate(this.atrule.prelude).trim()
+          : null;
+      const declarations = [];
+      node.block.children.forEach((decl) => {
+        if (decl.type !== "Declaration") return;
+        declarations.push({
+          property: decl.property,
+          value: generate(decl.value).trim(),
+          span: cssSpan(decl.loc, baseOffset),
+        });
+      });
+      rules.push({
+        selector: generate(node.prelude),
+        media,
+        span: cssSpan(node.loc, baseOffset),
+        declarations,
+      });
+    },
+  });
+  return rules;
+}
+
+function cssSpan(loc, baseOffset) {
+  if (!loc) return [null, null];
+  return [baseOffset + loc.start.offset, baseOffset + loc.end.offset];
 }
 
 // style/script/frontmatter are zones, not template nodes.

--- a/server/component-model.mjs
+++ b/server/component-model.mjs
@@ -1,0 +1,122 @@
+// Builds a structured, read-only model of one .astro component for the
+// Component Editor (spec: Anglesite-app docs/superpowers/specs/
+// 2026-07-05-component-editor-design.md §2.2).
+import { readFileSync } from "node:fs";
+import { join, normalize } from "node:path";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { parse } from "@astrojs/compiler";
+
+export class ComponentModelError extends Error {
+  constructor(reason, message) {
+    super(message);
+    this.reason = reason;
+  }
+}
+
+export async function buildComponentModel(projectRoot, relPath) {
+  if (
+    typeof relPath !== "string" ||
+    !relPath.endsWith(".astro") ||
+    normalize(relPath).startsWith("..") ||
+    relPath.startsWith("/")
+  ) {
+    throw new ComponentModelError("invalid-input", `not a project-relative .astro path: ${relPath}`);
+  }
+  const absPath = join(projectRoot, relPath);
+  let source;
+  try {
+    source = readFileSync(absPath, "utf-8");
+  } catch (err) {
+    throw new ComponentModelError("read-failed", `read ${relPath}: ${err.message}`);
+  }
+  let ast;
+  try {
+    ({ ast } = await parse(source, { position: true }));
+  } catch (err) {
+    throw new ComponentModelError("parse-failed", `parse ${relPath}: ${err.message}`);
+  }
+
+  const builder = new NodeBuilder();
+  const topLevel = ast.children ?? [];
+  const template = {
+    id: builder.nextId(),
+    kind: "fragment",
+    tag: null,
+    attrs: [],
+    span: [0, source.length],
+    loc: null,
+    children: topLevel
+      .filter((n) => !isZoneNode(n))
+      .map((n) => builder.toNode(n))
+      .filter(Boolean),
+  };
+
+  return {
+    version: fileVersion(projectRoot, source),
+    path: relPath,
+    template,
+    frontmatter: null, // Task 3
+    styles: [], // Task 2
+    clientScript: null, // Task 3
+  };
+}
+
+// style/script/frontmatter are zones, not template nodes.
+function isZoneNode(n) {
+  return n.type === "frontmatter" || (n.type === "element" && (n.name === "style" || n.name === "script"));
+}
+
+class NodeBuilder {
+  #next = 0;
+  nextId() {
+    return `n${this.#next++}`;
+  }
+  toNode(n) {
+    switch (n.type) {
+      case "element":
+        return this.#make(n, n.name === "slot" ? "slot" : "element", n.name);
+      case "component":
+      case "custom-element":
+        return this.#make(n, "component", n.name);
+      case "expression":
+        return { ...this.#base(n), kind: "expression", tag: null, attrs: [], children: [] };
+      case "text": {
+        const value = (n.value ?? "").trim();
+        if (!value) return null;
+        return { ...this.#base(n), kind: "text", tag: null, attrs: [], text: value.slice(0, 80), children: [] };
+      }
+      default:
+        return null; // comment, doctype, fragment wrappers
+    }
+  }
+  #make(n, kind, tag) {
+    return {
+      ...this.#base(n),
+      kind,
+      tag,
+      attrs: (n.attributes ?? []).map((a) => ({ name: a.name, value: a.value ?? null })),
+      children: (n.children ?? [])
+        .filter((c) => !isZoneNode(c))
+        .map((c) => this.toNode(c))
+        .filter(Boolean),
+    };
+  }
+  #base(n) {
+    const start = n.position?.start;
+    const end = n.position?.end;
+    return {
+      id: this.nextId(),
+      span: [start?.offset ?? null, end?.offset ?? null],
+      loc: start ? { line: start.line, column: start.column } : null,
+    };
+  }
+}
+
+function fileVersion(projectRoot, source) {
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], { cwd: projectRoot, encoding: "utf-8" }).trim();
+  } catch {
+    return "sha256:" + createHash("sha256").update(source).digest("hex").slice(0, 12);
+  }
+}

--- a/server/index-tools.mjs
+++ b/server/index-tools.mjs
@@ -15,6 +15,7 @@ import { undoEdit } from "./undo-edit.mjs";
 import { listContent } from "./list-content.mjs";
 import { createPage, createPost, createTyped } from "./create-content.mjs";
 import { creatableContentTypeIds } from "./content-types.mjs";
+import { buildComponentModel, ComponentModelError } from "./component-model.mjs";
 
 /**
  * The plugin version is the single source of truth (`bin/release.ts` keeps the
@@ -137,6 +138,35 @@ export function buildServer(projectRoot) {
         content: [{ type: "text", text: JSON.stringify(result) }],
         isError: result.status === "refused",
       };
+    },
+  );
+
+  server.tool(
+    "get_component_model",
+    "Parse an .astro component into a structured, read-only model: template node tree with source spans, frontmatter Props interface, scoped style rules, and client script zone. Used by the app's Component Editor.",
+    {
+      path: z.string().describe("Component path relative to the project root, e.g. src/components/Card.astro"),
+    },
+    async ({ path }) => {
+      try {
+        const model = await buildComponentModel(projectRoot, path);
+        return { content: [{ type: "text", text: JSON.stringify(model) }] };
+      } catch (err) {
+        const reason = err instanceof ComponentModelError ? err.reason : "parse-failed";
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                type: "anglesite:component-model-failed",
+                reason,
+                detail: String(err?.message ?? err),
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
     },
   );
 

--- a/server/index-tools.mjs
+++ b/server/index-tools.mjs
@@ -152,7 +152,10 @@ export function buildServer(projectRoot) {
         const model = await buildComponentModel(projectRoot, path);
         return { content: [{ type: "text", text: JSON.stringify(model) }] };
       } catch (err) {
-        const reason = err instanceof ComponentModelError ? err.reason : "parse-failed";
+        // Distinguish real syntax problems (ComponentModelError.parse-failed)
+        // from bugs in this tool — the app should not tell the user their
+        // component is invalid because we threw a TypeError.
+        const reason = err instanceof ComponentModelError ? err.reason : "internal-error";
         return {
           content: [
             {

--- a/server/props-interface.mjs
+++ b/server/props-interface.mjs
@@ -17,8 +17,23 @@ export function parseProps(frontmatterSource) {
       const dm = part.match(/^\s*(\w+)\s*=\s*(.+?)\s*$/s);
       if (!dm) continue;
       const prop = props.find((p) => p.name === dm[1]);
-      if (prop) prop.default = dm[2].trim();
+      if (prop && isBalanced(dm[2].trim())) prop.default = dm[2].trim();
     }
   }
   return props;
+}
+
+// A comma inside a default (array/object/call/string literal) makes the naive
+// comma-split above produce a truncated chunk. Rather than return that
+// silently-wrong value, require balanced brackets and quotes and leave
+// `default` null (unknown) when the chunk fails the check.
+function isBalanced(value) {
+  const pairs = { "(": ")", "[": "]", "{": "}" };
+  const open = [];
+  for (const ch of value) {
+    if (pairs[ch]) open.push(pairs[ch]);
+    else if (Object.values(pairs).includes(ch) && open.pop() !== ch) return false;
+  }
+  const quotesEven = ['"', "'", "`"].every((q) => (value.split(q).length - 1) % 2 === 0);
+  return open.length === 0 && quotesEven;
 }

--- a/server/props-interface.mjs
+++ b/server/props-interface.mjs
@@ -1,0 +1,24 @@
+// Heuristic Props extraction from Astro frontmatter TypeScript. Deliberately
+// regex-based (no TS compiler in the container): supports `interface Props`
+// or `type Props = { ... }` with one `name?: type;` member per line, and
+// defaults from `const { name = value } = Astro.props`. Anything fancier
+// yields [] — the editor treats that as "no knobs", never an error.
+export function parseProps(frontmatterSource) {
+  const block = frontmatterSource.match(/(?:interface\s+Props|type\s+Props\s*=)\s*\{([\s\S]*?)\n\}/);
+  if (!block) return [];
+  const props = [];
+  for (const line of block[1].split("\n")) {
+    const m = line.match(/^\s*(\w+)(\?)?\s*:\s*([^;]+);?\s*(?:\/\/.*)?$/);
+    if (m) props.push({ name: m[1], type: m[3].trim(), optional: Boolean(m[2]), default: null });
+  }
+  const destructure = frontmatterSource.match(/const\s*\{([\s\S]*?)\}\s*=\s*Astro\.props/);
+  if (destructure) {
+    for (const part of destructure[1].split(",")) {
+      const dm = part.match(/^\s*(\w+)\s*=\s*(.+?)\s*$/s);
+      if (!dm) continue;
+      const prop = props.find((p) => p.name === dm[1]);
+      if (prop) prop.default = dm[2].trim();
+    }
+  }
+  return props;
+}

--- a/tests/component-model.test.ts
+++ b/tests/component-model.test.ts
@@ -115,4 +115,28 @@ describe("buildComponentModel", () => {
     const [s, e] = plain.declarations[0].span;
     expect(CARD.slice(s, e)).toContain("padding");
   });
+
+  it("extracts frontmatter with a parsed Props interface", async () => {
+    const model = await buildComponentModel(tmpDir, "src/components/Card.astro");
+    expect(model.frontmatter?.source).toContain("interface Props");
+    expect(model.frontmatter?.props).toEqual([
+      { name: "title", type: "string", optional: false, default: null },
+      { name: "count", type: "number", optional: true, default: "1" },
+    ]);
+  });
+
+  it("extracts the client script zone", async () => {
+    const model = await buildComponentModel(tmpDir, "src/components/Card.astro");
+    expect(model.clientScript?.source).toContain("card mounted");
+    const [s, e] = model.clientScript!.span;
+    expect(CARD.slice(s!, e!)).toContain("card mounted");
+  });
+
+  it("returns null zones and empty props when absent", async () => {
+    writeFileSync(join(tmpDir, "src", "components", "Bare.astro"), `<p>hello</p>\n`);
+    const model = await buildComponentModel(tmpDir, "src/components/Bare.astro");
+    expect(model.frontmatter).toBeNull();
+    expect(model.clientScript).toBeNull();
+    expect(model.styles).toEqual([]);
+  });
 });

--- a/tests/component-model.test.ts
+++ b/tests/component-model.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildComponentModel } from "../server/component-model.mjs";
+
+const CARD = `---
+interface Props {
+  title: string;
+  count?: number;
+}
+const { title, count = 1 } = Astro.props;
+---
+<article class="card">
+  <h2>{title}</h2>
+  <slot />
+</article>
+
+<style>
+  .card { padding: 1rem; }
+  @media (max-width: 600px) {
+    .card { padding: 0.5rem; }
+  }
+</style>
+
+<script>
+  console.log("card mounted");
+</script>
+`;
+
+describe("buildComponentModel", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-cm-"));
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), CARD);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("builds the template tree with kinds, spans, and locs", async () => {
+    const model = await buildComponentModel(tmpDir, "src/components/Card.astro");
+    expect(model.path).toBe("src/components/Card.astro");
+    expect(model.version).toMatch(/^(sha256:[0-9a-f]{12}|[0-9a-f]{40})$/);
+
+    expect(model.template.kind).toBe("fragment");
+    const article = model.template.children[0];
+    expect(article.kind).toBe("element");
+    expect(article.tag).toBe("article");
+    expect(article.attrs).toEqual([{ name: "class", value: "card" }]);
+    expect(article.span[0]).toBeGreaterThan(0);
+    expect(article.loc?.line).toBeGreaterThan(0);
+
+    const [h2, slot] = article.children;
+    expect(h2.tag).toBe("h2");
+    expect(h2.children[0].kind).toBe("expression");
+    expect(slot.kind).toBe("slot");
+
+    // ids unique across the tree
+    const ids = new Set<string>();
+    const visit = (n: { id: string; children: { id: string }[] }) => {
+      expect(ids.has(n.id)).toBe(false);
+      ids.add(n.id);
+      (n.children as any[]).forEach(visit);
+    };
+    visit(model.template as any);
+  });
+
+  it("classifies component instances", async () => {
+    writeFileSync(
+      join(tmpDir, "src", "components", "Page.astro"),
+      `<div>\n  <Card title="hi" />\n</div>\n`,
+    );
+    const model = await buildComponentModel(tmpDir, "src/components/Page.astro");
+    const card = model.template.children[0].children[0];
+    expect(card.kind).toBe("component");
+    expect(card.tag).toBe("Card");
+    expect(card.attrs).toEqual([{ name: "title", value: "hi" }]);
+  });
+
+  it("rejects traversal and non-astro paths", async () => {
+    await expect(buildComponentModel(tmpDir, "../etc/passwd")).rejects.toMatchObject({
+      reason: "invalid-input",
+    });
+    await expect(buildComponentModel(tmpDir, "src/components/Card.css")).rejects.toMatchObject({
+      reason: "invalid-input",
+    });
+  });
+
+  it("reports read failures", async () => {
+    await expect(buildComponentModel(tmpDir, "src/components/Missing.astro")).rejects.toMatchObject({
+      reason: "read-failed",
+    });
+  });
+});

--- a/tests/component-model.test.ts
+++ b/tests/component-model.test.ts
@@ -44,7 +44,7 @@ describe("buildComponentModel", () => {
   it("builds the template tree with kinds, spans, and locs", async () => {
     const model = await buildComponentModel(tmpDir, "src/components/Card.astro");
     expect(model.path).toBe("src/components/Card.astro");
-    expect(model.version).toMatch(/^(sha256:[0-9a-f]{12}|[0-9a-f]{40})$/);
+    expect(model.version).toMatch(/^sha256:[0-9a-f]{12}$/);
 
     expect(model.template.kind).toBe("fragment");
     const article = model.template.children[0];
@@ -138,5 +138,43 @@ describe("buildComponentModel", () => {
     expect(model.frontmatter).toBeNull();
     expect(model.clientScript).toBeNull();
     expect(model.styles).toEqual([]);
+  });
+
+  it("version tracks file content, not repo state", async () => {
+    const before = await buildComponentModel(tmpDir, "src/components/Card.astro");
+    writeFileSync(
+      join(tmpDir, "src", "components", "Card.astro"),
+      CARD.replace("card mounted", "card remounted"),
+    );
+    const after = await buildComponentModel(tmpDir, "src/components/Card.astro");
+    expect(before.version).not.toBe(after.version);
+
+    // Same content → same version, regardless of when it's computed.
+    const again = await buildComponentModel(tmpDir, "src/components/Card.astro");
+    expect(again.version).toBe(after.version);
+  });
+
+  it("leaves defaults null rather than truncating comma-containing values", async () => {
+    writeFileSync(
+      join(tmpDir, "src", "components", "List.astro"),
+      `---
+interface Props {
+  items: string[];
+  label?: string;
+  count?: number;
+}
+const { items = ["a", "b"], label = "hello, world", count = 2 } = Astro.props;
+---
+<ul></ul>
+`,
+    );
+    const model = await buildComponentModel(tmpDir, "src/components/List.astro");
+    expect(model.frontmatter?.props).toEqual([
+      // Comma-split truncates these chunks; better null than wrong.
+      { name: "items", type: "string[]", optional: false, default: null },
+      { name: "label", type: "string", optional: true, default: null },
+      // Simple defaults still come through.
+      { name: "count", type: "number", optional: true, default: "2" },
+    ]);
   });
 });

--- a/tests/component-model.test.ts
+++ b/tests/component-model.test.ts
@@ -95,4 +95,24 @@ describe("buildComponentModel", () => {
       reason: "read-failed",
     });
   });
+
+  it("extracts style rules with media context and file-absolute spans", async () => {
+    const model = await buildComponentModel(tmpDir, "src/components/Card.astro");
+    expect(model.styles).toHaveLength(2);
+
+    const [plain, mobile] = model.styles;
+    expect(plain.selector).toBe(".card");
+    expect(plain.media).toBeNull();
+    expect(plain.declarations).toEqual([
+      expect.objectContaining({ property: "padding", value: "1rem" }),
+    ]);
+
+    expect(mobile.selector).toBe(".card");
+    expect(mobile.media).toContain("max-width");
+    expect(mobile.declarations[0].value).toBe("0.5rem");
+
+    // file-absolute span: the source slice at the declaration span mentions the property
+    const [s, e] = plain.declarations[0].span;
+    expect(CARD.slice(s, e)).toContain("padding");
+  });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -184,6 +184,7 @@ describe("MCP annotation server", () => {
         "create_content",
         "create_page",
         "create_post",
+        "get_component_model",
         "list_annotations",
         "list_content",
         "resolve_annotation",
@@ -496,6 +497,54 @@ describe("MCP annotation server", () => {
 
       // File must be byte-identical — dry_run must not mutate disk
       expect(readFileSync(filePath)).toEqual(before);
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("get_component_model returns a structured model over stdio", async () => {
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "src", "components", "Card.astro"),
+      `---\ninterface Props {\n  title: string;\n}\nconst { title } = Astro.props;\n---\n<article class="card"><h2>{title}</h2></article>\n<style>.card { padding: 1rem; }</style>\n`,
+    );
+    const proc = startServer(tmpDir);
+    try {
+      await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      });
+      sendNotification(proc, { jsonrpc: "2.0", method: "notifications/initialized" });
+
+      const response = await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "get_component_model", arguments: { path: "src/components/Card.astro" } },
+      });
+      const result = response.result as { content: { text: string }[]; isError?: boolean };
+      expect(result.isError).toBeFalsy();
+      const model = JSON.parse(result.content[0].text);
+      expect(model.path).toBe("src/components/Card.astro");
+      expect(model.template.children[0].tag).toBe("article");
+      expect(model.frontmatter.props[0].name).toBe("title");
+      expect(model.styles[0].selector).toBe(".card");
+
+      const failure = await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "get_component_model", arguments: { path: "src/components/Nope.astro" } },
+      });
+      const failResult = failure.result as { content: { text: string }[]; isError?: boolean };
+      expect(failResult.isError).toBe(true);
+      expect(JSON.parse(failResult.content[0].text).reason).toBe("read-failed");
     } finally {
       proc.kill();
     }

--- a/tests/source-loc-convention.test.ts
+++ b/tests/source-loc-convention.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { transform } from "@astrojs/compiler";
+
+// Pins the `data-astro-source-loc` annotation convention that the Component
+// Editor's selection-sync depends on (Anglesite-app `ComponentOutline.node(atLine:column:in:)`
+// and `JS/edit-overlay/src/component-canvas.ts`'s `highlight`/`findByLoc`): Astro's dev
+// server (via `transform(..., { annotateSourceFile: true })`) stamps the annotation at the
+// END of an element's opening tag, not at its parse position. An element parsed at line L
+// column 1 is annotated `L:C` for some `C > 1` — line matches, column never does exactly.
+// If a future `@astrojs/compiler` version changes this convention, this test fails first,
+// before the symptom shows up as broken selection sync in the app.
+describe("data-astro-source-loc annotation convention", () => {
+  it("stamps the end-of-opening-tag position, with a column strictly greater than the parse column", async () => {
+    const source = `<div>\n  <h2>Hi</h2>\n</div>\n`;
+    const result = await transform(source, {
+      annotateSourceFile: true,
+      filename: "Test.astro",
+    });
+
+    // <div> parses at line 1, column 1.
+    const divMatch = result.code.match(/<div[^>]*data-astro-source-loc="(\d+):(\d+)"/);
+    expect(divMatch).not.toBeNull();
+    const [, divLine, divColumn] = divMatch!;
+    expect(Number(divLine)).toBe(1);
+    expect(Number(divColumn)).toBeGreaterThan(1);
+
+    // <h2> parses at line 2, column 3 (after the two-space indent).
+    const h2Match = result.code.match(/<h2[^>]*data-astro-source-loc="(\d+):(\d+)"/);
+    expect(h2Match).not.toBeNull();
+    const [, h2Line, h2Column] = h2Match!;
+    expect(Number(h2Line)).toBe(2);
+    expect(Number(h2Column)).toBeGreaterThan(3);
+  });
+});


### PR DESCRIPTION
Adds a read-only component-model service: @astrojs/compiler template tree + css-tree style rules + heuristic Props extraction, exposed as the get_component_model MCP tool. App-side consumer: Anglesite-app Component Editor (spec 2026-07-05-component-editor-design.md in Anglesite-app). No behavior change to existing tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)