### PR TITLE
feat: component-style write ops (Component Editor slice 2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anglesite",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "AI webmaster that scaffolds, designs, and deploys Astro + Keystatic sites on Cloudflare Workers.",
   "author": {
     "name": "David W. Keith"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 - `get_component_model` MCP tool: structured read-only model of an `.astro`
   component (template tree, Props interface, style rules, client script) for
   the app's Component Editor (Slice 1).
+- `apply_edit` gains four component-style ops — `set-style-property`,
+  `remove-style-property`, `add-style-rule`, `set-rule-selector` — with
+  content-hash (`baseVersion`) staleness checking. Successful component-style
+  edits piggyback a freshly rebuilt `get_component_model` result on the reply.
 
 ## [1.0.0-beta.7] — 2026-05-07
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Anglesite is a Claude plugin that scaffolds and manages websites for small businesses. It works with Claude Cowork (non-technical site owners, GUI) and Claude Code (developers, CLI). It generates Astro + Keystatic sites deployed to Cloudflare Workers (Static Assets, via the `@astrojs/cloudflare` adapter).
 
-**Version:** 1.3.0 · **License:** ISC · **Node:** >=22 · **Module system:** ESM
+**Version:** 1.4.0 · **License:** ISC · **Node:** >=22 · **Module system:** ESM
 
 ## Plugin structure
 

--- a/agent-skills/README.md
+++ b/agent-skills/README.md
@@ -9,7 +9,7 @@ material lives in its `references/` directory.
 > Generated — do not edit by hand. Edit the plugin sources in `skills/` and run
 > `npm run build:agent-skills`.
 
-**Version:** 1.3.0 · **License:** ISC · 56 skills
+**Version:** 1.4.0 · **License:** ISC · 56 skills
 
 ## Install
 

--- a/agent-skills/add-store/SKILL.md
+++ b/agent-skills/add-store/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npx wrangler *), Bash(npm run build), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/animate/SKILL.md
+++ b/agent-skills/animate/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/backup/SKILL.md
+++ b/agent-skills/backup/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(git status *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git log *), Bash(git diff *), Bash(git checkout *), Bash(git branch *), Bash(git tag *), Bash(git show *), Bash(git stash *), Bash(git fetch *), Bash(git rev-parse *), Bash(npx tsx *), Read
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/booking/SKILL.md
+++ b/agent-skills/booking/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob, Bash(npm run build), Bash(npx astro check)
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/business-info/SKILL.md
+++ b/agent-skills/business-info/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/buy-button/SKILL.md
+++ b/agent-skills/buy-button/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/check/SKILL.md
+++ b/agent-skills/check/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run *), Bash(npx astro check), Bash(npx pa11y *), Bash(npx pa11y-ci *), Bash(npx tsx scripts/link-check.ts *), Bash(npx tsx scripts/a11y-audit.ts *), Bash(npx tsx scripts/a14y-audit.ts *), Bash(npx a14y *), Bash(a14y *), Bash(grep *), Bash(find dist/ *), Bash(stat *), Bash(npm audit *), Bash(lsof *), Bash(netstat *), Bash(getent *), Bash(nslookup *), Bash(gh issue *), Bash(gh label *), Write, Read, Glob, mcp__cloudflare__accounts_list, mcp__cloudflare__search_cloudflare_documentation, mcp__cloudflare__workers_list, mcp__cloudflare__workers_get_worker, mcp__cloudflare__workers_get_worker_code
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[optional: describe the problem]"

--- a/agent-skills/consent/SKILL.md
+++ b/agent-skills/consent/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(grep *), Write, Read, Glob, Edit
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/contact/SKILL.md
+++ b/agent-skills/contact/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(npx astro check), Bash(grep *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/convert/SKILL.md
+++ b/agent-skills/convert/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: ["Bash(npm run build)", "Bash(npm install)", "Bash(npm run ai-alt)", "Bash(zsh *)", "Bash(node *)", "Bash(npx sharp-cli *)", "Bash(mkdir *)", "Bash(git add *)", "Bash(git commit *)", "Bash(ls *)", "Bash(wc *)", "Bash(cp *)", "Bash(find src/content/posts *)", "Bash(find public/images *)", "Bash(find */images *)", "Bash(find */public *)", "Bash(find */static *)", "Bash(find */source *)", "Bash(find */content *)", "Bash(find */docs *)", "Bash(find */_posts *)", "Bash(find */layouts *)", "Bash(find */templates *)", "Bash(find */_includes *)", "Write", "Read", "Glob", "Edit"]
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/copy-edit/SKILL.md
+++ b/agent-skills/copy-edit/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/creative-canvas/SKILL.md
+++ b/agent-skills/creative-canvas/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm install *), Bash(npm run dev), Bash(npm run build), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
   argument-hint: "[effect description or library name]"

--- a/agent-skills/deploy/SKILL.md
+++ b/agent-skills/deploy/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npm run deploy *), Bash(npm run preview *), Bash(npm run ai-linkcheck *), Bash(npm run ai-a11y *), Bash(npm run ai-a14y *), Bash(npm run ai-perf *), Bash(npm run ai-webmention-send *), Bash(npx wrangler *), Bash(grep *), Bash(find dist/ *), Bash(gh *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git checkout *), Bash(git merge *), Bash(git branch *), Bash(kill *), Write, Read, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__search_cloudflare_documentation
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/design-import/SKILL.md
+++ b/agent-skills/design-import/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: ["Bash(node *)", "Bash(npx sharp-cli *)", "Bash(npx playwright install *)", "Bash(npm install *)", "Bash(npm run dev *)", "Bash(npm run build)", "Bash(mkdir *)", "Bash(curl *)", "Bash(git add *)", "Bash(git commit *)", "Bash(git push *)", "Bash(ls *)", "Bash(npm ls *)", "Bash(grep *)", "WebFetch", "Write", "Read", "Edit", "Glob"]
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[Canva site URL, Figma file URL, or freedesignmd.com system URL]"

--- a/agent-skills/design-interview/SKILL.md
+++ b/agent-skills/design-interview/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run *), WebFetch, Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/domain/SKILL.md
+++ b/agent-skills/domain/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(curl *), Write, Read, mcp__cloudflare__search_cloudflare_documentation
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[email, bluesky, or service name]"

--- a/agent-skills/donations/SKILL.md
+++ b/agent-skills/donations/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/email/SKILL.md
+++ b/agent-skills/email/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(curl *), Write, Read
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/experiment/SKILL.md
+++ b/agent-skills/experiment/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/export/SKILL.md
+++ b/agent-skills/export/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(mkdir *), Bash(cp *), Bash(rsync *), Bash(zip *), Bash(ls *), Bash(find *), Bash(du *), Bash(grep *), Bash(date *), Bash(git rev-parse *), Bash(npx wrangler r2 *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, Read, Write
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/forms/SKILL.md
+++ b/agent-skills/forms/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(npx astro check), Bash(grep *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/freedesignmd/SKILL.md
+++ b/agent-skills/freedesignmd/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: WebFetch, Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/giscus/SKILL.md
+++ b/agent-skills/giscus/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx astro check), Bash(grep *), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/i18n/SKILL.md
+++ b/agent-skills/i18n/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx astro check), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/import/SKILL.md
+++ b/agent-skills/import/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: ["WebFetch", "Bash(curl *)", "Bash(npx sharp-cli *)", "Bash(mkdir *)", "Bash(npm run build)", "Bash(npm install)", "Bash(npm run ai-alt)", "Bash(zsh *)", "Bash(node *)", "Bash(git add *)", "Bash(git commit *)", "Bash(git push *)", "Bash(ls *)", "Bash(wc *)", "Bash(grep *)", "Bash(find src/content/posts *)", "Bash(find public/images *)", "Bash(find */images *)", "Bash(find */public *)", "Bash(find */static *)", "Bash(find */source *)", "Bash(find */content *)", "Bash(find */docs *)", "Bash(find */_posts *)", "Bash(cp *)", "Write", "Read", "Glob", "Edit"]
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[website URL or local path]"

--- a/agent-skills/inbox/SKILL.md
+++ b/agent-skills/inbox/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run *), Bash(npx wrangler *), Bash(grep *), Write, Read, Edit, Glob, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__d1_database_create, mcp__cloudflare__d1_databases_list, mcp__cloudflare__d1_database_get, mcp__cloudflare__d1_database_query
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/indieweb/SKILL.md
+++ b/agent-skills/indieweb/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npm install *), Bash(npx wrangler *), Bash(openssl *), Bash(grep *), Bash(gh *), Bash(node *), Bash(mktemp *), Bash(printf *), Bash(rm *), Write, Read, Edit, Glob, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__d1_database_create, mcp__cloudflare__d1_databases_list, mcp__cloudflare__d1_database_get, mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_buckets_list
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/lemon-squeezy/SKILL.md
+++ b/agent-skills/lemon-squeezy/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/membership/SKILL.md
+++ b/agent-skills/membership/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(npx astro check), Bash(grep *), Bash(node *), Write, Read, Edit, Glob, mcp__cloudflare__kv_namespace_create, mcp__cloudflare__kv_namespace_get, mcp__cloudflare__kv_namespaces_list, mcp__cloudflare__accounts_list
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/menu/SKILL.md
+++ b/agent-skills/menu/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run dev), Bash(npm run build), Read, Write, Glob, Grep
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/new-page/SKILL.md
+++ b/agent-skills/new-page/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
   argument-hint: "[page name or purpose]"

