### PR TITLE
fix(mcp): walk JSX embedded in a top-level conditional expression (#414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ All notable changes to this project will be documented in this file.
   content-hash (`baseVersion`) staleness checking. Successful component-style
   edits piggyback a freshly rebuilt `get_component_model` result on the reply.
 
+### Fixed
+- `get_component_model`'s outline extraction no longer drops JSX embedded in
+  a top-level conditional expression (e.g. `{profile && (<footer>...</footer>)}`)
+  — a component whose entire template was one conditional root previously got
+  a childless outline with nothing to select or map canvas clicks onto.
+
 ## [1.0.0-beta.7] — 2026-05-07
 
 Big beta. Nine new user-invocable skills round out the 1.0 commerce, community, and ops surface; analytics gets honest about what it's measuring; deploy learns about agent readability and performance budgets.

--- a/server/component-model.mjs
+++ b/server/component-model.mjs
@@ -122,7 +122,20 @@ class NodeBuilder {
       case "fragment":
         return this.#make(n, "fragment", null);
       case "expression":
-        return { ...this.#base(n), kind: "expression", tag: null, attrs: [], children: [] };
+        // An expression's `children` mix raw JS source (as "text" pseudo-nodes,
+        // e.g. "profile && (" ) with any JSX actually embedded in it (e.g. a
+        // conditional root `{cond && (<el/>)}` or a mapped list). Only the
+        // latter are real markup — walk those; drop the JS-source text.
+        return {
+          ...this.#base(n),
+          kind: "expression",
+          tag: null,
+          attrs: [],
+          children: (n.children ?? [])
+            .filter((c) => c.type === "element" || c.type === "component" || c.type === "custom-element" || c.type === "fragment")
+            .map((c) => this.toNode(c))
+            .filter(Boolean),
+        };
       case "text": {
         const value = (n.value ?? "").trim();
         if (!value) return null;

--- a/server/component-model.mjs
+++ b/server/component-model.mjs
@@ -107,6 +107,10 @@ function isZoneNode(n) {
   return n.type === "frontmatter" || (n.type === "element" && (n.name === "style" || n.name === "script"));
 }
 
+// AST node types that represent real embedded JSX inside an expression's
+// `children` (as opposed to "text" pseudo-nodes, which are raw JS source).
+const JSX_CHILD_TYPES = new Set(["element", "component", "custom-element", "fragment"]);
+
 class NodeBuilder {
   #next = 0;
   nextId() {
@@ -126,13 +130,18 @@ class NodeBuilder {
         // e.g. "profile && (" ) with any JSX actually embedded in it (e.g. a
         // conditional root `{cond && (<el/>)}` or a mapped list). Only the
         // latter are real markup — walk those; drop the JS-source text.
+        //
+        // A two-branch conditional (`{cond ? <A/> : <B/>}`) surfaces both `<A>`
+        // and `<B>` as siblings here even though only one renders at a time —
+        // acceptable for a static outline/editor tree, but worth knowing if a
+        // future consumer assumes every outline row is on the live page.
         return {
           ...this.#base(n),
           kind: "expression",
           tag: null,
           attrs: [],
           children: (n.children ?? [])
-            .filter((c) => c.type === "element" || c.type === "component" || c.type === "custom-element" || c.type === "fragment")
+            .filter((c) => JSX_CHILD_TYPES.has(c.type))
             .map((c) => this.toNode(c))
             .filter(Boolean),
         };

--- a/tests/component-model.test.ts
+++ b/tests/component-model.test.ts
@@ -251,6 +251,39 @@ const { items = ["a", "b", label = "fallback" } = Astro.props;
     expect(model.styles[0].selector).toBe("body");
   });
 
+  it("walks JSX embedded in a top-level conditional expression instead of dropping it", async () => {
+    writeFileSync(
+      join(tmpDir, "src", "components", "Hcard.astro"),
+      `---
+const profile = { name: "x" };
+---
+{profile && (
+  <footer class="site-identity">
+    <div class="h-card">
+      <p class="p-name">{profile.name}</p>
+    </div>
+  </footer>
+)}
+`,
+    );
+    const model = await buildComponentModel(tmpDir, "src/components/Hcard.astro");
+    const expr = model.template.children[0];
+    expect(expr.kind).toBe("expression");
+    expect(expr.children).toHaveLength(1);
+
+    const footer = expr.children[0];
+    expect(footer.kind).toBe("element");
+    expect(footer.tag).toBe("footer");
+    const div = footer.children[0];
+    expect(div.tag).toBe("div");
+    const p = div.children[0];
+    expect(p.tag).toBe("p");
+    // The inline `{profile.name}` expression stays a childless leaf — its
+    // "children" are JS source (an identifier chain), not markup.
+    expect(p.children[0].kind).toBe("expression");
+    expect(p.children[0].children).toEqual([]);
+  });
+
   it("filters style/script zones at any depth while still extracting them", async () => {
     writeFileSync(
       join(tmpDir, "src", "components", "Nested.astro"),


### PR DESCRIPTION
Fixes #414.

## Summary

- `component-model.mjs`'s `NodeBuilder.toNode` hardcoded `children: []` for every `expression` AST node, on the assumption an expression is always a leaf (e.g. `{title}`). That's true for plain interpolation, but an expression's `children` in `@astrojs/compiler`'s AST also carries real embedded JSX — e.g. a conditional root `{profile && (<footer>...</footer>)}` or a mapped list `{items.map(i => <li>{i}</li>)}` — mixed in with "text" pseudo-nodes that are actually raw JS source, not markup.
- Any component whose entire template is a single top-level conditional (a common "only render if data exists" pattern — this is exactly what `Hcard.astro` in the template's microformats set does) got an outline with one childless `{…}` placeholder row and nothing to select or map canvas clicks onto.
- Fix: recurse into an expression's `element`/`component`/`custom-element`/`fragment` children (real embedded JSX) while still dropping its `text` pseudo-children (JS source). Simple expressions like `{title}` are unaffected — their only child is a "text" JS-identifier pseudo-node, which is still filtered out, so they stay leaves.

No Swift-side changes needed — `ComponentOutline.rows(from:)` and `ComponentOutline.node(atLine:column:)` in Anglesite-app already recurse generically over `node.children` regardless of parent kind, so nested JSX now surfaces correctly once the server sends it.

Found via Anglesite-app#491's manual GUI smoke test of the Component Editor against `Hcard.astro`, filed as #414.

## Test plan
- [x] Added a regression test reproducing the exact `Hcard.astro` shape (conditional root wrapping `<footer><div><p>{profile.name}</p></div></footer>`) — walks the full nested tree and confirms the inline `{profile.name}` expression still stays a childless leaf.
- [x] `npx vitest run tests/component-model.test.ts` — 17/17 pass
- [x] `npx vitest run` (full suite) — 138 files / 2945 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)