--- a/agent-skills/newsletter/SKILL.md
+++ b/agent-skills/newsletter/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(curl *), Bash(grep *), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/og-images/SKILL.md
+++ b/agent-skills/og-images/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run ai-images), Bash(npm run ai-og), Bash(npx wrangler r2 *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, Read, Glob, Write
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/optimize-images/SKILL.md
+++ b/agent-skills/optimize-images/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run ai-optimize), Bash(npx wrangler r2 *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/paddle/SKILL.md
+++ b/agent-skills/paddle/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Edit, Glob, Bash(npm run build), Bash(npx astro check)
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/photography/SKILL.md
+++ b/agent-skills/photography/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Read, Glob, Write
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/podcast/SKILL.md
+++ b/agent-skills/podcast/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npm run dev), Bash(npx wrangler r2 *), Bash(wc -c *), Bash(stat *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, mcp__cloudflare__r2_bucket_delete, Read, Write, Edit, Glob, Grep
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/print/SKILL.md
+++ b/agent-skills/print/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob, Bash(npm run ai-qr)
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/pwa/SKILL.md
+++ b/agent-skills/pwa/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(node *), Write, Read, Glob, Edit
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/qr/SKILL.md
+++ b/agent-skills/qr/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run ai-qr), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/redirects/SKILL.md
+++ b/agent-skills/redirects/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Read, Write, Edit, Glob, Bash(grep *), Bash(find *), Bash(wc *), Bash(sort *), Bash(awk *), Bash(test *), Bash(ls *), Bash(cat *)
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[add | remove | list | validate | import | review]"

--- a/agent-skills/repurpose/SKILL.md
+++ b/agent-skills/repurpose/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/reputation/SKILL.md
+++ b/agent-skills/reputation/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(date *), Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/search/SKILL.md
+++ b/agent-skills/search/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm install *), Bash(npm run build), Bash(npx astro check), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/seasonal/SKILL.md
+++ b/agent-skills/seasonal/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(date *), Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/seo/SKILL.md
+++ b/agent-skills/seo/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npm run ai-seo*), Bash(npx astro check), Bash(grep *), Bash(find dist/ *), Bash(git log *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[page /about | schema | sitemap | og-images]"

--- a/agent-skills/share/SKILL.md
+++ b/agent-skills/share/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Write, Read, Glob, Edit
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/shopify-buy-button/SKILL.md
+++ b/agent-skills/shopify-buy-button/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Edit, Glob, Bash(npm run build), Bash(npx astro check)
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/snipcart/SKILL.md
+++ b/agent-skills/snipcart/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Edit, Glob, Bash(npm run build), Bash(npx astro check)
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/social-media/SKILL.md
+++ b/agent-skills/social-media/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/start/SKILL.md
+++ b/agent-skills/start/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(zsh *), Bash(npm install), Bash(npm run *), Bash(gh *), Bash(git remote *), Bash(git push *), Bash(git branch *), Bash(git add *), Bash(git commit *), WebFetch, Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/stats/SKILL.md
+++ b/agent-skills/stats/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(curl *), Bash(grep *), Bash(git log *), Bash(cat perf-trend.json), Write, Edit, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/testimonials/SKILL.md
+++ b/agent-skills/testimonials/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/themes/SKILL.md
+++ b/agent-skills/themes/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: WebFetch, Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/tracking/SKILL.md
+++ b/agent-skills/tracking/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm install *), Bash(npm run build), Bash(npx astro check), Bash(grep *), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/update/SKILL.md
+++ b/agent-skills/update/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(zsh *), Bash(npm run *), Bash(npm install *), Bash(npm update *), Bash(npm outdated *), Bash(npm audit *), Bash(npx astro check), Bash(git add *), Bash(git commit *), Bash(git diff *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.3.0"
+  version: "1.4.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/update/references/package.json
+++ b/agent-skills/update/references/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anglesite",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "description": "AI webmaster that scaffolds, designs, and deploys Astro + Keystatic sites on Cloudflare Workers.",
   "scripts": {

--- a/agent-skills/update/references/template/package.json
+++ b/agent-skills/update/references/template/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dwk/anglesite",
   "type": "module",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "dev": "astro dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anglesite",
-  "version": "1.2.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anglesite",
-      "version": "1.2.0",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anglesite",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "description": "AI webmaster that scaffolds, designs, and deploys Astro + Keystatic sites on Cloudflare Workers.",
   "scripts": {

--- a/server/apply-edit-dispatcher.mjs
+++ b/server/apply-edit-dispatcher.mjs
@@ -36,14 +36,16 @@ import {
   createEditAppliedContent,
   createEditFailedContent,
   createEditPreviewContent,
+  COMPONENT_STYLE_OPS,
 } from "./apply-edit-schema.mjs";
+import { buildComponentModel } from "./component-model.mjs";
 
 function failed(id, reason, detail) {
   return { content: [createEditFailedContent(id, reason, detail)], isError: true };
 }
 
-function applied(id, file, range, commit, result) {
-  return { content: [createEditAppliedContent(id, file, range, commit, result)] };
+function applied(id, file, range, commit, result, model) {
+  return { content: [createEditAppliedContent(id, file, range, commit, result, model)] };
 }
 
 /** Splice `replacement` into `source` at the resolved byte range. */
@@ -191,6 +193,13 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
     return failed(edit.id, "needs-agent", "apply-instruction requires LLM interpretation; route to the agent");
   }
 
+  // Component-style ops (Component Editor styles panel) identify their target via a
+  // structured `component` payload rather than `selector`; fail fast rather than let
+  // resolveComponentStyle's own destructure surface a less specific refusal.
+  if (COMPONENT_STYLE_OPS.has(edit.op) && !edit.component) {
+    return failed(edit.id, "invalid-input", `op ${edit.op} requires a component payload`);
+  }
+
   // dry_run is read-only. Image edits can't be previewed without writing optimized
   // bytes to disk, so refuse rather than violate the no-write invariant.
   if (edit.dry_run && edit.op === "replace-image-src") {
@@ -212,7 +221,7 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
     };
   }
 
-  const resolution = resolveEdit(projectRoot, effectiveEdit);
+  const resolution = await resolveEdit(projectRoot, effectiveEdit);
   if (resolution.refused) {
     return failed(edit.id, resolution.reason, resolution.detail);
   }
@@ -251,5 +260,21 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
     }
   }
 
-  return applied(edit.id, file, range, commit, imageResult ? { src: imageResult.src, srcset: imageResult.srcset } : undefined);
+  let model;
+  if (COMPONENT_STYLE_OPS.has(edit.op)) {
+    try {
+      model = await buildComponentModel(projectRoot, edit.component.path);
+    } catch {
+      model = undefined; // best-effort — a failed refetch shouldn't fail an already-applied edit
+    }
+  }
+
+  return applied(
+    edit.id,
+    file,
+    range,
+    commit,
+    imageResult ? { src: imageResult.src, srcset: imageResult.srcset } : undefined,
+    model,
+  );
 }

--- a/server/apply-edit-dispatcher.mjs
+++ b/server/apply-edit-dispatcher.mjs
@@ -39,6 +39,7 @@ import {
   COMPONENT_STYLE_OPS,
 } from "./apply-edit-schema.mjs";
 import { buildComponentModel } from "./component-model.mjs";
+import { fileVersion } from "./file-version.mjs";
 
 function failed(id, reason, detail) {
   return { content: [createEditFailedContent(id, reason, detail)], isError: true };
@@ -234,6 +235,16 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
     source = readFileSync(absPath, "utf-8");
   } catch (err) {
     return failed(edit.id, "write-failed", `read ${file}: ${err.message}`);
+  }
+
+  // Component-style ops resolve via an async parser (component-style-edit.mjs's
+  // `await parse(...)`), which opens a real yield point between that resolver's own
+  // baseVersion check and this second, independent read. A concurrent edit landing in
+  // that window would otherwise splice this call's now-stale byte offsets into the
+  // other call's already-written content — re-validate the hash against this fresh
+  // read, immediately before splicing, to close the gap.
+  if (COMPONENT_STYLE_OPS.has(edit.op) && fileVersion(source) !== edit.component.baseVersion) {
+    return failed(edit.id, "stale", `${file} changed since the model was fetched`);
   }
 
   const next = spliceSource(source, range, replacement);

--- a/server/apply-edit-schema.mjs
+++ b/server/apply-edit-schema.mjs
@@ -139,11 +139,14 @@ export function createEditFailedContent(id, reason, detail) {
  *  offsets in `file`; `commit` is the SHA the patch was committed to on the hidden
  *  `anglesite/edits` branch (added by #298). `result` is optional, op-scoped metadata that the
  *  overlay can apply directly: e.g. `replace-image-src` returns `{ src, srcset? }` so the
- *  overlay swaps both attributes on success without re-deriving them from the patch text. */
-export function createEditAppliedContent(id, file, range, commit, result) {
+ *  overlay swaps both attributes on success without re-deriving them from the patch text.
+ *  `model` is a fresh `buildComponentModel` result piggybacked on component-style-op success so
+ *  the app never needs a second round-trip to `get_component_model` after a write. */
+export function createEditAppliedContent(id, file, range, commit, result, model) {
   const body = { type: "anglesite:edit-applied", id, file, range };
   if (commit !== undefined) body.commit = commit;
   if (result !== undefined) body.result = result;
+  if (model !== undefined) body.model = model;
   return { type: "text", text: JSON.stringify(body) };
 }
 

--- a/server/apply-edit-schema.mjs
+++ b/server/apply-edit-schema.mjs
@@ -8,7 +8,9 @@
  *   - `selector: ElementInfo` (drops `element/tagName/textFingerprint/domPath`; matches
  *     selector.mjs's existing typedef).
  *   - `path` (drops `url`; the app already uses `path` on its side).
- *   - `op` is the closed enum {replace-text, replace-attr, replace-image-src, edit-style, apply-instruction}.
+ *   - `op` is the closed enum {replace-text, replace-attr, replace-image-src, edit-style, apply-instruction}
+ *     plus the four Component Editor style ops (`COMPONENT_STYLE_OPS`): set-style-property,
+ *     remove-style-property, add-style-rule, set-rule-selector — see `componentEditSchema`.
  *   - No `site` field — the MCP server already knows its `projectRoot`.
  *   - `type` is accepted-and-ignored — the app uses it as a WKWebView-side boundary tag.
  */
@@ -38,8 +40,49 @@ export const elementInfoSchema = z.object({
 
 /** Edit operations the server accepts. The patcher resolves the first four; `apply-instruction`
  *  is an NL-forwarding op the app's Foundation Models chat path sends — the server returns a
- *  structured `needs-agent` refusal so the app can route it to its agent. */
-export const editOps = ["replace-text", "replace-attr", "replace-image-src", "edit-style", "apply-instruction"];
+ *  structured `needs-agent` refusal so the app can route it to its agent. The last four are the
+ *  Component Editor's component-style ops (see `componentEditSchema` / `COMPONENT_STYLE_OPS`). */
+export const editOps = [
+  "replace-text",
+  "replace-attr",
+  "replace-image-src",
+  "edit-style",
+  "apply-instruction",
+  "set-style-property",
+  "remove-style-property",
+  "add-style-rule",
+  "set-rule-selector",
+];
+
+/** The subset of `editOps` that operate on a component's scoped `<style>` via `component`
+ *  rather than on a page element via `selector`. Reused by `patcher.mjs` and
+ *  `apply-edit-dispatcher.mjs` to branch dispatch without repeating the op-name list. */
+export const COMPONENT_STYLE_OPS = new Set([
+  "set-style-property",
+  "remove-style-property",
+  "add-style-rule",
+  "set-rule-selector",
+]);
+
+/** Structured payload for the four component-style ops. Identifies the target rule by its exact
+ *  byte span (from `get_component_model`'s `styles[].span`) plus a `baseVersion` content-hash
+ *  guard so a stale client-side model is refused rather than silently mis-patching. */
+export const componentEditSchema = z.object({
+  path: z.string().describe("Component path relative to the project root, e.g. src/components/Card.astro"),
+  baseVersion: z.string().describe("Content-hash version (sha256:...) the edit was computed against; a mismatch is refused as stale"),
+  ruleSpan: z
+    .tuple([z.number().int().nullable(), z.number().int().nullable()])
+    .optional()
+    .describe("Identifies an existing rule by its exact byte span from get_component_model's styles[].span. Required for set-style-property, remove-style-property, set-rule-selector. Omitted for add-style-rule."),
+  property: z.string().optional().describe("Declaration property name; required for set-style-property and remove-style-property"),
+  value: z.string().optional().describe("Declaration value; required for set-style-property"),
+  selector: z.string().optional().describe("New rule's selector for add-style-rule, or the renamed selector for set-rule-selector"),
+  media: z.string().nullable().optional().describe("@media condition for add-style-rule; absent/null means no wrapping media query"),
+  declarations: z
+    .array(z.object({ property: z.string(), value: z.string() }))
+    .optional()
+    .describe("Initial declarations for add-style-rule"),
+});
 
 /** The MCP tool's input shape, as passed to `server.tool(name, description, shape, handler)`. */
 export const applyEditInputShape = {
@@ -54,19 +97,27 @@ export const applyEditInputShape = {
     ),
   path: z
     .string()
-    .describe("Page path where the edit happened, e.g. /about/"),
-  selector: elementInfoSchema.describe(
-    "Structured element metadata; resolved server-side via selector.mjs.buildSelector",
-  ),
+    .describe("Page or component path"),
+  selector: elementInfoSchema
+    .optional()
+    .describe(
+      "Structured element metadata for page-level ops; resolved server-side via selector.mjs.buildSelector",
+    ),
+  component: componentEditSchema
+    .optional()
+    .describe(
+      "Structured component-style edit payload for set-style-property/remove-style-property/add-style-rule/set-rule-selector",
+    ),
   op: z
     .enum(editOps)
     .describe(
-      "Edit operation: replace-text (innerText), replace-attr (value is {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>), apply-instruction (reserved: sent only by the Anglesite-app Foundation Models chat path; always returns edit-failed/needs-agent — do not use from external callers)",
+      "Edit operation: replace-text (innerText), replace-attr (value is {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>), apply-instruction (reserved: sent only by the Anglesite-app Foundation Models chat path; always returns edit-failed/needs-agent — do not use from external callers), set-style-property/remove-style-property/add-style-rule/set-rule-selector (component-style ops — see componentEditSchema)",
     ),
   value: z
     .unknown()
+    .optional()
     .describe(
-      "Operation payload; varies by op (string for replace-text, {name, value} for replace-attr, {filename, mimeType, dataURL} for replace-image-src, {property, value} for edit-style, string for apply-instruction — the NL instruction text)",
+      "Operation payload; varies by op (string for replace-text, {name, value} for replace-attr, {filename, mimeType, dataURL} for replace-image-src, {property, value} for edit-style, string for apply-instruction — the NL instruction text). Omitted for the component-style ops, whose payload is `component`.",
     ),
   dry_run: z
     .boolean()

--- a/server/component-model.mjs
+++ b/server/component-model.mjs
@@ -3,10 +3,10 @@
 // 2026-07-05-component-editor-design.md §2.2).
 import { readFileSync } from "node:fs";
 import { join, normalize } from "node:path";
-import { createHash } from "node:crypto";
 import { parse } from "@astrojs/compiler";
-import { parse as parseCss, generate, walk } from "css-tree";
 import { parseProps } from "./props-interface.mjs";
+import { fileVersion } from "./file-version.mjs";
+import { indexCssRules } from "./css-rule-index.mjs";
 
 export class ComponentModelError extends Error {
   constructor(reason, message) {
@@ -94,52 +94,12 @@ function collectElements(node, name, out) {
 }
 
 function extractRules(styleElement) {
-  const lang = (styleElement.attributes ?? []).find((a) => a.name === "lang")?.value;
-  if (lang && lang.trim().toLowerCase() !== "css") return []; // scss/less etc.: css-tree error-recovery emits garbage rows
-  const textChild = (styleElement.children ?? []).find((c) => c.type === "text");
-  if (!textChild?.value) return [];
-  const baseOffset = textChild.position?.start?.offset ?? 0;
-  let cssAst;
-  try {
-    cssAst = parseCss(textChild.value, {
-      positions: true,
-      parseValue: false,
-      parseAtrulePrelude: false,
-    });
-  } catch {
-    return []; // unparseable CSS: styles stay empty; template/props still usable
-  }
-  const rules = [];
-  walk(cssAst, {
-    visit: "Rule",
-    enter(node) {
-      const media =
-        this.atrule && this.atrule.name === "media" && this.atrule.prelude
-          ? generate(this.atrule.prelude).trim()
-          : null;
-      const declarations = [];
-      node.block.children.forEach((decl) => {
-        if (decl.type !== "Declaration") return;
-        declarations.push({
-          property: decl.property,
-          value: generate(decl.value).trim(),
-          span: cssSpan(decl.loc, baseOffset),
-        });
-      });
-      rules.push({
-        selector: generate(node.prelude),
-        media,
-        span: cssSpan(node.loc, baseOffset),
-        declarations,
-      });
-    },
-  });
-  return rules;
-}
-
-function cssSpan(loc, baseOffset) {
-  if (!loc) return [null, null];
-  return [baseOffset + loc.start.offset, baseOffset + loc.end.offset];
+  return indexCssRules(styleElement).map(({ selector, media, span, declarations }) => ({
+    selector,
+    media,
+    span,
+    declarations,
+  }));
 }
 
 // style/script/frontmatter are zones, not template nodes.
@@ -193,12 +153,4 @@ class NodeBuilder {
       loc: start ? { line: start.line, column: start.column } : null,
     };
   }
-}
-
-// Content hash, not a git SHA: apply_edit commits land on the hidden
-// anglesite/edits branch without moving HEAD, so a repo-level SHA would stay
-// constant across edits — useless as a staleness token. Hashing the file
-// content means the version changes exactly when the model's source does.
-function fileVersion(source) {
-  return "sha256:" + createHash("sha256").update(source).digest("hex").slice(0, 12);
 }

--- a/server/component-style-edit.mjs
+++ b/server/component-style-edit.mjs
@@ -33,7 +33,7 @@ export async function resolveComponentStyle(projectRoot, edit) {
   try {
     source = readFileSync(absPath, "utf-8");
   } catch (err) {
-    return refuse("no-match", `read ${relPath}: ${err.message}`);
+    return refuse("read-failed", `read ${relPath}: ${err.message}`);
   }
 
   if (fileVersion(source) !== baseVersion) {
@@ -44,7 +44,7 @@ export async function resolveComponentStyle(projectRoot, edit) {
   try {
     ({ ast } = await parse(source, { position: true }));
   } catch (err) {
-    return refuse("invalid-input", `parse ${relPath}: ${err.message}`);
+    return refuse("parse-failed", `parse ${relPath}: ${err.message}`);
   }
 
   const styleElements = [];

--- a/server/component-style-edit.mjs
+++ b/server/component-style-edit.mjs
@@ -1,0 +1,167 @@
+import { readFileSync } from "node:fs";
+import { join, normalize } from "node:path";
+import { parse } from "@astrojs/compiler";
+import { fileVersion } from "./file-version.mjs";
+import { indexCssRules } from "./css-rule-index.mjs";
+
+/**
+ * Write-side resolver for the four Component Editor style ops
+ * (set-style-property, remove-style-property, set-rule-selector,
+ * add-style-rule). Re-indexes the target .astro file's <style> block(s)
+ * fresh from disk via `indexCssRules` (Task 2) and turns the requested op
+ * into a precise byte-range splice — the same `{file, range, replacement}`
+ * shape every other resolver in `patcher.mjs` produces.
+ */
+
+function refuse(reason, detail) {
+  return { refused: true, reason, detail };
+}
+
+export async function resolveComponentStyle(projectRoot, edit) {
+  const { component } = edit;
+  if (!component || typeof component !== "object") {
+    return refuse("invalid-input", "component payload is required for this op");
+  }
+  const { path: relPath, baseVersion, ruleSpan, property, value, selector, media, declarations } = component;
+
+  if (typeof relPath !== "string" || !relPath.endsWith(".astro") || normalize(relPath).startsWith("..") || relPath.startsWith("/")) {
+    return refuse("invalid-input", `not a project-relative .astro path: ${relPath}`);
+  }
+
+  const absPath = join(projectRoot, relPath);
+  let source;
+  try {
+    source = readFileSync(absPath, "utf-8");
+  } catch (err) {
+    return refuse("no-match", `read ${relPath}: ${err.message}`);
+  }
+
+  if (fileVersion(source) !== baseVersion) {
+    return refuse("stale", `${relPath} changed since the model was fetched`);
+  }
+
+  let ast;
+  try {
+    ({ ast } = await parse(source, { position: true }));
+  } catch (err) {
+    return refuse("invalid-input", `parse ${relPath}: ${err.message}`);
+  }
+
+  const styleElements = [];
+  collectStyleElements(ast, styleElements);
+  const rules = styleElements.flatMap((el) => indexCssRules(el));
+
+  switch (edit.op) {
+    case "set-style-property":
+      return applySetStyleProperty(relPath, rules, ruleSpan, property, value);
+    case "remove-style-property":
+      return applyRemoveStyleProperty(relPath, source, rules, ruleSpan, property);
+    case "set-rule-selector":
+      return applySetRuleSelector(relPath, rules, ruleSpan, selector);
+    case "add-style-rule":
+      return applyAddStyleRule(relPath, source, styleElements, selector, media, declarations);
+    default:
+      return refuse("invalid-input", `unsupported component-style op: ${edit.op}`);
+  }
+}
+
+function collectStyleElements(node, out) {
+  if (node.type === "element" && node.name === "style") out.push(node);
+  for (const child of node.children ?? []) collectStyleElements(child, out);
+}
+
+function findRule(rules, ruleSpan) {
+  if (!Array.isArray(ruleSpan) || ruleSpan.length !== 2) return undefined;
+  return rules.find((r) => r.span[0] === ruleSpan[0] && r.span[1] === ruleSpan[1]);
+}
+
+function applySetStyleProperty(file, rules, ruleSpan, property, value) {
+  if (typeof property !== "string" || typeof value !== "string") {
+    return refuse("invalid-input", "set-style-property requires component.property and component.value");
+  }
+  const rule = findRule(rules, ruleSpan);
+  if (!rule) return refuse("no-match", "no rule found at the given span — the file may have changed");
+
+  const existing = rule.declarations.find((d) => d.property === property);
+  if (existing) {
+    return { file, range: { start: existing.span[0], end: existing.span[1] }, replacement: `${property}: ${value}` };
+  }
+  const insertAt = rule.blockInner[1];
+  return { file, range: { start: insertAt, end: insertAt }, replacement: `\n  ${property}: ${value};` };
+}
+
+function applyRemoveStyleProperty(file, source, rules, ruleSpan, property) {
+  if (typeof property !== "string") {
+    return refuse("invalid-input", "remove-style-property requires component.property");
+  }
+  const rule = findRule(rules, ruleSpan);
+  if (!rule) return refuse("no-match", "no rule found at the given span — the file may have changed");
+
+  const decl = rule.declarations.find((d) => d.property === property);
+  if (!decl) return refuse("no-match", `no declaration for property "${property}" on this rule`);
+
+  // Extend the end past a trailing separator: consume one ";" if present
+  // (the last declaration in a block has no trailing ";", so don't eat "}").
+  let end = decl.span[1];
+  while (end < source.length && source[end] !== ";" && source[end] !== "}") end++;
+  if (source[end] === ";") end++;
+
+  // Trim leading horizontal whitespace back to (but not past) a preceding
+  // newline, then also swallow that one newline so removing a declaration
+  // doesn't leave a blank line behind. Only trims a single line's worth of
+  // indentation — a rule's block is always indented on its own line in the
+  // sources this resolver targets.
+  let start = decl.span[0];
+  while (start > 0 && (source[start - 1] === " " || source[start - 1] === "\t")) start--;
+  if (start > 0 && source[start - 1] === "\n") start--;
+
+  return { file, range: { start, end }, replacement: "" };
+}
+
+function applySetRuleSelector(file, rules, ruleSpan, selector) {
+  if (typeof selector !== "string" || selector.trim() === "") {
+    return refuse("invalid-input", "set-rule-selector requires a non-empty component.selector");
+  }
+  const rule = findRule(rules, ruleSpan);
+  if (!rule) return refuse("no-match", "no rule found at the given span — the file may have changed");
+
+  return { file, range: { start: rule.preludeSpan[0], end: rule.preludeSpan[1] }, replacement: selector };
+}
+
+function applyAddStyleRule(file, source, styleElements, selector, media, declarations) {
+  if (typeof selector !== "string" || selector.trim() === "") {
+    return refuse("invalid-input", "add-style-rule requires a non-empty component.selector");
+  }
+  const decls = Array.isArray(declarations) ? declarations : [];
+  const body = decls.map((d) => `  ${d.property}: ${d.value};`).join("\n");
+  const rule = media
+    ? `@media ${media} {\n  ${selector} {\n${body ? body.split("\n").map((l) => "  " + l).join("\n") + "\n" : ""}  }\n}`
+    : `${selector} {\n${body ? body + "\n" : ""}}`;
+
+  const lastStyle = styleElements[styleElements.length - 1];
+  if (!lastStyle) {
+    return { file, range: { start: source.length, end: source.length }, replacement: `\n<style>\n${rule}\n</style>\n` };
+  }
+  const insertAt = styleInsertionPoint(lastStyle, source);
+  return { file, range: { start: insertAt, end: insertAt }, replacement: `\n\n${rule}` };
+}
+
+/**
+ * Where to splice a new rule into an existing <style> element: right before
+ * its closing tag. Normally that's the text child's end offset — but a
+ * genuinely empty `<style></style>` has no text child at all, and
+ * `lastStyle.position.end.offset` is the offset *after* `</style>`, not
+ * before it. Falling back to that would splice the new rule outside the
+ * style element (rendered as literal page text, not CSS). Instead, derive
+ * the pre-closing-tag offset from the closing tag's own length, verified
+ * against the source so a malformed/unexpected shape still degrades to the
+ * (safe, if imprecise) end-of-element offset rather than guessing wrong.
+ */
+function styleInsertionPoint(styleEl, source) {
+  const textChild = (styleEl.children ?? []).find((c) => c.type === "text");
+  if (textChild?.position?.end?.offset != null) return textChild.position.end.offset;
+  const closeTag = `</${styleEl.name}>`;
+  const candidate = styleEl.position.end.offset - closeTag.length;
+  if (source.slice(candidate, styleEl.position.end.offset) === closeTag) return candidate;
+  return styleEl.position.end.offset;
+}

--- a/server/css-rule-index.mjs
+++ b/server/css-rule-index.mjs
@@ -1,0 +1,58 @@
+import { parse as parseCss, generate, walk } from "css-tree";
+
+/**
+ * Span-precise CSS rule index for one <style> element. Shared by the
+ * read-only component model (component-model.mjs) and the write-side
+ * resolver (component-style-edit.mjs) so both agree byte-for-byte on rule
+ * identity — selector text alone is not reliable (css-tree's generate()
+ * re-serializes and can normalize whitespace/quoting away from the source).
+ */
+export function indexCssRules(styleElement) {
+  const lang = (styleElement.attributes ?? []).find((a) => a.name === "lang")?.value;
+  if (lang && lang.trim().toLowerCase() !== "css") return []; // scss/less etc.: css-tree error-recovery emits garbage rows
+  const textChild = (styleElement.children ?? []).find((c) => c.type === "text");
+  if (!textChild?.value) return [];
+  const baseOffset = textChild.position?.start?.offset ?? 0;
+
+  let cssAst;
+  try {
+    cssAst = parseCss(textChild.value, { positions: true, parseValue: false, parseAtrulePrelude: false });
+  } catch {
+    return []; // unparseable CSS: styles stay empty; template/props still usable
+  }
+
+  const rules = [];
+  walk(cssAst, {
+    visit: "Rule",
+    enter(node) {
+      const media =
+        this.atrule && this.atrule.name === "media" && this.atrule.prelude
+          ? generate(this.atrule.prelude).trim()
+          : null;
+      const declarations = [];
+      node.block.children.forEach((decl) => {
+        if (decl.type !== "Declaration") return;
+        declarations.push({
+          property: decl.property,
+          value: generate(decl.value).trim(),
+          span: span(decl.loc, baseOffset),
+        });
+      });
+      const blockSpan = span(node.block.loc, baseOffset);
+      rules.push({
+        selector: generate(node.prelude),
+        preludeSpan: span(node.prelude.loc, baseOffset),
+        media,
+        span: span(node.loc, baseOffset),
+        blockInner: [blockSpan[0] + 1, blockSpan[1] - 1],
+        declarations,
+      });
+    },
+  });
+  return rules;
+}
+
+function span(loc, baseOffset) {
+  if (!loc) return [null, null];
+  return [baseOffset + loc.start.offset, baseOffset + loc.end.offset];
+}

--- a/server/file-version.mjs
+++ b/server/file-version.mjs
@@ -1,0 +1,11 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Content hash, not a git SHA: apply_edit commits land on the hidden
+ * anglesite/edits branch without moving HEAD, so a repo-level SHA would stay
+ * constant across edits — useless as a staleness token. Hashing the file
+ * content means the version changes exactly when the model's source does.
+ */
+export function fileVersion(source) {
+  return "sha256:" + createHash("sha256").update(source).digest("hex").slice(0, 12);
+}

--- a/server/patcher.mjs
+++ b/server/patcher.mjs
@@ -1,6 +1,8 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative, extname, basename, dirname } from "node:path";
 import { rewriteAstroStyle } from "./style-edit.mjs";
+import { resolveComponentStyle } from "./component-style-edit.mjs";
+import { COMPONENT_STYLE_OPS } from "./apply-edit-schema.mjs";
 
 /**
  * @typedef {import('./apply-edit-schema.mjs').default} _unused
@@ -11,17 +13,26 @@ import { rewriteAstroStyle } from "./style-edit.mjs";
 /**
  * Resolve an edit payload to a source-file patch.
  *
- * Tries resolvers in priority order: .mdoc → Keystatic YAML/JSON → .astro.
- * Returns the first non-refusal. If all refuse, returns the most informative
- * refusal (from the highest-priority resolver that had an opinion).
+ * Tries resolvers in priority order: edit-style → component-style ops → .mdoc →
+ * Keystatic YAML/JSON → .astro. Returns the first non-refusal. If all refuse,
+ * returns the most informative refusal (from the highest-priority resolver
+ * that had an opinion).
+ *
+ * Async because `resolveComponentStyle` (component-style-edit.mjs) parses the
+ * target .astro file with `@astrojs/compiler`, which is itself async. Every
+ * other resolver here is synchronous; awaiting their (non-Promise) return
+ * values is a no-op, so this doesn't change their behavior.
  *
  * @param {string} projectRoot
- * @param {{ path: string, selector: object, op: string, value?: unknown }} edit
- * @returns {ResolveResult | ResolveRefusal}
+ * @param {{ path: string, selector: object, op: string, value?: unknown, component?: object }} edit
+ * @returns {Promise<ResolveResult | ResolveRefusal>}
  */
-export function resolve(projectRoot, edit) {
+export async function resolve(projectRoot, edit) {
   if (edit.op === "edit-style") {
     return resolveStyle(projectRoot, edit);
+  }
+  if (COMPONENT_STYLE_OPS.has(edit.op)) {
+    return resolveComponentStyle(projectRoot, edit);
   }
   const resolvers = [resolveMdoc, resolveKeystatic, resolveAstro];
   let bestRefusal = /** @type {ResolveRefusal | null} */ (null);

--- a/template/package.json
+++ b/template/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dwk/anglesite",
   "type": "module",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "dev": "astro dev",

--- a/test/apply-edit-schema.test.js
+++ b/test/apply-edit-schema.test.js
@@ -45,8 +45,10 @@ describe("applyEditInputShape", () => {
     ).toBe(true);
   });
 
-  it("requires id, path, selector, and op", () => {
-    for (const field of ["id", "path", "selector", "op"]) {
+  it("requires id, path, and op", () => {
+    // `selector` is optional as of the Component Editor's style ops (#496): those ops carry
+    // their payload in `component` instead — see apply-edit-schema-component.test.ts.
+    for (const field of ["id", "path", "op"]) {
       const { [field]: _omitted, ...rest } = validPayload;
       expect(
         applyEditSchema.safeParse(rest).success,

--- a/test/patcher.test.js
+++ b/test/patcher.test.js
@@ -27,8 +27,8 @@ function makeEdit(overrides = {}) {
 // ── .mdoc resolver ────────────────────────────────────────────────
 
 describe("mdoc resolver", () => {
-  it("unique match → returns correct {file, range, replacement}", () => {
-    const result = resolve(FIXTURE_ROOT, makeEdit({
+  it("unique match → returns correct {file, range, replacement}", async () => {
+    const result = await resolve(FIXTURE_ROOT, makeEdit({
       path: "/blog/hello-world/",
       selector: makeSelector({ textContent: "Welcome to our new website! We are excited to share our journey with you." }),
       value: "Welcome to our redesigned website!",
@@ -42,8 +42,8 @@ describe("mdoc resolver", () => {
     expect(matched).toBe("Welcome to our new website! We are excited to share our journey with you.");
   });
 
-  it("no match → refuses with reason: no-match", () => {
-    const result = resolve(FIXTURE_ROOT, makeEdit({
+  it("no match → refuses with reason: no-match", async () => {
+    const result = await resolve(FIXTURE_ROOT, makeEdit({
       path: "/blog/hello-world/",
       selector: makeSelector({ textContent: "This text does not exist anywhere" }),
     }));
@@ -51,8 +51,8 @@ describe("mdoc resolver", () => {
     expect(result.reason).toBe("no-match");
   });
 
-  it("multiple matches → refuses with reason: ambiguous", () => {
-    const result = resolve(FIXTURE_ROOT, makeEdit({
+  it("multiple matches → refuses with reason: ambiguous", async () => {
+    const result = await resolve(FIXTURE_ROOT, makeEdit({
       path: "/blog/duplicate-text/",
       selector: makeSelector({ textContent: "Welcome to our bakery! We bake fresh bread every morning." }),
     }));
@@ -60,8 +60,8 @@ describe("mdoc resolver", () => {
     expect(result.reason).toBe("ambiguous");
   });
 
-  it("finds text in the body, not in the frontmatter", () => {
-    const result = resolve(FIXTURE_ROOT, makeEdit({
+  it("finds text in the body, not in the frontmatter", async () => {
+    const result = await resolve(FIXTURE_ROOT, makeEdit({
       path: "/blog/hello-world/",
       selector: makeSelector({ textContent: "This is the second paragraph with some bold text and a link." }),
       value: "Updated second paragraph.",
@@ -75,8 +75,8 @@ describe("mdoc resolver", () => {
 // ── Keystatic (YAML/JSON) resolver ────────────────────────────────
 
 describe("keystatic resolver", () => {
-  it("unique match in YAML → returns correct {file, range, replacement}", () => {
-    const result = resolve(FIXTURE_ROOT, makeEdit({
+  it("unique match in YAML → returns correct {file, range, replacement}", async () => {
+    const result = await resolve(FIXTURE_ROOT, makeEdit({
       path: "/",
       selector: makeSelector({ textContent: "Fresh bread since 1985" }),
       value: "Fresh bread since 1980",
@@ -92,8 +92,8 @@ describe("keystatic resolver", () => {
     }
   });
 
-  it("no match in data files → falls through to astro resolver", () => {
-    const result = resolve(FIXTURE_ROOT, makeEdit({
+  it("no match in data files → falls through to astro resolver", async () => {
+    const result = await resolve(FIXTURE_ROOT, makeEdit({
       path: "/",
       selector: makeSelector({ textContent: "We sell the finest goods in town. Come visit us today!" }),
       value: "Updated shop description",
@@ -107,8 +107,8 @@ describe("keystatic resolver", () => {
 // ── .astro resolver ───────────────────────────────────────────────
 
 describe("astro resolver", () => {
-  it("unique match → returns correct {file, range, replacement}", () => {
-    const result = resolve(FIXTURE_ROOT, makeEdit({
+  it("unique match → returns correct {file, range, replacement}", async () => {
+    const result = await resolve(FIXTURE_ROOT, makeEdit({
       path: "/",
       selector: makeSelector({ tag: "H1", textContent: "Welcome to Our Shop" }),
       value: "Welcome to Our New Shop",
@@ -122,8 +122,8 @@ describe("astro resolver", () => {
     expect(matched).toBe("Welcome to Our Shop");
   });
 
-  it("no match → refuses with reason: no-match", () => {
-    const result = resolve(FIXTURE_ROOT, makeEdit({
+  it("no match → refuses with reason: no-match", async () => {
+    const result = await resolve(FIXTURE_ROOT, makeEdit({
       path: "/",
       selector: makeSelector({ textContent: "This sentence does not appear anywhere in the project" }),
     }));
@@ -131,8 +131,8 @@ describe("astro resolver", () => {
     expect(result.reason).toBe("no-match");
   });
 
-  it("dynamic expression → refuses with reason: dynamic-expression", () => {
-    const result = resolve(FIXTURE_ROOT, makeEdit({
+  it("dynamic expression → refuses with reason: dynamic-expression", async () => {
+    const result = await resolve(FIXTURE_ROOT, makeEdit({
       path: "/about/",
       // "12" rendered by {teamSize} in about.astro — not static text
       selector: makeSelector({ textContent: "Our team of 12 experts is here to help you." }),
@@ -144,8 +144,8 @@ describe("astro resolver", () => {
     expect(result.reason).toBe("dynamic-expression");
   });
 
-  it("resolves static text from index.astro for / path", () => {
-    const result = resolve(FIXTURE_ROOT, makeEdit({
+  it("resolves static text from index.astro for / path", async () => {
+    const result = await resolve(FIXTURE_ROOT, makeEdit({
       path: "/",
       selector: makeSelector({ tag: "P", textContent: "Open Monday through Friday, 9am to 5pm." }),
       value: "Open every day, 8am to 6pm.",
@@ -156,8 +156,8 @@ describe("astro resolver", () => {
   });
 
   describe("replace-image-src", () => {
-    it("rewrites the entire <img> opening tag with new src + srcset", () => {
-      const result = resolve(FIXTURE_ROOT, {
+    it("rewrites the entire <img> opening tag with new src + srcset", async () => {
+      const result = await resolve(FIXTURE_ROOT, {
         path: "/photo/",
         selector: { tag: "IMG", classes: [], nthChild: 1, textContent: "/images/hero.jpg" },
         op: "replace-image-src",
@@ -178,8 +178,8 @@ describe("astro resolver", () => {
       expect(matched.endsWith("/>") || matched.endsWith(">")).toBe(true);
     });
 
-    it("adds srcset when the original <img> had none", () => {
-      const result = resolve(FIXTURE_ROOT, {
+    it("adds srcset when the original <img> had none", async () => {
+      const result = await resolve(FIXTURE_ROOT, {
         path: "/photo/",
         selector: { tag: "IMG", classes: [], nthChild: 2, textContent: "/images/loose.jpg" },
         op: "replace-image-src",
@@ -194,8 +194,8 @@ describe("astro resolver", () => {
       expect(result.replacement).toContain('alt="No srcset"');
     });
 
-    it("refuses with no-match when no <img> with the current src is found", () => {
-      const result = resolve(FIXTURE_ROOT, {
+    it("refuses with no-match when no <img> with the current src is found", async () => {
+      const result = await resolve(FIXTURE_ROOT, {
         path: "/photo/",
         selector: { tag: "IMG", classes: [], nthChild: 1, textContent: "/images/missing.jpg" },
         op: "replace-image-src",
@@ -210,11 +210,11 @@ describe("astro resolver", () => {
 // ── Cross-resolver priority ───────────────────────────────────────
 
 describe("cross-resolver priority", () => {
-  it("mdoc wins over astro when both could match", () => {
+  it("mdoc wins over astro when both could match", async () => {
     // The mdoc fixture has "Welcome to our new website!" which a greedy astro
     // resolver might also match if there were an astro file with the same text.
     // By design, mdoc is tried first.
-    const result = resolve(FIXTURE_ROOT, makeEdit({
+    const result = await resolve(FIXTURE_ROOT, makeEdit({
       path: "/blog/hello-world/",
       selector: makeSelector({ textContent: "Welcome to our new website! We are excited to share our journey with you." }),
       value: "Updated content",
@@ -224,8 +224,8 @@ describe("cross-resolver priority", () => {
     }
   });
 
-  it("all three refuse → returns the most informative reason", () => {
-    const result = resolve(FIXTURE_ROOT, makeEdit({
+  it("all three refuse → returns the most informative reason", async () => {
+    const result = await resolve(FIXTURE_ROOT, makeEdit({
       path: "/nonexistent/",
       selector: makeSelector({ textContent: "Text that does not exist in any file" }),
     }));
@@ -238,8 +238,8 @@ describe("cross-resolver priority", () => {
 // ── Resolver contract ─────────────────────────────────────────────
 
 describe("resolver contract", () => {
-  it("successful resolve returns file, range, and replacement", () => {
-    const result = resolve(FIXTURE_ROOT, makeEdit({
+  it("successful resolve returns file, range, and replacement", async () => {
+    const result = await resolve(FIXTURE_ROOT, makeEdit({
       path: "/",
       selector: makeSelector({ tag: "H1", textContent: "Welcome to Our Shop" }),
       value: "Updated Title",
@@ -254,8 +254,8 @@ describe("resolver contract", () => {
     expect(result.range.start).toBeLessThan(result.range.end);
   });
 
-  it("refusal returns refused: true and a reason string", () => {
-    const result = resolve(FIXTURE_ROOT, makeEdit({
+  it("refusal returns refused: true and a reason string", async () => {
+    const result = await resolve(FIXTURE_ROOT, makeEdit({
       path: "/",
       selector: makeSelector({ textContent: "No such text" }),
     }));
@@ -263,8 +263,8 @@ describe("resolver contract", () => {
     expect(typeof result.reason).toBe("string");
   });
 
-  it("range bytes correctly slice the original file", () => {
-    const result = resolve(FIXTURE_ROOT, makeEdit({
+  it("range bytes correctly slice the original file", async () => {
+    const result = await resolve(FIXTURE_ROOT, makeEdit({
       path: "/",
       selector: makeSelector({ tag: "P", textContent: "Open Monday through Friday, 9am to 5pm." }),
       value: "Replacement",

--- a/tests/apply-edit-dispatcher-component-style.test.ts
+++ b/tests/apply-edit-dispatcher-component-style.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { applyEdit } from "../server/apply-edit-dispatcher.mjs";
+import { fileVersion } from "../server/file-version.mjs";
+
+const CARD = `---\n---\n<article class="card"><slot /></article>\n\n<style>\n  .card { padding: 1rem; }\n</style>\n`;
+
+function parseContent(response) {
+  return JSON.parse(response.content[0].text);
+}
+
+describe("applyEdit — component-style ops", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-aed-"));
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), CARD);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rejects a component-style op with no component payload", async () => {
+    const response = await applyEdit(tmpDir, { id: "1", path: "x", op: "set-style-property", value: {} });
+    expect(response.isError).toBe(true);
+    const body = parseContent(response);
+    expect(body.reason).toBe("invalid-input");
+  });
+
+  it("applies set-style-property and piggybacks a fresh model", async () => {
+    const baseVersion = fileVersion(CARD);
+    const { indexCssRules } = await import("../server/css-rule-index.mjs");
+    const { parse } = await import("@astrojs/compiler");
+    const { ast } = await parse(CARD, { position: true });
+    const styleEl = ast.children.find((n) => n.type === "element" && n.name === "style");
+    const [cardRule] = indexCssRules(styleEl);
+
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Card.astro",
+      op: "set-style-property",
+      component: { path: "src/components/Card.astro", baseVersion, ruleSpan: cardRule.span, property: "color", value: "blue" },
+    });
+    expect(response.isError).toBeFalsy();
+    const body = parseContent(response);
+    expect(body.type).toBe("anglesite:edit-applied");
+    expect(body.model).toBeDefined();
+    expect(body.model.styles[0].declarations.some((d) => d.property === "color" && d.value === "blue")).toBe(true);
+  });
+
+  it("surfaces stale as a failed reply", async () => {
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Card.astro",
+      op: "set-style-property",
+      component: { path: "src/components/Card.astro", baseVersion: "sha256:000000000000", ruleSpan: [0, 1], property: "color", value: "blue" },
+    });
+    expect(response.isError).toBe(true);
+    const body = parseContent(response);
+    expect(body.reason).toBe("stale");
+  });
+});

--- a/tests/apply-edit-dispatcher-component-style.test.ts
+++ b/tests/apply-edit-dispatcher-component-style.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { applyEdit } from "../server/apply-edit-dispatcher.mjs";
@@ -62,5 +62,38 @@ describe("applyEdit — component-style ops", () => {
     expect(response.isError).toBe(true);
     const body = parseContent(response);
     expect(body.reason).toBe("stale");
+  });
+
+  it("re-checks staleness after the resolver's async gap, refusing a concurrent write race", async () => {
+    const baseVersion = fileVersion(CARD);
+    const { indexCssRules } = await import("../server/css-rule-index.mjs");
+    const { parse } = await import("@astrojs/compiler");
+    const { ast } = await parse(CARD, { position: true });
+    const styleEl = ast.children.find((n) => n.type === "element" && n.name === "style");
+    const [cardRule] = indexCssRules(styleEl);
+
+    const editPromise = applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Card.astro",
+      op: "set-style-property",
+      component: { path: "src/components/Card.astro", baseVersion, ruleSpan: cardRule.span, property: "color", value: "blue" },
+    });
+
+    // Simulate a second edit landing while this one is suspended at
+    // resolveComponentStyle's `await parse(...)` — rewrite the file (changing its
+    // hash) before this call's dispatcher-level re-check runs. This synchronous
+    // write executes before `parse()`'s WASM call can resolve, since calling an
+    // async function runs synchronously up to its first real suspension point.
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), CARD.replace("padding: 1rem", "padding: 3rem"));
+
+    const response = await editPromise;
+    expect(response.isError).toBe(true);
+    const body = parseContent(response);
+    expect(body.reason).toBe("stale");
+
+    // And the concurrent write itself must survive untouched — not clobbered by
+    // this call's stale byte-offset splice.
+    const onDisk = readFileSync(join(tmpDir, "src", "components", "Card.astro"), "utf-8");
+    expect(onDisk).toContain("padding: 3rem");
   });
 });

--- a/tests/apply-edit-schema-component.test.ts
+++ b/tests/apply-edit-schema-component.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { editOps, componentEditSchema, applyEditInputShape, COMPONENT_STYLE_OPS } from "../server/apply-edit-schema.mjs";
+
+describe("component-style op schema", () => {
+  it("registers the four new op names", () => {
+    for (const op of ["set-style-property", "remove-style-property", "add-style-rule", "set-rule-selector"]) {
+      expect(editOps).toContain(op);
+      expect(COMPONENT_STYLE_OPS.has(op)).toBe(true);
+    }
+  });
+
+  it("accepts a set-style-property component payload", () => {
+    const schema = z.object(applyEditInputShape);
+    const result = schema.safeParse({
+      id: "1",
+      path: "src/components/Card.astro",
+      op: "set-style-property",
+      component: { path: "src/components/Card.astro", baseVersion: "sha256:abc123456789", ruleSpan: [10, 40], property: "color", value: "red" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a component payload missing baseVersion", () => {
+    const result = componentEditSchema.safeParse({ path: "src/components/Card.astro", property: "color", value: "red" });
+    expect(result.success).toBe(false);
+  });
+
+  it("still accepts a legacy replace-attr edit with selector and no component", () => {
+    const schema = z.object(applyEditInputShape);
+    const result = schema.safeParse({
+      id: "1",
+      path: "/about/",
+      op: "replace-attr",
+      selector: { tag: "h1", classes: [], nthChild: 1 },
+      value: { name: "class", value: "big" },
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/tests/component-style-edit.test.ts
+++ b/tests/component-style-edit.test.ts
@@ -45,6 +45,16 @@ describe("resolveComponentStyle", () => {
     expect(result.reason).toBe("stale");
   });
 
+  it("refuses with read-failed (not no-match) when the file can't be read", async () => {
+    const edit = { op: "set-style-property", component: { path: "src/components/Missing.astro", baseVersion: "sha256:000000000000", ruleSpan: [0, 1], property: "color", value: "blue" } };
+    const result = await resolveComponentStyle(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    // Distinct from "no-match" (a rule span that doesn't resolve within a file that
+    // DID read and parse successfully) — matches buildComponentModel's ComponentModelError
+    // reason for the same failure mode on the same file.
+    expect(result.reason).toBe("read-failed");
+  });
+
   it("set-style-property updates an existing declaration in place", async () => {
     const baseVersion = fileVersion(CARD);
     // Recompute the real span via the resolver's own indexing to avoid hand-counting offsets:

--- a/tests/component-style-edit.test.ts
+++ b/tests/component-style-edit.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resolveComponentStyle } from "../server/component-style-edit.mjs";
+import { fileVersion } from "../server/file-version.mjs";
+
+const CARD = `---
+interface Props { title: string; }
+---
+<article class="card">
+  <h2>{title}</h2>
+</article>
+
+<style>
+  .card { padding: 1rem; color: red; }
+  @media (max-width: 600px) {
+    .card { padding: 0.5rem; }
+  }
+</style>
+`;
+
+describe("resolveComponentStyle", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-cse-"));
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), CARD);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function apply(resolution) {
+    const source = readFileSync(join(tmpDir, "src", "components", "Card.astro"), "utf-8");
+    return source.slice(0, resolution.range.start) + resolution.replacement + source.slice(resolution.range.end);
+  }
+
+  it("refuses with stale when baseVersion does not match", async () => {
+    const edit = { op: "set-style-property", component: { path: "src/components/Card.astro", baseVersion: "sha256:000000000000", ruleSpan: [0, 1], property: "color", value: "blue" } };
+    const result = await resolveComponentStyle(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("stale");
+  });
+
+  it("set-style-property updates an existing declaration in place", async () => {
+    const baseVersion = fileVersion(CARD);
+    // Recompute the real span via the resolver's own indexing to avoid hand-counting offsets:
+    const { indexCssRules } = await import("../server/css-rule-index.mjs");
+    const { parse } = await import("@astrojs/compiler");
+    const { ast } = await parse(CARD, { position: true });
+    const styleEl = ast.children.find((n) => n.type === "element" && n.name === "style");
+    const [cardRule] = indexCssRules(styleEl);
+
+    const edit = { op: "set-style-property", component: { path: "src/components/Card.astro", baseVersion, ruleSpan: cardRule.span, property: "color", value: "blue" } };
+    const result = await resolveComponentStyle(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    expect(apply(result)).toContain("color: blue");
+    expect(apply(result)).not.toContain("color: red");
+  });
+
+  it("set-style-property inserts a new declaration when the property is absent", async () => {
+    const baseVersion = fileVersion(CARD);
+    const { indexCssRules } = await import("../server/css-rule-index.mjs");
+    const { parse } = await import("@astrojs/compiler");
+    const { ast } = await parse(CARD, { position: true });
+    const styleEl = ast.children.find((n) => n.type === "element" && n.name === "style");
+    const [cardRule] = indexCssRules(styleEl);
+
+    const edit = { op: "set-style-property", component: { path: "src/components/Card.astro", baseVersion, ruleSpan: cardRule.span, property: "margin", value: "0" } };
+    const result = await resolveComponentStyle(tmpDir, edit);
+    expect(apply(result)).toMatch(/margin: 0;\s*}/);
+  });
+
+  it("remove-style-property deletes the declaration and its semicolon", async () => {
+    const baseVersion = fileVersion(CARD);
+    const { indexCssRules } = await import("../server/css-rule-index.mjs");
+    const { parse } = await import("@astrojs/compiler");
+    const { ast } = await parse(CARD, { position: true });
+    const styleEl = ast.children.find((n) => n.type === "element" && n.name === "style");
+    const [cardRule] = indexCssRules(styleEl);
+
+    const edit = { op: "remove-style-property", component: { path: "src/components/Card.astro", baseVersion, ruleSpan: cardRule.span, property: "color" } };
+    const result = await resolveComponentStyle(tmpDir, edit);
+    expect(apply(result)).not.toContain("color");
+    expect(apply(result)).toContain("padding: 1rem");
+  });
+
+  it("set-rule-selector renames only the prelude", async () => {
+    const baseVersion = fileVersion(CARD);
+    const { indexCssRules } = await import("../server/css-rule-index.mjs");
+    const { parse } = await import("@astrojs/compiler");
+    const { ast } = await parse(CARD, { position: true });
+    const styleEl = ast.children.find((n) => n.type === "element" && n.name === "style");
+    const [cardRule] = indexCssRules(styleEl);
+
+    const edit = { op: "set-rule-selector", component: { path: "src/components/Card.astro", baseVersion, ruleSpan: cardRule.span, selector: ".card--big" } };
+    const result = await resolveComponentStyle(tmpDir, edit);
+    expect(apply(result)).toContain(".card--big {");
+    expect(apply(result)).toContain("padding: 1rem");
+  });
+
+  it("add-style-rule appends a new rule before the closing </style>", async () => {
+    const baseVersion = fileVersion(CARD);
+    const edit = { op: "add-style-rule", component: { path: "src/components/Card.astro", baseVersion, selector: "h2", declarations: [{ property: "font-weight", value: "bold" }] } };
+    const result = await resolveComponentStyle(tmpDir, edit);
+    const next = apply(result);
+    expect(next).toMatch(/h2\s*{\s*font-weight: bold;\s*}/);
+    expect(next.indexOf("h2 {")).toBeGreaterThan(next.indexOf(".card {"));
+  });
+
+  it("add-style-rule creates a <style> block when none exists", async () => {
+    const noStyle = `---\n---\n<article class="card"><slot /></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), noStyle);
+    const baseVersion = fileVersion(noStyle);
+    const edit = { op: "add-style-rule", component: { path: "src/components/Card.astro", baseVersion, selector: ".card", declarations: [{ property: "padding", value: "1rem" }] } };
+    const result = await resolveComponentStyle(tmpDir, edit);
+    const next = apply(result);
+    expect(next).toContain("<style>");
+    expect(next).toMatch(/\.card\s*{\s*padding: 1rem;\s*}/);
+  });
+
+  it("add-style-rule appends inside an existing but empty <style></style> block", async () => {
+    const emptyStyle = `---\n---\n<article class="card"><slot /></article>\n\n<style></style>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), emptyStyle);
+    const baseVersion = fileVersion(emptyStyle);
+    const edit = { op: "add-style-rule", component: { path: "src/components/Card.astro", baseVersion, selector: ".card", declarations: [{ property: "padding", value: "1rem" }] } };
+    const result = await resolveComponentStyle(tmpDir, edit);
+    const next = apply(result);
+    // The new rule must land inside the <style> tags, not after them.
+    expect(next.indexOf(".card {")).toBeGreaterThan(next.indexOf("<style>"));
+    expect(next.indexOf(".card {")).toBeLessThan(next.indexOf("</style>"));
+    expect(next).toMatch(/\.card\s*{\s*padding: 1rem;\s*}/);
+  });
+
+  it("refuses no-match when the rule span no longer exists", async () => {
+    const baseVersion = fileVersion(CARD);
+    const edit = { op: "set-style-property", component: { path: "src/components/Card.astro", baseVersion, ruleSpan: [9999, 10010], property: "color", value: "blue" } };
+    const result = await resolveComponentStyle(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("no-match");
+  });
+});

--- a/tests/css-rule-index.test.ts
+++ b/tests/css-rule-index.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "@astrojs/compiler";
+import { indexCssRules } from "../server/css-rule-index.mjs";
+
+const SOURCE = `<style>
+  .card { padding: 1rem; color: red; }
+  @media (max-width: 600px) {
+    .card { padding: 0.5rem; }
+  }
+</style>
+`;
+
+async function styleElement() {
+  const { ast } = await parse(SOURCE, { position: true });
+  return ast.children.find((n: any) => n.type === "element" && n.name === "style");
+}
+
+describe("indexCssRules", () => {
+  it("captures selector, media, span, preludeSpan, blockInner, and declarations", async () => {
+    const el = await styleElement();
+    const rules = indexCssRules(el);
+    expect(rules).toHaveLength(2);
+
+    const [card, media] = rules;
+    expect(card.selector).toBe(".card");
+    expect(card.media).toBeNull();
+    expect(SOURCE.slice(card.preludeSpan[0], card.preludeSpan[1])).toBe(".card");
+    expect(SOURCE.slice(card.span[0], card.span[1])).toContain("padding: 1rem");
+    expect(card.declarations).toEqual([
+      { property: "padding", value: "1rem", span: card.declarations[0].span },
+      { property: "color", value: "red", span: card.declarations[1].span },
+    ]);
+    expect(SOURCE.slice(card.declarations[0].span[0], card.declarations[0].span[1])).toBe("padding: 1rem");
+    // blockInner sits strictly inside the braces
+    expect(SOURCE[card.blockInner[0] - 1]).toBe("{");
+    expect(SOURCE[card.blockInner[1]]).toBe("}");
+
+    expect(media.media).toBe("(max-width: 600px)");
+    expect(media.selector).toBe(".card");
+  });
+
+  it("returns [] for a non-CSS lang attribute", async () => {
+    const src = `<style lang="scss">.x { &:hover { color: blue; } }</style>`;
+    const { ast } = await parse(src, { position: true });
+    const el = ast.children.find((n: any) => n.type === "element" && n.name === "style");
+    expect(indexCssRules(el)).toEqual([]);
+  });
+});

--- a/tests/file-version.test.ts
+++ b/tests/file-version.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { fileVersion } from "../server/file-version.mjs";
+
+describe("fileVersion", () => {
+  it("is deterministic for identical content", () => {
+    expect(fileVersion("a")).toBe(fileVersion("a"));
+  });
+
+  it("changes when content changes", () => {
+    expect(fileVersion("a")).not.toBe(fileVersion("b"));
+  });
+
+  it("matches the sha256:<12 hex> format", () => {
+    expect(fileVersion("hello")).toMatch(/^sha256:[0-9a-f]{12}$/);
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -549,4 +549,74 @@ describe("MCP annotation server", () => {
       proc.kill();
     }
   });
+
+  it("apply_edit set-style-property round trip returns a piggybacked model", async () => {
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "src", "components", "Card.astro"),
+      `---\ninterface Props {\n  title: string;\n}\nconst { title } = Astro.props;\n---\n<article class="card"><h2>{title}</h2></article>\n<style>.card { padding: 1rem; }</style>\n`,
+    );
+    const proc = startServer(tmpDir);
+    try {
+      await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      });
+      sendNotification(proc, { jsonrpc: "2.0", method: "notifications/initialized" });
+
+      const modelResponse = await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "get_component_model", arguments: { path: "src/components/Card.astro" } },
+      });
+      const modelResult = modelResponse.result as { content: { text: string }[]; isError?: boolean };
+      expect(modelResult.isError).toBeFalsy();
+      const model = JSON.parse(modelResult.content[0].text);
+      const rule = model.styles[0];
+      expect(rule.selector).toBe(".card");
+
+      const editResponse = await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: {
+          name: "apply_edit",
+          arguments: {
+            id: "rt-1",
+            path: "src/components/Card.astro",
+            op: "set-style-property",
+            component: {
+              path: "src/components/Card.astro",
+              baseVersion: model.version,
+              ruleSpan: rule.span,
+              property: "color",
+              value: "blue",
+            },
+          },
+        },
+      });
+      const editResult = editResponse.result as { content: { text: string }[]; isError?: boolean };
+      expect(editResult.isError).toBeFalsy();
+      const body = JSON.parse(editResult.content[0].text);
+      expect(body.type).toBe("anglesite:edit-applied");
+      expect(
+        body.model.styles[0].declarations.some(
+          (d: { property: string; value: string }) => d.property === "color" && d.value === "blue",
+        ),
+      ).toBe(true);
+
+      // Confirm the write actually landed on disk, not just in the piggybacked model.
+      const onDisk = readFileSync(join(tmpDir, "src", "components", "Card.astro"), "utf-8");
+      expect(onDisk).toMatch(/color:\s*blue/);
+    } finally {
+      proc.kill();
+    }
+  });
 });

--- a/tests/patcher-edit-style.test.ts
+++ b/tests/patcher-edit-style.test.ts
@@ -13,8 +13,8 @@ beforeEach(() => {
 afterEach(() => rmSync(root, { recursive: true, force: true }));
 
 describe("patcher resolve() for edit-style", () => {
-  it("returns whole-file replacement with the merged style", () => {
-    const r = resolve(root, {
+  it("returns whole-file replacement with the merged style", async () => {
+    const r = await resolve(root, {
       path: "/about/",
       selector: { tag: "h1", id: "t", classes: [], nthChild: 1, textContent: "Welcome" },
       op: "edit-style",
@@ -25,8 +25,8 @@ describe("patcher resolve() for edit-style", () => {
     expect(r.replacement).toMatch(/#t\s*\{[^}]*color:\s*teal/);
   });
 
-  it("refuses with invalid-input when value.value is missing", () => {
-    const r = resolve(root, {
+  it("refuses with invalid-input when value.value is missing", async () => {
+    const r = await resolve(root, {
       path: "/about/",
       selector: { tag: "h1", id: "t", classes: [], nthChild: 1, textContent: "Welcome" },
       op: "edit-style",


### PR DESCRIPTION
## Summary

Part 1 of Component Editor Slice 2 (Anglesite-app#492): the plugin-side write ops for the Styles panel.

- Extracts shared `fileVersion`/`indexCssRules` helpers (span-precise CSS rule indexing) out of `component-model.mjs` so the read model and the new write resolver can't drift.
- Adds four `apply_edit` ops: `set-style-property`, `remove-style-property`, `add-style-rule`, `set-rule-selector` — identified by exact byte span (never by selector text, which `css-tree`'s `generate()` normalizes away from the source).
- Content-hash `baseVersion` staleness check on every write, refused as `"stale"` before any mutation.
- Successful component-style edits piggyback a freshly rebuilt `get_component_model` result on the reply, so the app never needs a second round-trip.
- Full stdio MCP round-trip test proves the real server path, not just unit tests.

Built task-by-task via subagent-driven development (implementer + independent reviewer per task, with an extra-scrutiny pass on the byte-splice resolver — the reviewer independently reproduced compiler offsets to verify a real edge-case bug the implementer caught and fixed in the empty-`<style>` insertion path).

## Test plan

- [x] `npm test` — 138/138 files, 2942/2942 tests passing
- [x] `npm run build:agent-skills` regenerated and its CI-gating test (`tests/build-agent-skills.test.ts`) passes
- [x] Version synced across `package.json`, `.claude-plugin/plugin.json`, `template/package.json`, `CLAUDE.md` per `bin/release.ts`'s convention (bumped by hand here — see note below)
- [ ] Tag/publish `v1.4.0` — **deliberately deferred**, not part of this PR. Needs a go-ahead before `bin/release.ts`'s tag+push step runs.

Closes #492 (plugin half; app-side consumption is a separate Anglesite-app PR).