### PR TITLE
feat(mcp): component-structure write ops + Unicode span-corruption fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ All notable changes to this project will be documented in this file.
   element. `indexCssRules` now takes the file's `lineStarts` and derives
   `baseOffset` from the `<style>` text child's line/column, same as the fix
   above.
+- `apply_edit`'s `add-style-rule` op had the same UTF-8-byte-offset bug in
+  `styleInsertionPoint` — an emoji or other multi-byte-UTF-8 character before
+  an empty `<style></style>` block spliced the new rule after the closing
+  tag (rendered as literal page text) instead of inside it. Now derived from
+  `lineStarts` like the fixes above.
 
 ## [1.0.0-beta.7] — 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ All notable changes to this project will be documented in this file.
   character earlier in the file silently drifted the offset of every node
   after it. Spans are now derived from the (reliably UTF-16-based) line/column
   fields instead of trusting `.offset`.
+- `get_component_model`'s `styles[]` (CSS rule/declaration spans) had the same
+  UTF-8-byte-offset-vs-UTF-16-index bug as above, independently, in
+  `indexCssRules`'s `baseOffset` — corrupted whenever a component's source
+  contained an emoji or other multi-byte-UTF-8 character before its `<style>`
+  element. `indexCssRules` now takes the file's `lineStarts` and derives
+  `baseOffset` from the `<style>` text child's line/column, same as the fix
+  above.
 
 ## [1.0.0-beta.7] — 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All notable changes to this project will be documented in this file.
   a top-level conditional expression (e.g. `{profile && (<footer>...</footer>)}`)
   — a component whose entire template was one conditional root previously got
   a childless outline with nothing to select or map canvas clicks onto.
+- `get_component_model` no longer reports corrupted `span`/`loc` values for
+  template nodes, attributes, frontmatter, and the client script whenever the
+  component's source contains an emoji or other multi-byte-UTF-8 character
+  (accented Latin, CJK, etc.) — `@astrojs/compiler@4.0.0` reports source
+  positions as UTF-8 byte offsets, not JS-string (UTF-16) indices, so any such
+  character earlier in the file silently drifted the offset of every node
+  after it. Spans are now derived from the (reliably UTF-16-based) line/column
+  fields instead of trusting `.offset`.
 
 ## [1.0.0-beta.7] — 2026-05-07
 

--- a/server/apply-edit-dispatcher.mjs
+++ b/server/apply-edit-dispatcher.mjs
@@ -36,7 +36,7 @@ import {
   createEditAppliedContent,
   createEditFailedContent,
   createEditPreviewContent,
-  COMPONENT_STYLE_OPS,
+  COMPONENT_OPS,
 } from "./apply-edit-schema.mjs";
 import { buildComponentModel } from "./component-model.mjs";
 import { fileVersion } from "./file-version.mjs";
@@ -194,10 +194,10 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
     return failed(edit.id, "needs-agent", "apply-instruction requires LLM interpretation; route to the agent");
   }
 
-  // Component-style ops (Component Editor styles panel) identify their target via a
-  // structured `component` payload rather than `selector`; fail fast rather than let
-  // resolveComponentStyle's own destructure surface a less specific refusal.
-  if (COMPONENT_STYLE_OPS.has(edit.op) && !edit.component) {
+  // Component ops (Component Editor styles panel + structure ops) identify their target
+  // via a structured `component` payload rather than `selector`; fail fast rather than
+  // let the resolver's own destructure surface a less specific refusal.
+  if (COMPONENT_OPS.has(edit.op) && !edit.component) {
     return failed(edit.id, "invalid-input", `op ${edit.op} requires a component payload`);
   }
 
@@ -237,13 +237,13 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
     return failed(edit.id, "write-failed", `read ${file}: ${err.message}`);
   }
 
-  // Component-style ops resolve via an async parser (component-style-edit.mjs's
-  // `await parse(...)`), which opens a real yield point between that resolver's own
-  // baseVersion check and this second, independent read. A concurrent edit landing in
-  // that window would otherwise splice this call's now-stale byte offsets into the
-  // other call's already-written content — re-validate the hash against this fresh
-  // read, immediately before splicing, to close the gap.
-  if (COMPONENT_STYLE_OPS.has(edit.op) && fileVersion(source) !== edit.component.baseVersion) {
+  // Component ops resolve via an async parser (component-style-edit.mjs's /
+  // component-structure-edit.mjs's `await parse(...)`), which opens a real yield point
+  // between that resolver's own baseVersion check and this second, independent read. A
+  // concurrent edit landing in that window would otherwise splice this call's now-stale
+  // byte offsets into the other call's already-written content — re-validate the hash
+  // against this fresh read, immediately before splicing, to close the gap.
+  if (COMPONENT_OPS.has(edit.op) && fileVersion(source) !== edit.component.baseVersion) {
     return failed(edit.id, "stale", `${file} changed since the model was fetched`);
   }
 
@@ -272,7 +272,7 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
   }
 
   let model;
-  if (COMPONENT_STYLE_OPS.has(edit.op)) {
+  if (COMPONENT_OPS.has(edit.op)) {
     try {
       model = await buildComponentModel(projectRoot, edit.component.path);
     } catch {

--- a/server/apply-edit-schema.mjs
+++ b/server/apply-edit-schema.mjs
@@ -52,6 +52,10 @@ export const editOps = [
   "remove-style-property",
   "add-style-rule",
   "set-rule-selector",
+  "insert-node",
+  "move-node",
+  "remove-node",
+  "set-attr",
 ];
 
 /** The subset of `editOps` that operate on a component's scoped `<style>` via `component`
@@ -64,6 +68,13 @@ export const COMPONENT_STYLE_OPS = new Set([
   "set-rule-selector",
 ]);
 
+/** The subset of `editOps` that operate on a component's template structure (DOM nodes)
+ *  via `component` rather than on a page element via `selector`. */
+export const COMPONENT_STRUCTURE_OPS = new Set(["insert-node", "move-node", "remove-node", "set-attr"]);
+
+/** Union of style and structure component ops — used by the dispatcher's shared checks. */
+export const COMPONENT_OPS = new Set([...COMPONENT_STYLE_OPS, ...COMPONENT_STRUCTURE_OPS]);
+
 /** Structured payload for the four component-style ops. Identifies the target rule by its exact
  *  byte span (from `get_component_model`'s `styles[].span`) plus a `baseVersion` content-hash
  *  guard so a stale client-side model is refused rather than silently mis-patching. */
@@ -75,13 +86,28 @@ export const componentEditSchema = z.object({
     .optional()
     .describe("Identifies an existing rule by its exact byte span from get_component_model's styles[].span. Required for set-style-property, remove-style-property, set-rule-selector. Omitted for add-style-rule."),
   property: z.string().optional().describe("Declaration property name; required for set-style-property and remove-style-property"),
-  value: z.string().optional().describe("Declaration value; required for set-style-property"),
+  value: z.string().nullable().optional().describe("Declaration value; required for set-style-property. For set-attr, a null value means remove the attribute."),
   selector: z.string().optional().describe("New rule's selector for add-style-rule, or the renamed selector for set-rule-selector"),
   media: z.string().nullable().optional().describe("@media condition for add-style-rule; absent/null means no wrapping media query"),
   declarations: z
     .array(z.object({ property: z.string(), value: z.string() }))
     .optional()
     .describe("Initial declarations for add-style-rule"),
+  nodeId: z.string().optional().describe("Identifies an existing template node by its get_component_model id. Required for set-attr, remove-node, move-node's source node."),
+  name: z.string().optional().describe("Attribute name for set-attr"),
+  parentId: z.string().optional().describe("Parent node id for insert-node (the fragment root's id for a top-level insert)"),
+  index: z.number().int().optional().describe("Child index to insert at, for insert-node"),
+  newParentId: z.string().optional().describe("Destination parent node id for move-node"),
+  newIndex: z.number().int().optional().describe("Destination child index for move-node"),
+  node: z
+    .object({
+      kind: z.enum(["element", "component", "slot"]),
+      tag: z.string().optional().describe("HTML tag name (element) or component name (component); omitted for slot"),
+      componentPath: z.string().optional().describe("Project-relative .astro path to import, required when kind=component"),
+      slotName: z.string().optional().describe("Named slot, for kind=slot; omitted means the default slot"),
+    })
+    .optional()
+    .describe("New node spec for insert-node"),
 });
 
 /** The MCP tool's input shape, as passed to `server.tool(name, description, shape, handler)`. */
@@ -111,7 +137,7 @@ export const applyEditInputShape = {
   op: z
     .enum(editOps)
     .describe(
-      "Edit operation: replace-text (innerText), replace-attr (value is {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>), apply-instruction (reserved: sent only by the Anglesite-app Foundation Models chat path; always returns edit-failed/needs-agent — do not use from external callers), set-style-property/remove-style-property/add-style-rule/set-rule-selector (component-style ops — see componentEditSchema)",
+      "Edit operation: replace-text (innerText), replace-attr (value is {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>), apply-instruction (reserved: sent only by the Anglesite-app Foundation Models chat path; always returns edit-failed/needs-agent — do not use from external callers), set-style-property/remove-style-property/add-style-rule/set-rule-selector (component-style ops), insert-node/move-node/remove-node/set-attr (component-structure ops — see componentEditSchema)",
     ),
   value: z
     .unknown()

--- a/server/component-model.mjs
+++ b/server/component-model.mjs
@@ -7,6 +7,7 @@ import { parse } from "@astrojs/compiler";
 import { parseProps } from "./props-interface.mjs";
 import { fileVersion } from "./file-version.mjs";
 import { indexCssRules } from "./css-rule-index.mjs";
+import { buildTemplateNodeIndex } from "./component-node-index.mjs";
 
 export class ComponentModelError extends Error {
   constructor(reason, message) {
@@ -38,20 +39,9 @@ export async function buildComponentModel(projectRoot, relPath) {
     throw new ComponentModelError("parse-failed", `parse ${relPath}: ${err.message}`);
   }
 
-  const builder = new NodeBuilder();
   const topLevel = ast.children ?? [];
-  const template = {
-    id: builder.nextId(),
-    kind: "fragment",
-    tag: null,
-    attrs: [],
-    span: [0, source.length],
-    loc: null,
-    children: topLevel
-      .filter((n) => !isZoneNode(n))
-      .map((n) => builder.toNode(n))
-      .filter(Boolean),
-  };
+  const { byId, rootId } = buildTemplateNodeIndex(ast, source);
+  const template = toPublicNode(byId, rootId);
 
   const styleElements = [];
   collectElements(ast, "style", styleElements);
@@ -102,77 +92,17 @@ function extractRules(styleElement) {
   }));
 }
 
-// style/script/frontmatter are zones, not template nodes.
-function isZoneNode(n) {
-  return n.type === "frontmatter" || (n.type === "element" && (n.name === "style" || n.name === "script"));
-}
-
-// AST node types that represent real embedded JSX inside an expression's
-// `children` (as opposed to "text" pseudo-nodes, which are raw JS source).
-const JSX_CHILD_TYPES = new Set(["element", "component", "custom-element", "fragment"]);
-
-class NodeBuilder {
-  #next = 0;
-  nextId() {
-    return `n${this.#next++}`;
-  }
-  toNode(n) {
-    switch (n.type) {
-      case "element":
-        return this.#make(n, n.name === "slot" ? "slot" : "element", n.name);
-      case "component":
-      case "custom-element":
-        return this.#make(n, "component", n.name);
-      case "fragment":
-        return this.#make(n, "fragment", null);
-      case "expression":
-        // An expression's `children` mix raw JS source (as "text" pseudo-nodes,
-        // e.g. "profile && (" ) with any JSX actually embedded in it (e.g. a
-        // conditional root `{cond && (<el/>)}` or a mapped list). Only the
-        // latter are real markup — walk those; drop the JS-source text.
-        //
-        // A two-branch conditional (`{cond ? <A/> : <B/>}`) surfaces both `<A>`
-        // and `<B>` as siblings here even though only one renders at a time —
-        // acceptable for a static outline/editor tree, but worth knowing if a
-        // future consumer assumes every outline row is on the live page.
-        return {
-          ...this.#base(n),
-          kind: "expression",
-          tag: null,
-          attrs: [],
-          children: (n.children ?? [])
-            .filter((c) => JSX_CHILD_TYPES.has(c.type))
-            .map((c) => this.toNode(c))
-            .filter(Boolean),
-        };
-      case "text": {
-        const value = (n.value ?? "").trim();
-        if (!value) return null;
-        return { ...this.#base(n), kind: "text", tag: null, attrs: [], text: value.slice(0, 80), children: [] };
-      }
-      default:
-        return null; // comment, doctype
-    }
-  }
-  #make(n, kind, tag) {
-    return {
-      ...this.#base(n),
-      kind,
-      tag,
-      attrs: (n.attributes ?? []).map((a) => ({ name: a.name, value: a.value ?? null })),
-      children: (n.children ?? [])
-        .filter((c) => !isZoneNode(c))
-        .map((c) => this.toNode(c))
-        .filter(Boolean),
-    };
-  }
-  #base(n) {
-    const start = n.position?.start;
-    const end = n.position?.end;
-    return {
-      id: this.nextId(),
-      span: [start?.offset ?? null, end?.offset ?? null],
-      loc: start ? { line: start.line, column: start.column } : null,
-    };
-  }
+function toPublicNode(byId, id) {
+  const r = byId.get(id);
+  const node = {
+    id: r.id,
+    kind: r.kind,
+    tag: r.tag,
+    attrs: r.attrs.map(({ name, value }) => ({ name, value })),
+    span: r.span,
+    loc: r.loc,
+    children: r.childIds.map((cid) => toPublicNode(byId, cid)),
+  };
+  if (r.text !== undefined) node.text = r.text;
+  return node;
 }

--- a/server/component-model.mjs
+++ b/server/component-model.mjs
@@ -7,7 +7,7 @@ import { parse } from "@astrojs/compiler";
 import { parseProps } from "./props-interface.mjs";
 import { fileVersion } from "./file-version.mjs";
 import { indexCssRules } from "./css-rule-index.mjs";
-import { buildTemplateNodeIndex } from "./component-node-index.mjs";
+import { buildTemplateNodeIndex, buildLineStarts, offsetFromLineColumn } from "./component-node-index.mjs";
 
 export class ComponentModelError extends Error {
   constructor(reason, message) {
@@ -43,6 +43,11 @@ export async function buildComponentModel(projectRoot, relPath) {
   const { byId, rootId } = buildTemplateNodeIndex(ast, source);
   const template = toPublicNode(byId, rootId);
 
+  // See the offset-encoding note in component-node-index.mjs: @astrojs/compiler's
+  // `position.*.offset` is a UTF-8 byte offset, not a JS-string index, so it's never
+  // consulted here either — spans below are derived from the (reliable) line/column.
+  const lineStarts = buildLineStarts(source);
+
   const styleElements = [];
   collectElements(ast, "style", styleElements);
   const styles = styleElements.flatMap((el) => extractRules(el));
@@ -51,7 +56,7 @@ export async function buildComponentModel(projectRoot, relPath) {
   const frontmatter = fmNode
     ? {
         source: fmNode.value ?? "",
-        span: [fmNode.position?.start?.offset ?? null, fmNode.position?.end?.offset ?? null],
+        span: [offsetFromLineColumn(lineStarts, fmNode.position?.start), offsetFromLineColumn(lineStarts, fmNode.position?.end)],
         props: parseProps(fmNode.value ?? ""),
       }
     : null;
@@ -64,7 +69,10 @@ export async function buildComponentModel(projectRoot, relPath) {
   const clientScript = scriptText
     ? {
         source: scriptText.value,
-        span: [scriptText.position?.start?.offset ?? null, scriptText.position?.end?.offset ?? null],
+        span: [
+          offsetFromLineColumn(lineStarts, scriptText.position?.start),
+          offsetFromLineColumn(lineStarts, scriptText.position?.end),
+        ],
       }
     : null;
 

--- a/server/component-model.mjs
+++ b/server/component-model.mjs
@@ -50,7 +50,7 @@ export async function buildComponentModel(projectRoot, relPath) {
 
   const styleElements = [];
   collectElements(ast, "style", styleElements);
-  const styles = styleElements.flatMap((el) => extractRules(el));
+  const styles = styleElements.flatMap((el) => extractRules(el, lineStarts));
 
   const fmNode = topLevel.find((n) => n.type === "frontmatter");
   const frontmatter = fmNode
@@ -91,8 +91,8 @@ function collectElements(node, name, out) {
   for (const child of node.children ?? []) collectElements(child, name, out);
 }
 
-function extractRules(styleElement) {
-  return indexCssRules(styleElement).map(({ selector, media, span, declarations }) => ({
+function extractRules(styleElement, lineStarts) {
+  return indexCssRules(styleElement, lineStarts).map(({ selector, media, span, declarations }) => ({
     selector,
     media,
     span,

--- a/server/component-node-index.mjs
+++ b/server/component-node-index.mjs
@@ -10,15 +10,51 @@ export function isZoneNode(n) {
   return n.type === "frontmatter" || (n.type === "element" && (n.name === "style" || n.name === "script"));
 }
 
-function attrSpan(a) {
+// @astrojs/compiler (4.0.0) reports `position.*.offset` as a UTF-8 BYTE offset into the
+// source (an artifact of the underlying WASM parser operating on byte slices), not a
+// JavaScript-string (UTF-16 code unit) index. Any character that takes more than one
+// UTF-8 byte — astral-plane emoji, but also ordinary accented Latin/CJK/etc characters —
+// appearing anywhere EARLIER in the source makes `.offset` diverge from the index
+// `source.slice()` actually needs, silently corrupting the span of every node that
+// follows it (not a fixed/predictable delta — it accumulates per multi-byte character).
+//
+// `.line`/`.column`, by contrast, ARE computed in UTF-16 code-unit terms matching JS
+// string semantics (verified directly against @astrojs/compiler@4.0.0 across text
+// nodes, attribute values, and multiple/nested astral-plane characters — see
+// tests/component-node-index.test.ts). So every span below is derived by converting
+// (line, column) to a source-string index via `lineStarts`; `.offset` is never consulted.
+//
+// This does NOT fix the separate, pre-existing bug where "expression"-kind nodes report
+// an off-by-one start (and an end offset that can exceed the source's length entirely)
+// regardless of Unicode — that's a distinct compiler quirk in how expression boundaries
+// are computed, not an offset-encoding mismatch, and line/column are equally wrong for
+// those nodes. See server/component-structure-edit.mjs's `resolveAllSpans` for the
+// lexical-rediscovery strategy the write path uses instead of trusting positions at all.
+export function buildLineStarts(source) {
+  const starts = [0];
+  for (let i = 0; i < source.length; i++) {
+    if (source.charCodeAt(i) === 10 /* "\n" */) starts.push(i + 1);
+  }
+  return starts;
+}
+
+export function offsetFromLineColumn(lineStarts, pos) {
+  if (!pos) return null;
+  const lineStart = lineStarts[pos.line - 1];
+  if (lineStart == null) return null;
+  return lineStart + (pos.column - 1);
+}
+
+function attrSpan(a, lineStarts) {
   if (!a.position?.start) return [null, null];
-  const start = a.position.start.offset;
-  if (a.position.end?.offset != null) return [start, a.position.end.offset];
+  const start = offsetFromLineColumn(lineStarts, a.position.start);
+  const end = offsetFromLineColumn(lineStarts, a.position.end);
+  if (end != null) return [start, end];
   const text = a.kind === "empty" ? a.name : `${a.name}="${a.value}"`;
   return [start, start + text.length];
 }
 
-function attrsOf(n) {
+function attrsOf(n, lineStarts) {
   // NOTE: `a.value ?? null` intentionally does NOT special-case
   // `a.kind === "empty"` — @astrojs/compiler gives empty (valueless)
   // attributes like `disabled` a value of `""` (not null/undefined), and the
@@ -28,15 +64,15 @@ function attrsOf(n) {
   return (n.attributes ?? []).map((a) => ({
     name: a.name,
     value: a.value ?? null,
-    span: attrSpan(a),
+    span: attrSpan(a, lineStarts),
   }));
 }
 
-function baseSpanLoc(n) {
+function baseSpanLoc(n, lineStarts) {
   const start = n.position?.start;
   const end = n.position?.end;
   return {
-    span: [start?.offset ?? null, end?.offset ?? null],
+    span: [offsetFromLineColumn(lineStarts, start), offsetFromLineColumn(lineStarts, end)],
     loc: start ? { line: start.line, column: start.column } : null,
   };
 }
@@ -45,6 +81,7 @@ export function buildTemplateNodeIndex(ast, source) {
   const byId = new Map();
   let next = 0;
   const nextId = () => `n${next++}`;
+  const lineStarts = buildLineStarts(source);
 
   const rootId = nextId();
   const rootChildIds = [];
@@ -67,21 +104,37 @@ export function buildTemplateNodeIndex(ast, source) {
           id: nextId(),
           kind: n.name === "slot" ? "slot" : "element",
           tag: n.name,
-          attrs: attrsOf(n),
-          ...baseSpanLoc(n),
+          attrs: attrsOf(n, lineStarts),
+          ...baseSpanLoc(n, lineStarts),
           parentId,
           childIds: [],
         };
         break;
       case "component":
       case "custom-element":
-        record = { id: nextId(), kind: "component", tag: n.name, attrs: attrsOf(n), ...baseSpanLoc(n), parentId, childIds: [] };
+        record = {
+          id: nextId(),
+          kind: "component",
+          tag: n.name,
+          attrs: attrsOf(n, lineStarts),
+          ...baseSpanLoc(n, lineStarts),
+          parentId,
+          childIds: [],
+        };
         break;
       case "fragment":
-        record = { id: nextId(), kind: "fragment", tag: null, attrs: attrsOf(n), ...baseSpanLoc(n), parentId, childIds: [] };
+        record = {
+          id: nextId(),
+          kind: "fragment",
+          tag: null,
+          attrs: attrsOf(n, lineStarts),
+          ...baseSpanLoc(n, lineStarts),
+          parentId,
+          childIds: [],
+        };
         break;
       case "expression": {
-        record = { id: nextId(), kind: "expression", tag: null, attrs: [], ...baseSpanLoc(n), parentId, childIds: [] };
+        record = { id: nextId(), kind: "expression", tag: null, attrs: [], ...baseSpanLoc(n, lineStarts), parentId, childIds: [] };
         byId.set(record.id, record);
         for (const c of n.children ?? []) {
           if (!JSX_CHILD_TYPES.has(c.type)) continue;
@@ -93,7 +146,16 @@ export function buildTemplateNodeIndex(ast, source) {
       case "text": {
         const value = (n.value ?? "").trim();
         if (!value) return null;
-        record = { id: nextId(), kind: "text", tag: null, attrs: [], text: value.slice(0, 80), ...baseSpanLoc(n), parentId, childIds: [] };
+        record = {
+          id: nextId(),
+          kind: "text",
+          tag: null,
+          attrs: [],
+          text: value.slice(0, 80),
+          ...baseSpanLoc(n, lineStarts),
+          parentId,
+          childIds: [],
+        };
         byId.set(record.id, record);
         return record;
       }

--- a/server/component-node-index.mjs
+++ b/server/component-node-index.mjs
@@ -1,0 +1,119 @@
+// Shared depth-first node index for one .astro component's template — the
+// single source of truth for node `id` assignment, consumed by BOTH the
+// read-only component-model.mjs and the structural write resolver
+// (component-structure-edit.mjs), so the two always agree on identity for
+// the same source (same deterministic walk over the same parsed AST).
+
+const JSX_CHILD_TYPES = new Set(["element", "component", "custom-element", "fragment"]);
+
+export function isZoneNode(n) {
+  return n.type === "frontmatter" || (n.type === "element" && (n.name === "style" || n.name === "script"));
+}
+
+function attrSpan(a) {
+  if (!a.position?.start) return [null, null];
+  const start = a.position.start.offset;
+  if (a.position.end?.offset != null) return [start, a.position.end.offset];
+  const text = a.kind === "empty" ? a.name : `${a.name}="${a.value}"`;
+  return [start, start + text.length];
+}
+
+function attrsOf(n) {
+  // NOTE: `a.value ?? null` intentionally does NOT special-case
+  // `a.kind === "empty"` — @astrojs/compiler gives empty (valueless)
+  // attributes like `disabled` a value of `""` (not null/undefined), and the
+  // pre-refactor NodeBuilder preserved that `""` in the model's public JSON.
+  // Special-casing empty attrs to `null` here would silently change
+  // component-model.mjs's output for a case none of its existing tests cover.
+  return (n.attributes ?? []).map((a) => ({
+    name: a.name,
+    value: a.value ?? null,
+    span: attrSpan(a),
+  }));
+}
+
+function baseSpanLoc(n) {
+  const start = n.position?.start;
+  const end = n.position?.end;
+  return {
+    span: [start?.offset ?? null, end?.offset ?? null],
+    loc: start ? { line: start.line, column: start.column } : null,
+  };
+}
+
+export function buildTemplateNodeIndex(ast, source) {
+  const byId = new Map();
+  let next = 0;
+  const nextId = () => `n${next++}`;
+
+  const rootId = nextId();
+  const rootChildIds = [];
+  byId.set(rootId, {
+    id: rootId,
+    kind: "fragment",
+    tag: null,
+    attrs: [],
+    span: [0, source.length],
+    loc: null,
+    parentId: null,
+    childIds: rootChildIds,
+  });
+
+  function visit(n, parentId) {
+    let record;
+    switch (n.type) {
+      case "element":
+        record = {
+          id: nextId(),
+          kind: n.name === "slot" ? "slot" : "element",
+          tag: n.name,
+          attrs: attrsOf(n),
+          ...baseSpanLoc(n),
+          parentId,
+          childIds: [],
+        };
+        break;
+      case "component":
+      case "custom-element":
+        record = { id: nextId(), kind: "component", tag: n.name, attrs: attrsOf(n), ...baseSpanLoc(n), parentId, childIds: [] };
+        break;
+      case "fragment":
+        record = { id: nextId(), kind: "fragment", tag: null, attrs: attrsOf(n), ...baseSpanLoc(n), parentId, childIds: [] };
+        break;
+      case "expression": {
+        record = { id: nextId(), kind: "expression", tag: null, attrs: [], ...baseSpanLoc(n), parentId, childIds: [] };
+        byId.set(record.id, record);
+        for (const c of n.children ?? []) {
+          if (!JSX_CHILD_TYPES.has(c.type)) continue;
+          const child = visit(c, record.id);
+          if (child) record.childIds.push(child.id);
+        }
+        return record;
+      }
+      case "text": {
+        const value = (n.value ?? "").trim();
+        if (!value) return null;
+        record = { id: nextId(), kind: "text", tag: null, attrs: [], text: value.slice(0, 80), ...baseSpanLoc(n), parentId, childIds: [] };
+        byId.set(record.id, record);
+        return record;
+      }
+      default:
+        return null; // comment, doctype
+    }
+    byId.set(record.id, record);
+    for (const c of n.children ?? []) {
+      if (isZoneNode(c)) continue;
+      const child = visit(c, record.id);
+      if (child) record.childIds.push(child.id);
+    }
+    return record;
+  }
+
+  const topLevel = (ast.children ?? []).filter((n) => !isZoneNode(n));
+  for (const n of topLevel) {
+    const child = visit(n, rootId);
+    if (child) rootChildIds.push(child.id);
+  }
+
+  return { byId, rootId };
+}

--- a/server/component-structure-edit.mjs
+++ b/server/component-structure-edit.mjs
@@ -101,47 +101,280 @@ function applySetAttr(file, source, byId, component) {
   return { file, range: { start: insertAt, end: insertAt }, replacement: ` ${name}="${escapeAttr(value)}"` };
 }
 
-// @astrojs/compiler (4.0.0) reports unreliable source positions for "expression"
-// nodes: `position.start.offset` lands one character before the actual opening
-// "{" (confirmed against multiple fixtures), and `position.end.offset` can be
-// arbitrary/out-of-bounds garbage once the expression contains nested JSX that
-// itself carries an expression (e.g. `{items.map((i) => (<li>{i}</li>))}`) —
-// the reported end offset was seen to exceed the file length entirely, which
-// silently truncates a naive `source.slice()`-based removal. Recompute the
-// true span for expression nodes directly from the source via brace-depth
-// matching (skipping string/template-literal contents) instead of trusting
-// the parser's position for this node kind. Other node kinds (element,
-// component, text, ...) don't exhibit this and keep their reported span.
-function trueSpan(node, source) {
-  if (node.kind !== "expression" || node.span[0] == null) return node.span;
-  let start = node.span[0];
-  while (start < source.length && source[start] !== "{") start++;
-  if (start >= source.length) return node.span;
+// @astrojs/compiler (4.0.0) reports CORRUPTED source positions for ANY node kind —
+// element/component/fragment/slot as well as "expression" — whenever astral-plane
+// Unicode (e.g. an emoji) appears anywhere in the source BEFORE that node. The
+// corruption is not a fixed/predictable delta, so `position.start/end.offset` cannot
+// be trusted, patched, or scanned-forward-from for ANY node kind (an earlier version of
+// this file only patched expression-kind nodes by scanning forward from the reported
+// offset for the next literal "{" — that can land on the WRONG node entirely under this
+// bug, silently deleting an unrelated sibling). Root-causing the compiler's offset math
+// is out of scope here; instead, remove-node NEVER consults `node.span`/`position.offset`
+// to locate a removal boundary. It re-derives the node's true span purely lexically from
+// `source`, anchored by the node's ordinal position among same-(kind,tag) siblings under
+// its parent — `byId`'s parent/child SHAPE (not its offsets) is unaffected by the bug,
+// since it comes from the AST tree structure, not from position numbers.
+//
+// Two lexical scanners do the actual span-finding, operating on `source` with
+// frontmatter/`<style>`/`<script>`/HTML-comment zones blanked out (`maskOpaqueZones`) so
+// stray `<`, `>`, `{`, `}` in those regions can't produce false matches:
+//   - findNthExpressionBlock: the k-th top-level `{...}` block in *text* position
+//     (i.e. not inside a tag's own attribute list — `<div class={x}>`'s `{x}` doesn't
+//     count) anywhere in the source.
+//   - findNthTagSpan: the k-th `<tagName ...>...</tagName>` (or self-closing
+//     `<tagName ... />`) occurrence of a given tag name anywhere in the source, with its
+//     true matching close resolved via depth-counting over nested same-name tags.
+//
+// Both scan the WHOLE source rather than a "search window" bounded by the parent's own
+// span — the parent's span may ALSO be corrupted, so it can't be trusted as a bound
+// either. The sibling-ordinal anchor (not a tight window) is what disambiguates.
+//
+// LIMITATIONS (a deliberate, documented simplification — not a general HTML/JSX parser;
+// remove-node refuses with "no-match" rather than guessing when these scanners can't
+// find a confident k-th occurrence, so failure is safe even where these limits are hit):
+//   - The ordinal count spans the WHOLE document in source order, not just the target's
+//     immediate siblings. A node nested *inside* an earlier same-tag sibling (e.g.
+//     `<div><div/></div><div/>`, removing the second top-level div) can shift the count
+//     and misidentify the target. Not exercised by any fixture in this repo today.
+//   - findNthExpressionBlock only counts *top-level* `{...}` blocks: an expression nested
+//     inside another expression's JSX children is consumed as part of the outer block's
+//     span (matching the existing "remove as a single opaque unit" requirement), so it
+//     can't separately target such a nested node — but buildTemplateNodeIndex doesn't
+//     index those as separate nodes anyway (JSX_CHILD_TYPES excludes "expression").
+//   - Shorthand `<>...</>` fragments (kind "fragment" with no tag name) have no lexical
+//     tag to search for and are refused outright, as are any other unhandled node kinds
+//     (e.g. "text") — this fix only covers "expression" and "element"/"component"/
+//     "slot"/"fragment-with-a-tag" removal, matching the reported bug's scope.
 
-  let depth = 0;
-  let quote = null;
-  for (let i = start; i < source.length; i++) {
-    const ch = source[i];
-    if (quote) {
-      if (ch === "\\") {
-        i++;
-      } else if (ch === quote) {
-        quote = null;
-      }
+function maskOpaqueZones(source) {
+  const maskRange = (str, start, end) => str.slice(0, start) + " ".repeat(end - start) + str.slice(end);
+  let masked = source;
+  const fm = source.match(/^(---\r?\n)([\s\S]*?)(\r?\n---)/);
+  if (fm) masked = maskRange(masked, fm.index, fm.index + fm[0].length);
+  masked = masked.replace(/<(style|script)\b[^>]*>[\s\S]*?<\/\1>/gi, (m) => " ".repeat(m.length));
+  masked = masked.replace(/<!--[\s\S]*?-->/g, (m) => " ".repeat(m.length));
+  return masked;
+}
+
+function isWordChar(ch) {
+  return !!ch && /[a-zA-Z0-9:_.-]/.test(ch);
+}
+
+function skipQuoted(s, pos, quoteChar) {
+  let j = pos + 1;
+  while (j < s.length) {
+    if (s[j] === "\\") {
+      j += 2;
       continue;
     }
+    if (s[j] === quoteChar) return j + 1;
+    j++;
+  }
+  return s.length;
+}
+
+// End (exclusive) of the brace-delimited block starting at `start` (s[start] === "{"),
+// honoring nested braces and quoted/template-literal strings. Returns -1 if unterminated.
+function scanBraceBlock(s, start) {
+  let depth = 0;
+  let j = start;
+  while (j < s.length) {
+    const ch = s[j];
     if (ch === '"' || ch === "'" || ch === "`") {
-      quote = ch;
+      j = skipQuoted(s, j, ch);
+      continue;
+    }
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return j + 1;
+    }
+    j++;
+  }
+  return -1;
+}
+
+// End (exclusive) of a tag's own opening `<...>` starting at `start` (s[start] === "<"),
+// honoring quoted attribute values and brace-delimited attribute expressions so a stray
+// `>` inside either doesn't prematurely close the tag. Returns null if unterminated.
+function scanTagOpen(s, start) {
+  let j = start + 1;
+  while (j < s.length) {
+    const ch = s[j];
+    if (ch === '"' || ch === "'" || ch === "`") {
+      j = skipQuoted(s, j, ch);
       continue;
     }
     if (ch === "{") {
-      depth++;
-    } else if (ch === "}") {
+      const end = scanBraceBlock(s, j);
+      if (end === -1) return null;
+      j = end;
+      continue;
+    }
+    if (ch === ">") return { end: j + 1, selfClosing: s[j - 1] === "/" };
+    j++;
+  }
+  return null;
+}
+
+// If `s[i]` starts a tag (open or close), returns { closing, name, afterName }; else null.
+function readTagOpenerAt(s, i) {
+  if (s[i] !== "<") return null;
+  const closing = s[i + 1] === "/";
+  const nameStart = closing ? i + 2 : i + 1;
+  let j = nameStart;
+  while (isWordChar(s[j])) j++;
+  const name = s.slice(nameStart, j);
+  if (!name) return null;
+  return { closing, name, afterName: j };
+}
+
+// The k-th (0-based) top-level `{...}` block in text position anywhere in `masked`.
+function findNthExpressionBlock(masked, k) {
+  let count = 0;
+  let i = 0;
+  const n = masked.length;
+  while (i < n) {
+    const ch = masked[i];
+    if (ch === "<") {
+      const opener = readTagOpenerAt(masked, i);
+      if (opener) {
+        if (opener.closing) {
+          const gt = masked.indexOf(">", opener.afterName);
+          i = gt === -1 ? n : gt + 1;
+          continue;
+        }
+        const tagInfo = scanTagOpen(masked, i);
+        if (tagInfo) {
+          i = tagInfo.end;
+          continue;
+        }
+      }
+    }
+    if (ch === "{") {
+      const end = scanBraceBlock(masked, i);
+      if (end === -1) {
+        i++;
+        continue;
+      }
+      if (count === k) return [i, end];
+      count++;
+      i = end;
+      continue;
+    }
+    i++;
+  }
+  return null;
+}
+
+// From just after a non-self-closing open tag's `<tagName ...>`, scans forward
+// depth-counting nested same-name tags to find the true matching `</tagName>`. Returns
+// the offset just past that close tag, or -1 if unterminated.
+function findMatchingClose(masked, tagName, from) {
+  let depth = 1;
+  let i = from;
+  const n = masked.length;
+  while (i < n) {
+    const opener = readTagOpenerAt(masked, i);
+    if (!opener) {
+      i++;
+      continue;
+    }
+    if (opener.name !== tagName) {
+      if (opener.closing) {
+        const gt = masked.indexOf(">", opener.afterName);
+        i = gt === -1 ? n : gt + 1;
+      } else {
+        const tagInfo = scanTagOpen(masked, i);
+        if (!tagInfo) return -1;
+        i = tagInfo.end;
+      }
+      continue;
+    }
+    if (opener.closing) {
       depth--;
-      if (depth === 0) return [start, i + 1];
+      const gt = masked.indexOf(">", opener.afterName);
+      const closeEnd = gt === -1 ? n : gt + 1;
+      if (depth === 0) return closeEnd;
+      i = closeEnd;
+    } else {
+      const tagInfo = scanTagOpen(masked, i);
+      if (!tagInfo) return -1;
+      if (!tagInfo.selfClosing) depth++;
+      i = tagInfo.end;
     }
   }
-  return node.span;
+  return -1;
+}
+
+// The k-th (0-based) occurrence of an open tag named `tagName` anywhere in `masked`
+// (self-closing or not), with its true matching close.
+function findNthTagSpan(masked, tagName, k) {
+  let count = 0;
+  let i = 0;
+  const n = masked.length;
+  while (i < n) {
+    const opener = readTagOpenerAt(masked, i);
+    if (!opener) {
+      i++;
+      continue;
+    }
+    if (opener.closing) {
+      const gt = masked.indexOf(">", opener.afterName);
+      i = gt === -1 ? n : gt + 1;
+      continue;
+    }
+    const tagInfo = scanTagOpen(masked, i);
+    if (!tagInfo) return null;
+    if (opener.name === tagName) {
+      if (count === k) {
+        if (tagInfo.selfClosing) return [i, tagInfo.end];
+        const closeEnd = findMatchingClose(masked, tagName, tagInfo.end);
+        return closeEnd === -1 ? null : [i, closeEnd];
+      }
+      count++;
+    }
+    i = tagInfo.end;
+  }
+  return null;
+}
+
+// Establishes the node's 0-based ordinal `k` among its parent's children that share the
+// same (kind, tag) grouping (expression nodes group by kind alone — tag is always null).
+function siblingOrdinal(byId, node) {
+  const parent = byId.get(node.parentId);
+  if (!parent) return null;
+  const sameGroup = parent.childIds
+    .map((id) => byId.get(id))
+    .filter((n) => n && (node.kind === "expression" ? n.kind === "expression" : n.kind === node.kind && n.tag === node.tag));
+  const k = sameGroup.findIndex((n) => n.id === node.id);
+  return k === -1 ? null : k;
+}
+
+function findTrueSpan(byId, node, source) {
+  const k = siblingOrdinal(byId, node);
+  if (k === null) return null;
+  const masked = maskOpaqueZones(source);
+  if (node.kind === "expression") return findNthExpressionBlock(masked, k);
+  if ((node.kind === "element" || node.kind === "component" || node.kind === "slot" || node.kind === "fragment") && node.tag) {
+    return findNthTagSpan(masked, node.tag, k);
+  }
+  return null; // unhandled kind (e.g. "text", tagless fragment) — caller refuses
+}
+
+// Defends against a scanner returning a span that doesn't actually start with the
+// marker we searched for — belt-and-suspenders on top of the ordinal anchor.
+function spanLooksSane(source, node, span) {
+  if (!span) return false;
+  const [start, end] = span;
+  if (start == null || end == null || end <= start || end > source.length) return false;
+  if (node.kind === "expression") {
+    return source[start] === "{" && source[end - 1] === "}";
+  }
+  const prefix = `<${node.tag}`;
+  if (source.slice(start, start + prefix.length) !== prefix) return false;
+  const afterPrefixChar = source[start + prefix.length];
+  return afterPrefixChar === undefined || /[\s/>]/.test(afterPrefixChar);
 }
 
 function applyRemoveNode(file, source, byId, component) {
@@ -152,12 +385,13 @@ function applyRemoveNode(file, source, byId, component) {
   const node = byId.get(nodeId);
   if (!node) return refuse("no-match", "no node found at the given id — the file may have changed");
   if (node.parentId === null) return refuse("invalid-input", "cannot remove the component's root");
-  if (node.span[0] == null || node.span[1] == null) {
-    return refuse("no-match", "node has no removable span (likely the synthetic root)");
-  }
-  const span = trueSpan(node, source);
-  if (span[0] == null || span[1] == null) {
-    return refuse("no-match", "node has no removable span (likely the synthetic root)");
+
+  const span = findTrueSpan(byId, node, source);
+  if (!spanLooksSane(source, node, span)) {
+    return refuse(
+      "no-match",
+      "could not lexically re-locate the node's true source span without trusting compiler offsets — refusing rather than risking corruption"
+    );
   }
 
   // Trim a single leading run of horizontal whitespace back to (but not past) a preceding

--- a/server/component-structure-edit.mjs
+++ b/server/component-structure-edit.mjs
@@ -9,6 +9,13 @@ function refuse(reason, detail) {
   return { refused: true, reason, detail };
 }
 
+// Matches escapeAttr in create-content.mjs: escape "&" first (so it doesn't
+// double-escape the entities this introduces), then escape '"' so the value
+// can't break out of the double-quoted attribute it's interpolated into.
+function escapeAttr(s) {
+  return String(s).replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
 function validPath(relPath) {
   return typeof relPath === "string" && relPath.endsWith(".astro") && !normalize(relPath).startsWith("..") && !relPath.startsWith("/");
 }
@@ -28,7 +35,7 @@ async function loadFresh(projectRoot, relPath, baseVersion) {
   try {
     ({ ast } = await parse(source, { position: true }));
   } catch (err) {
-    return { error: refuse("invalid-input", `parse ${relPath}: ${err.message}`) };
+    return { error: refuse("parse-failed", `parse ${relPath}: ${err.message}`) };
   }
   const { byId, rootId } = buildTemplateNodeIndex(ast, source);
   return { source, ast, byId, rootId };
@@ -50,13 +57,13 @@ export async function resolveComponentStructure(projectRoot, edit) {
 
   switch (edit.op) {
     case "set-attr":
-      return applySetAttr(relPath, byId, component);
+      return applySetAttr(relPath, source, byId, component);
     default:
       return refuse("invalid-input", `unsupported component-structure op: ${edit.op}`);
   }
 }
 
-function applySetAttr(file, byId, component) {
+function applySetAttr(file, source, byId, component) {
   const { nodeId, name, value } = component;
   if (typeof nodeId !== "string" || typeof name !== "string") {
     return refuse("invalid-input", "set-attr requires component.nodeId and component.name");
@@ -69,14 +76,19 @@ function applySetAttr(file, byId, component) {
 
   if (value === null || value === undefined) {
     if (!existing) return refuse("no-match", `node has no attribute "${name}" to remove`);
-    // Trim exactly the one leading space that separated this attribute from the previous
-    // token (tag name or prior attribute) so removal doesn't leave a double space.
-    const start = existing.span[0] - 1 >= 0 ? existing.span[0] - 1 : existing.span[0];
+    // Mirrors applyRemoveStyleProperty in component-style-edit.mjs: trim leading horizontal
+    // whitespace back to (but not past) a preceding newline, then also swallow that one
+    // newline, so removing an attribute on a one-per-line-formatted tag doesn't leave a
+    // blank/trailing-whitespace line behind. On a single-line tag this just trims back to
+    // the previous token (tag name or prior attribute), same as before.
+    let start = existing.span[0];
+    while (start > 0 && (source[start - 1] === " " || source[start - 1] === "\t")) start--;
+    if (start > 0 && source[start - 1] === "\n") start--;
     return { file, range: { start, end: existing.span[1] }, replacement: "" };
   }
 
   if (existing) {
-    return { file, range: { start: existing.span[0], end: existing.span[1] }, replacement: `${name}="${value}"` };
+    return { file, range: { start: existing.span[0], end: existing.span[1] }, replacement: `${name}="${escapeAttr(value)}"` };
   }
   // Insert right after the opening tag name / last attribute — i.e. at the end of the node's
   // own attribute list. `node.span[0]` is the start of `<tag`; the tag-name end is the offset
@@ -84,5 +96,5 @@ function applySetAttr(file, byId, component) {
   // attribute's end when present; otherwise fall back to just after the tag name.
   const lastAttr = node.attrs[node.attrs.length - 1];
   const insertAt = lastAttr ? lastAttr.span[1] : node.span[0] + 1 + (node.tag?.length ?? 0);
-  return { file, range: { start: insertAt, end: insertAt }, replacement: ` ${name}="${value}"` };
+  return { file, range: { start: insertAt, end: insertAt }, replacement: ` ${name}="${escapeAttr(value)}"` };
 }

--- a/server/component-structure-edit.mjs
+++ b/server/component-structure-edit.mjs
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { join, normalize, dirname, relative } from "node:path";
+import { join, normalize, dirname, relative, sep } from "node:path";
 import { parse } from "@astrojs/compiler";
 import { fileVersion } from "./file-version.mjs";
 import { buildTemplateNodeIndex } from "./component-node-index.mjs";
@@ -60,6 +60,8 @@ export async function resolveComponentStructure(projectRoot, edit) {
       return applySetAttr(relPath, source, byId, component);
     case "remove-node":
       return applyRemoveNode(relPath, source, byId, rootId, component);
+    case "insert-node":
+      return applyInsertNode(relPath, source, byId, rootId, component);
     default:
       return refuse("invalid-input", `unsupported component-structure op: ${edit.op}`);
   }
@@ -462,4 +464,145 @@ function collectComponentTags(byId, nodeId) {
   }
   walk(nodeId);
   return names;
+}
+
+function buildMarkup(nodeSpec) {
+  if (nodeSpec.kind === "slot") {
+    return nodeSpec.slotName ? `<slot name="${escapeAttr(nodeSpec.slotName)}" />` : `<slot />`;
+  }
+  if (nodeSpec.kind === "component") {
+    return `<${nodeSpec.tag} />`;
+  }
+  return `<${nodeSpec.tag}></${nodeSpec.tag}>`;
+}
+
+/** Relative import specifier from the target component's own directory to the component
+ *  being inserted, Astro-style (keeps the .astro extension, always POSIX-separated, always
+ *  prefixed with ./ or ../ so it never gets mistaken for a bare-specifier package import). */
+function importSpecifier(targetRelPath, componentRelPath) {
+  const rel = relative(dirname(targetRelPath), componentRelPath).split(sep).join("/");
+  return rel.startsWith(".") ? rel : `./${rel}`;
+}
+
+// Offset just inside `parent`'s content when it currently has no (resolvable) children to
+// anchor on — i.e. "right after the opening tag" for a real element/component/slot, or
+// "end of file" for the synthetic fragment root (which has no lexical open/close tag of
+// its own to anchor on). Returns null when a safe insertion point can't be determined
+// (parent's own span wasn't resolved, or it turns out to be self-closing/void and
+// therefore has no content region to insert into at all).
+function childlessInsertionPoint(parent, rootId, spans, source) {
+  if (parent.id === rootId) return source.length;
+  const parentSpan = spans.get(parent.id);
+  if (!parentSpan) return null;
+  const wholeText = source.slice(parentSpan[0], parentSpan[1]);
+  if (wholeText.endsWith("/>") || VOID_ELEMENTS.has(parent.tag)) return null; // no closing tag to insert before
+  const closeTag = `</${parent.tag}>`;
+  const candidate = parentSpan[1] - closeTag.length;
+  return source.slice(candidate, parentSpan[1]) === closeTag ? candidate : parentSpan[1];
+}
+
+// The non-empty-children insertion offset (below, inlined in `applyInsertNode`) picks the
+// nearest RESOLVABLE sibling as its anchor, since text-kind children (and any node
+// `resolveAllSpans` couldn't resolve) have no entry in `spans`:
+//   - Appending (clampedIndex === children.length): the nearest resolvable sibling
+//     searching BACKWARD from the end, anchored at its span END.
+//   - Inserting before children[clampedIndex]: the nearest resolvable sibling searching
+//     FORWARD from that index, anchored at its span START (so the new node lands
+//     immediately before it); if none found forward, falls back to searching BACKWARD for
+//     the nearest resolvable PRECEDING sibling's span END instead. If no child in the list
+//     is resolvable at all, falls back to the childless-parent case.
+
+function applyInsertNode(file, source, byId, rootId, component) {
+  const { parentId, index, node: nodeSpec } = component;
+  if (typeof parentId !== "string" || typeof index !== "number" || !nodeSpec || typeof nodeSpec !== "object") {
+    return refuse("invalid-input", "insert-node requires component.parentId, component.index, and component.node");
+  }
+  if (!["element", "component", "slot"].includes(nodeSpec.kind)) {
+    return refuse("invalid-input", `unsupported node.kind: ${nodeSpec.kind}`);
+  }
+  if ((nodeSpec.kind === "element" || nodeSpec.kind === "component") && typeof nodeSpec.tag !== "string") {
+    return refuse("invalid-input", "node.tag is required for element/component inserts");
+  }
+  if (nodeSpec.kind === "component" && typeof nodeSpec.componentPath !== "string") {
+    return refuse("invalid-input", "node.componentPath is required for component inserts");
+  }
+
+  const parent = byId.get(parentId);
+  if (!parent) return refuse("no-match", "no parent node found at the given id — the file may have changed");
+  if (parent.kind === "text") {
+    return refuse("invalid-input", "cannot insert into a text node — it has no children");
+  }
+
+  // Same discipline as remove-node: NEVER trust `node.span`/`position.offset` straight off
+  // `byId` (unreliable for expression-kind nodes, and historically for others too — see
+  // the file-level comment above `resolveAllSpans`). Every insertion offset below is
+  // derived exclusively from the `spans` Map this returns.
+  let spans;
+  try {
+    spans = resolveAllSpans(byId, rootId, source);
+  } catch (err) {
+    if (!(err instanceof SpanResolutionError)) throw err;
+    return refuse(
+      "no-match",
+      "could not lexically re-locate the parent's true source span without trusting compiler offsets — refusing rather than risking corruption"
+    );
+  }
+
+  const children = parent.childIds.map((id) => byId.get(id));
+  let insertAt;
+  if (children.length === 0) {
+    insertAt = childlessInsertionPoint(parent, rootId, spans, source);
+  } else {
+    const clampedIndex = Math.max(0, Math.min(index, children.length));
+    if (clampedIndex === children.length) {
+      // Append: nearest resolvable sibling searching backward, anchored at its span end.
+      for (let i = children.length - 1; i >= 0 && insertAt == null; i--) {
+        const span = spans.get(children[i].id);
+        if (span) insertAt = span[1];
+      }
+    } else {
+      // Insert before children[clampedIndex]: nearest resolvable sibling searching
+      // forward, anchored at its span start (lands immediately before it).
+      for (let i = clampedIndex; i < children.length && insertAt == null; i++) {
+        const span = spans.get(children[i].id);
+        if (span) insertAt = span[0];
+      }
+      // None found forward (e.g. only trailing text children remain) — fall back to the
+      // nearest resolvable PRECEDING sibling's span end instead.
+      if (insertAt == null) {
+        for (let i = clampedIndex - 1; i >= 0 && insertAt == null; i--) {
+          const span = spans.get(children[i].id);
+          if (span) insertAt = span[1];
+        }
+      }
+    }
+    // No child in the list was resolvable at all — fall back to the childless case.
+    if (insertAt == null) {
+      insertAt = childlessInsertionPoint(parent, rootId, spans, source);
+    }
+  }
+
+  if (insertAt == null) {
+    return refuse("no-match", "could not resolve an insertion point for the given parent/index");
+  }
+
+  const markup = buildMarkup(nodeSpec);
+  const withNode = source.slice(0, insertAt) + markup + source.slice(insertAt);
+
+  if (nodeSpec.kind !== "component") {
+    return { file, range: { start: 0, end: source.length }, replacement: withNode };
+  }
+
+  // Component insert: also add (or reuse) its default import in the frontmatter.
+  const fmMatch = withNode.match(/^(---\r?\n)([\s\S]*?)(\r?\n---)/);
+  if (!fmMatch) {
+    // No frontmatter at all yet — synthesize one carrying just the import.
+    const importLine = `import ${nodeSpec.tag} from "${importSpecifier(file, nodeSpec.componentPath)}";\n`;
+    return { file, range: { start: 0, end: source.length }, replacement: `---\n${importLine}---\n${withNode}` };
+  }
+  const [, open, fmBody] = fmMatch;
+  const fmBodyStart = fmMatch.index + open.length;
+  const { source: newFmBody } = ensureImport(fmBody, { localName: nodeSpec.tag, specifier: importSpecifier(file, nodeSpec.componentPath) });
+  const rewritten = withNode.slice(0, fmBodyStart) + newFmBody + withNode.slice(fmBodyStart + fmBody.length);
+  return { file, range: { start: 0, end: source.length }, replacement: rewritten };
 }

--- a/server/component-structure-edit.mjs
+++ b/server/component-structure-edit.mjs
@@ -311,6 +311,13 @@ class SpanResolutionError extends Error {
   }
 }
 
+// HTML void elements: never have a closing tag, self-closing or not — same terminal
+// handling as an explicit self-closing tag (<img />). https://html.spec.whatwg.org/#void-elements
+const VOID_ELEMENTS = new Set([
+  "area", "base", "br", "col", "embed", "hr", "img", "input",
+  "link", "meta", "param", "source", "track", "wbr",
+]);
+
 // Reconstructs correct byte spans for every element/component/slot/fragment/expression
 // node in `byId` in one full depth-first walk, in lockstep with a monotonically
 // advancing cursor through `source` (see the file-level comment above for why this
@@ -354,12 +361,16 @@ function resolveAllSpans(byId, rootId, source) {
     if (openIdx === -1 || (boundEnd != null && openIdx >= boundEnd)) throw new SpanResolutionError(nodeId);
     const tagInfo = scanTagOpen(masked, openIdx);
     if (!tagInfo) throw new SpanResolutionError(nodeId);
-    if (tagInfo.selfClosing || node.childIds.length === 0) {
-      if (tagInfo.selfClosing) {
-        spans.set(nodeId, [openIdx, tagInfo.end]);
-        cursor = tagInfo.end;
-        return;
-      }
+    // Void elements (<img>, <br>, etc.) never have a closing tag — treat them as
+    // terminal at their own opening tag's end, same as an explicit self-closing tag,
+    // regardless of what the model reports for childIds. Checked before the close-tag
+    // search below so a bare `<img src="x">` never triggers a `</img>` lookup.
+    if (tagInfo.selfClosing || VOID_ELEMENTS.has(node.tag)) {
+      spans.set(nodeId, [openIdx, tagInfo.end]);
+      cursor = tagInfo.end;
+      return;
+    }
+    if (node.childIds.length === 0) {
       // Childless in the model (no element/component/expression/non-blank-text child)
       // but not self-closing — e.g. `<p></p>` or `<div>   </div>`. Still has a real
       // close tag; find it directly from just past the open tag.

--- a/server/component-structure-edit.mjs
+++ b/server/component-structure-edit.mjs
@@ -1,0 +1,88 @@
+import { readFileSync } from "node:fs";
+import { join, normalize, dirname, relative } from "node:path";
+import { parse } from "@astrojs/compiler";
+import { fileVersion } from "./file-version.mjs";
+import { buildTemplateNodeIndex } from "./component-node-index.mjs";
+import { ensureImport, pruneImportIfUnused } from "./frontmatter-imports.mjs";
+
+function refuse(reason, detail) {
+  return { refused: true, reason, detail };
+}
+
+function validPath(relPath) {
+  return typeof relPath === "string" && relPath.endsWith(".astro") && !normalize(relPath).startsWith("..") && !relPath.startsWith("/");
+}
+
+async function loadFresh(projectRoot, relPath, baseVersion) {
+  const absPath = join(projectRoot, relPath);
+  let source;
+  try {
+    source = readFileSync(absPath, "utf-8");
+  } catch (err) {
+    return { error: refuse("read-failed", `read ${relPath}: ${err.message}`) };
+  }
+  if (fileVersion(source) !== baseVersion) {
+    return { error: refuse("stale", `${relPath} changed since the model was fetched`) };
+  }
+  let ast;
+  try {
+    ({ ast } = await parse(source, { position: true }));
+  } catch (err) {
+    return { error: refuse("invalid-input", `parse ${relPath}: ${err.message}`) };
+  }
+  const { byId, rootId } = buildTemplateNodeIndex(ast, source);
+  return { source, ast, byId, rootId };
+}
+
+export async function resolveComponentStructure(projectRoot, edit) {
+  const { component } = edit;
+  if (!component || typeof component !== "object") {
+    return refuse("invalid-input", "component payload is required for this op");
+  }
+  const { path: relPath, baseVersion } = component;
+  if (!validPath(relPath)) {
+    return refuse("invalid-input", `not a project-relative .astro path: ${relPath}`);
+  }
+
+  const loaded = await loadFresh(projectRoot, relPath, baseVersion);
+  if (loaded.error) return loaded.error;
+  const { source, byId } = loaded;
+
+  switch (edit.op) {
+    case "set-attr":
+      return applySetAttr(relPath, byId, component);
+    default:
+      return refuse("invalid-input", `unsupported component-structure op: ${edit.op}`);
+  }
+}
+
+function applySetAttr(file, byId, component) {
+  const { nodeId, name, value } = component;
+  if (typeof nodeId !== "string" || typeof name !== "string") {
+    return refuse("invalid-input", "set-attr requires component.nodeId and component.name");
+  }
+  const node = byId.get(nodeId);
+  if (!node || node.span[0] == null || node.span[1] == null) {
+    return refuse("no-match", "no node found at the given id — the file may have changed");
+  }
+  const existing = node.attrs.find((a) => a.name === name);
+
+  if (value === null || value === undefined) {
+    if (!existing) return refuse("no-match", `node has no attribute "${name}" to remove`);
+    // Trim exactly the one leading space that separated this attribute from the previous
+    // token (tag name or prior attribute) so removal doesn't leave a double space.
+    const start = existing.span[0] - 1 >= 0 ? existing.span[0] - 1 : existing.span[0];
+    return { file, range: { start, end: existing.span[1] }, replacement: "" };
+  }
+
+  if (existing) {
+    return { file, range: { start: existing.span[0], end: existing.span[1] }, replacement: `${name}="${value}"` };
+  }
+  // Insert right after the opening tag name / last attribute — i.e. at the end of the node's
+  // own attribute list. `node.span[0]` is the start of `<tag`; the tag-name end is the offset
+  // right before the first attribute (or before `>`/`/>` if there are none). Reuse the last
+  // attribute's end when present; otherwise fall back to just after the tag name.
+  const lastAttr = node.attrs[node.attrs.length - 1];
+  const insertAt = lastAttr ? lastAttr.span[1] : node.span[0] + 1 + (node.tag?.length ?? 0);
+  return { file, range: { start: insertAt, end: insertAt }, replacement: ` ${name}="${value}"` };
+}

--- a/server/component-structure-edit.mjs
+++ b/server/component-structure-edit.mjs
@@ -62,6 +62,8 @@ export async function resolveComponentStructure(projectRoot, edit) {
       return applyRemoveNode(relPath, source, byId, rootId, component);
     case "insert-node":
       return applyInsertNode(relPath, source, byId, rootId, component);
+    case "move-node":
+      return applyMoveNode(relPath, source, byId, rootId, component);
     default:
       return refuse("invalid-input", `unsupported component-structure op: ${edit.op}`);
   }
@@ -501,9 +503,14 @@ function childlessInsertionPoint(parent, rootId, spans, source) {
   return source.slice(candidate, parentSpan[1]) === closeTag ? candidate : parentSpan[1];
 }
 
-// The non-empty-children insertion offset (below, inlined in `applyInsertNode`) picks the
-// nearest RESOLVABLE sibling as its anchor, since text-kind children (and any node
-// `resolveAllSpans` couldn't resolve) have no entry in `spans`:
+// Resolves the character offset in `source` at which to insert new content as a child of
+// `parent` at position `index` (clamped to the child count). Shared by insert-node (new
+// content, nothing excluded) and move-node (destination side; excludes the node being
+// moved from the sibling list, since it may already be a child of `parent` when reordering
+// in place).
+//
+// Picks the nearest RESOLVABLE sibling as its anchor, since text-kind children (and any
+// node `resolveAllSpans` couldn't resolve) have no entry in `spans`:
 //   - Appending (clampedIndex === children.length): the nearest resolvable sibling
 //     searching BACKWARD from the end, anchored at its span END.
 //   - Inserting before children[clampedIndex]: the nearest resolvable sibling searching
@@ -511,6 +518,37 @@ function childlessInsertionPoint(parent, rootId, spans, source) {
 //     immediately before it); if none found forward, falls back to searching BACKWARD for
 //     the nearest resolvable PRECEDING sibling's span END instead. If no child in the list
 //     is resolvable at all, falls back to the childless-parent case.
+//
+// Returns null when no insertion point could be resolved.
+function resolveInsertionOffset(byId, rootId, spans, source, parent, index, excludeChildId) {
+  const children = parent.childIds.filter((id) => id !== excludeChildId).map((id) => byId.get(id));
+  if (children.length === 0) {
+    return childlessInsertionPoint(parent, rootId, spans, source);
+  }
+  const clampedIndex = Math.max(0, Math.min(index, children.length));
+  let insertAt = null;
+  if (clampedIndex === children.length) {
+    for (let i = children.length - 1; i >= 0 && insertAt == null; i--) {
+      const span = spans.get(children[i].id);
+      if (span) insertAt = span[1];
+    }
+  } else {
+    for (let i = clampedIndex; i < children.length && insertAt == null; i++) {
+      const span = spans.get(children[i].id);
+      if (span) insertAt = span[0];
+    }
+    if (insertAt == null) {
+      for (let i = clampedIndex - 1; i >= 0 && insertAt == null; i--) {
+        const span = spans.get(children[i].id);
+        if (span) insertAt = span[1];
+      }
+    }
+  }
+  if (insertAt == null) {
+    insertAt = childlessInsertionPoint(parent, rootId, spans, source);
+  }
+  return insertAt;
+}
 
 function applyInsertNode(file, source, byId, rootId, component) {
   const { parentId, index, node: nodeSpec } = component;
@@ -548,40 +586,7 @@ function applyInsertNode(file, source, byId, rootId, component) {
     );
   }
 
-  const children = parent.childIds.map((id) => byId.get(id));
-  let insertAt;
-  if (children.length === 0) {
-    insertAt = childlessInsertionPoint(parent, rootId, spans, source);
-  } else {
-    const clampedIndex = Math.max(0, Math.min(index, children.length));
-    if (clampedIndex === children.length) {
-      // Append: nearest resolvable sibling searching backward, anchored at its span end.
-      for (let i = children.length - 1; i >= 0 && insertAt == null; i--) {
-        const span = spans.get(children[i].id);
-        if (span) insertAt = span[1];
-      }
-    } else {
-      // Insert before children[clampedIndex]: nearest resolvable sibling searching
-      // forward, anchored at its span start (lands immediately before it).
-      for (let i = clampedIndex; i < children.length && insertAt == null; i++) {
-        const span = spans.get(children[i].id);
-        if (span) insertAt = span[0];
-      }
-      // None found forward (e.g. only trailing text children remain) — fall back to the
-      // nearest resolvable PRECEDING sibling's span end instead.
-      if (insertAt == null) {
-        for (let i = clampedIndex - 1; i >= 0 && insertAt == null; i--) {
-          const span = spans.get(children[i].id);
-          if (span) insertAt = span[1];
-        }
-      }
-    }
-    // No child in the list was resolvable at all — fall back to the childless case.
-    if (insertAt == null) {
-      insertAt = childlessInsertionPoint(parent, rootId, spans, source);
-    }
-  }
-
+  const insertAt = resolveInsertionOffset(byId, rootId, spans, source, parent, index, undefined);
   if (insertAt == null) {
     return refuse("no-match", "could not resolve an insertion point for the given parent/index");
   }
@@ -604,5 +609,107 @@ function applyInsertNode(file, source, byId, rootId, component) {
   const fmBodyStart = fmMatch.index + open.length;
   const { source: newFmBody } = ensureImport(fmBody, { localName: nodeSpec.tag, specifier: importSpecifier(file, nodeSpec.componentPath) });
   const rewritten = withNode.slice(0, fmBodyStart) + newFmBody + withNode.slice(fmBodyStart + fmBody.length);
+  return { file, range: { start: 0, end: source.length }, replacement: rewritten };
+}
+
+// True if `nodeId` is a descendant of `ancestorId`, walking `byId`'s `parentId` chain
+// upward from `nodeId`. Used to refuse move-node when the requested destination sits
+// inside the subtree of the node being moved (which would otherwise create a cycle).
+function isDescendant(byId, ancestorId, nodeId) {
+  const node = byId.get(nodeId);
+  let cur = node?.parentId ?? null;
+  while (cur !== null) {
+    if (cur === ancestorId) return true;
+    cur = byId.get(cur)?.parentId ?? null;
+  }
+  return false;
+}
+
+// move-node is an in-source remove-then-reinsert against a single mutable string, done in
+// ONE splice against the ORIGINAL (pre-removal) source rather than two sequential edits.
+// Both the node's own span and the destination insertion offset are resolved from the same
+// `resolveAllSpans` call, over the SAME unmutated `source` — exactly like remove-node and
+// insert-node resolve their spans/offsets, and for the same reason (never trust
+// `node.span`/`position.offset` straight off `byId`, see the file-level comment above
+// `resolveAllSpans`).
+//
+// Because both offsets are resolved against the original string, removing the node's old
+// text shifts every offset that came after it — including, potentially, the destination
+// insertion offset. Rather than computing that shift as a separate correction pass, the
+// splice below picks one of two mutually exclusive orderings directly from the ORIGINAL
+// offsets:
+//   - insertAt <= removeStart: the destination is at or before the node's own (trimmed)
+//     removal start, so the removal happens entirely AFTER the insertion point in the
+//     original string — insert first, then everything from the insertion point up to
+//     removeStart carries over unshifted, and the removed range is simply dropped.
+//   - insertAt >= removeEnd: the destination is at or after the node's own removal end, so
+//     the removal happens entirely BEFORE the insertion point — the removed range is
+//     dropped first, then everything from removeEnd up to the insertion point carries over
+//     unshifted, followed by the moved node's text, then the remainder.
+// A destination offset strictly BETWEEN removeStart and removeEnd would mean landing inside
+// the very span being removed; the ancestor check earlier already rules out the structural
+// case that would cause this (moving into your own subtree), but it's guarded again below
+// as a fail-closed check rather than assumed.
+function applyMoveNode(file, source, byId, rootId, component) {
+  const { nodeId, newParentId, newIndex } = component;
+  if (typeof nodeId !== "string" || typeof newParentId !== "string" || typeof newIndex !== "number") {
+    return refuse("invalid-input", "move-node requires component.nodeId, component.newParentId, and component.newIndex");
+  }
+  const node = byId.get(nodeId);
+  const newParent = byId.get(newParentId);
+  if (!node || !newParent) return refuse("no-match", "nodeId or newParentId not found — the file may have changed");
+  if (node.parentId === null) return refuse("invalid-input", "cannot move the component's root");
+  if (newParent.kind === "text") {
+    return refuse("invalid-input", "cannot move a node into a text node — it has no children");
+  }
+  if (nodeId === newParentId || isDescendant(byId, nodeId, newParentId)) {
+    return refuse("invalid-input", "cannot move a node into its own subtree");
+  }
+
+  let spans;
+  try {
+    spans = resolveAllSpans(byId, rootId, source);
+  } catch (err) {
+    if (!(err instanceof SpanResolutionError)) throw err;
+    return refuse(
+      "no-match",
+      "could not lexically re-locate the node's true source span without trusting compiler offsets — refusing rather than risking corruption"
+    );
+  }
+  const nodeSpan = spans.get(nodeId);
+  if (!nodeSpan) {
+    return refuse(
+      "no-match",
+      "could not lexically re-locate the node's true source span without trusting compiler offsets — refusing rather than risking corruption"
+    );
+  }
+
+  // Resolve the destination offset on the ORIGINAL source, excluding the moving node from
+  // `newParent`'s own children list (it may already be one of them, when reordering siblings
+  // in place — see the file-level comment above `resolveInsertionOffset`).
+  const insertAt = resolveInsertionOffset(byId, rootId, spans, source, newParent, newIndex, nodeId);
+  if (insertAt == null) {
+    return refuse("no-match", "could not resolve an insertion point for the given newParentId/newIndex");
+  }
+
+  const nodeText = source.slice(nodeSpan[0], nodeSpan[1]);
+
+  // Same whitespace/newline cleanup remove-node uses at the node's old location: trim a
+  // leading run of horizontal whitespace back to (but not past) a preceding newline, then
+  // swallow that newline too, so the old location doesn't leave a blank line behind.
+  let removeStart = nodeSpan[0];
+  while (removeStart > 0 && (source[removeStart - 1] === " " || source[removeStart - 1] === "\t")) removeStart--;
+  if (removeStart > 0 && source[removeStart - 1] === "\n") removeStart--;
+  const removeEnd = nodeSpan[1];
+
+  if (insertAt > removeStart && insertAt < removeEnd) {
+    return refuse("invalid-input", "insertion point falls inside the node's own span being moved");
+  }
+
+  const rewritten =
+    insertAt <= removeStart
+      ? source.slice(0, insertAt) + nodeText + source.slice(insertAt, removeStart) + source.slice(removeEnd)
+      : source.slice(0, removeStart) + source.slice(removeEnd, insertAt) + nodeText + source.slice(insertAt);
+
   return { file, range: { start: 0, end: source.length }, replacement: rewritten };
 }

--- a/server/component-structure-edit.mjs
+++ b/server/component-structure-edit.mjs
@@ -78,6 +78,14 @@ function applySetAttr(file, source, byId, component) {
   if (!node || node.span[0] == null || node.span[1] == null) {
     return refuse("no-match", "no node found at the given id — the file may have changed");
   }
+  // Only element/component/slot nodes are tag-shaped (`<tag ...>`); text and shorthand
+  // fragments have no attribute list to search or insert into, and expression nodes'
+  // spans are unreliable even via line/column (see resolveAllSpans' file-level comment).
+  // Trusting node.span/node.attrs for any other kind would splice attribute syntax into
+  // running text or an unreliable expression span instead of refusing.
+  if (node.kind !== "element" && node.kind !== "component" && node.kind !== "slot") {
+    return refuse("invalid-input", `set-attr requires a tag-shaped node (element/component/slot), got kind=${node.kind}`);
+  }
   const existing = node.attrs.find((a) => a.name === name);
 
   if (value === null || value === undefined) {

--- a/server/component-structure-edit.mjs
+++ b/server/component-structure-edit.mjs
@@ -58,6 +58,8 @@ export async function resolveComponentStructure(projectRoot, edit) {
   switch (edit.op) {
     case "set-attr":
       return applySetAttr(relPath, source, byId, component);
+    case "remove-node":
+      return applyRemoveNode(relPath, source, byId, component);
     default:
       return refuse("invalid-input", `unsupported component-structure op: ${edit.op}`);
   }
@@ -97,4 +99,108 @@ function applySetAttr(file, source, byId, component) {
   const lastAttr = node.attrs[node.attrs.length - 1];
   const insertAt = lastAttr ? lastAttr.span[1] : node.span[0] + 1 + (node.tag?.length ?? 0);
   return { file, range: { start: insertAt, end: insertAt }, replacement: ` ${name}="${escapeAttr(value)}"` };
+}
+
+// @astrojs/compiler (4.0.0) reports unreliable source positions for "expression"
+// nodes: `position.start.offset` lands one character before the actual opening
+// "{" (confirmed against multiple fixtures), and `position.end.offset` can be
+// arbitrary/out-of-bounds garbage once the expression contains nested JSX that
+// itself carries an expression (e.g. `{items.map((i) => (<li>{i}</li>))}`) —
+// the reported end offset was seen to exceed the file length entirely, which
+// silently truncates a naive `source.slice()`-based removal. Recompute the
+// true span for expression nodes directly from the source via brace-depth
+// matching (skipping string/template-literal contents) instead of trusting
+// the parser's position for this node kind. Other node kinds (element,
+// component, text, ...) don't exhibit this and keep their reported span.
+function trueSpan(node, source) {
+  if (node.kind !== "expression" || node.span[0] == null) return node.span;
+  let start = node.span[0];
+  while (start < source.length && source[start] !== "{") start++;
+  if (start >= source.length) return node.span;
+
+  let depth = 0;
+  let quote = null;
+  for (let i = start; i < source.length; i++) {
+    const ch = source[i];
+    if (quote) {
+      if (ch === "\\") {
+        i++;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      continue;
+    }
+    if (ch === "{") {
+      depth++;
+    } else if (ch === "}") {
+      depth--;
+      if (depth === 0) return [start, i + 1];
+    }
+  }
+  return node.span;
+}
+
+function applyRemoveNode(file, source, byId, component) {
+  const { nodeId } = component;
+  if (typeof nodeId !== "string") {
+    return refuse("invalid-input", "remove-node requires component.nodeId");
+  }
+  const node = byId.get(nodeId);
+  if (!node) return refuse("no-match", "no node found at the given id — the file may have changed");
+  if (node.parentId === null) return refuse("invalid-input", "cannot remove the component's root");
+  if (node.span[0] == null || node.span[1] == null) {
+    return refuse("no-match", "node has no removable span (likely the synthetic root)");
+  }
+  const span = trueSpan(node, source);
+  if (span[0] == null || span[1] == null) {
+    return refuse("no-match", "node has no removable span (likely the synthetic root)");
+  }
+
+  // Trim a single leading run of horizontal whitespace back to (but not past) a preceding
+  // newline, then swallow that newline too — mirrors remove-style-property's cleanup so
+  // removing a node doesn't leave a blank line in its place.
+  let start = span[0];
+  while (start > 0 && (source[start - 1] === " " || source[start - 1] === "\t")) start--;
+  if (start > 0 && source[start - 1] === "\n") start--;
+
+  const withoutNode = source.slice(0, start) + source.slice(span[1]);
+
+  // Prune now-unused component imports. Only meaningful for `component`-kind nodes (and any
+  // component-kind descendants the removed subtree also carried away); walk the removed
+  // subtree collecting component tag names, then check each against the frontmatter's import
+  // list against the POST-removal template text.
+  const removedComponentNames = collectComponentTags(byId, nodeId);
+  if (removedComponentNames.length === 0) {
+    return { file, range: { start: 0, end: source.length }, replacement: withoutNode };
+  }
+
+  const fmMatch = withoutNode.match(/^(---\r?\n)([\s\S]*?)(\r?\n---)/);
+  if (!fmMatch) {
+    return { file, range: { start: 0, end: source.length }, replacement: withoutNode };
+  }
+  const [whole, open, fmBody, close] = fmMatch;
+  const fmStart = fmMatch.index;
+  const fmBodyStart = fmStart + open.length;
+  let newFmBody = fmBody;
+  for (const name of removedComponentNames) {
+    newFmBody = pruneImportIfUnused(newFmBody, withoutNode.slice(fmStart + whole.length), name).source;
+  }
+  const rewritten = withoutNode.slice(0, fmBodyStart) + newFmBody + withoutNode.slice(fmBodyStart + fmBody.length);
+  return { file, range: { start: 0, end: source.length }, replacement: rewritten };
+}
+
+function collectComponentTags(byId, nodeId) {
+  const names = [];
+  function walk(id) {
+    const n = byId.get(id);
+    if (!n) return;
+    if (n.kind === "component" && n.tag) names.push(n.tag);
+    for (const c of n.childIds) walk(c);
+  }
+  walk(nodeId);
+  return names;
 }

--- a/server/component-structure-edit.mjs
+++ b/server/component-structure-edit.mjs
@@ -53,13 +53,13 @@ export async function resolveComponentStructure(projectRoot, edit) {
 
   const loaded = await loadFresh(projectRoot, relPath, baseVersion);
   if (loaded.error) return loaded.error;
-  const { source, byId } = loaded;
+  const { source, byId, rootId } = loaded;
 
   switch (edit.op) {
     case "set-attr":
       return applySetAttr(relPath, source, byId, component);
     case "remove-node":
-      return applyRemoveNode(relPath, source, byId, component);
+      return applyRemoveNode(relPath, source, byId, rootId, component);
     default:
       return refuse("invalid-input", `unsupported component-structure op: ${edit.op}`);
   }
@@ -104,47 +104,51 @@ function applySetAttr(file, source, byId, component) {
 // @astrojs/compiler (4.0.0) reports CORRUPTED source positions for ANY node kind —
 // element/component/fragment/slot as well as "expression" — whenever astral-plane
 // Unicode (e.g. an emoji) appears anywhere in the source BEFORE that node. The
-// corruption is not a fixed/predictable delta, so `position.start/end.offset` cannot
-// be trusted, patched, or scanned-forward-from for ANY node kind (an earlier version of
-// this file only patched expression-kind nodes by scanning forward from the reported
-// offset for the next literal "{" — that can land on the WRONG node entirely under this
-// bug, silently deleting an unrelated sibling). Root-causing the compiler's offset math
-// is out of scope here; instead, remove-node NEVER consults `node.span`/`position.offset`
-// to locate a removal boundary. It re-derives the node's true span purely lexically from
-// `source`, anchored by the node's ordinal position among same-(kind,tag) siblings under
-// its parent — `byId`'s parent/child SHAPE (not its offsets) is unaffected by the bug,
-// since it comes from the AST tree structure, not from position numbers.
+// corruption is not a fixed/predictable delta, so `position.start/end.offset` cannot be
+// trusted, patched, or scanned-forward-from for ANY node kind. Root-causing the
+// compiler's offset math is out of scope here; instead, remove-node NEVER consults
+// `node.span`/`position.offset` to locate a removal boundary.
 //
-// Two lexical scanners do the actual span-finding, operating on `source` with
-// frontmatter/`<style>`/`<script>`/HTML-comment zones blanked out (`maskOpaqueZones`) so
-// stray `<`, `>`, `{`, `}` in those regions can't produce false matches:
-//   - findNthExpressionBlock: the k-th top-level `{...}` block in *text* position
-//     (i.e. not inside a tag's own attribute list — `<div class={x}>`'s `{x}` doesn't
-//     count) anywhere in the source.
-//   - findNthTagSpan: the k-th `<tagName ...>...</tagName>` (or self-closing
-//     `<tagName ... />`) occurrence of a given tag name anywhere in the source, with its
-//     true matching close resolved via depth-counting over nested same-name tags.
+// A first fix (see git history) re-derived each node's span by finding the k-th
+// DOCUMENT-WIDE occurrence of its `(kind, tag)` marker, where k was the node's ordinal
+// among its TRUE parent's children. That broke whenever an EARLIER sibling contained a
+// nested descendant of the same `(kind, tag)` — e.g. `<div><div>Inner</div></div>
+// <div>Target</div>`: removing the second top-level `<div>` instead silently removed
+// "Inner", because document-wide occurrence counting doesn't respect nesting depth (the
+// 2nd `<div>` textually is nested one level inside the FIRST top-level div, not a
+// sibling of "Target" at all). Same bug for expressions.
 //
-// Both scan the WHOLE source rather than a "search window" bounded by the parent's own
-// span — the parent's span may ALSO be corrupted, so it can't be trusted as a bound
-// either. The sibling-ordinal anchor (not a tight window) is what disambiguates.
+// `resolveAllSpans` replaces that ordinal search with a monotonic-cursor parallel walk:
+// it walks `byId` in the SAME depth-first order the AST was built in (that order is
+// already correct — @astrojs/compiler gets tree STRUCTURE right; only its byte OFFSETS
+// are corrupted), advancing a single cursor through `source` in lockstep. The cursor
+// only ever moves forward and always fully consumes a node's entire extent (including
+// all its descendants) before searching for the NEXT sibling, so a later sibling's
+// search can never accidentally match something nested inside an earlier sibling — by
+// the time that search runs, the cursor has already passed the entire earlier subtree.
+// No occurrence counting is needed at all: each sibling is simply "the next occurrence
+// of this marker from here."
+//
+// Searches run over `maskOpaqueZones(source)` (frontmatter/`<style>`/`<script>`/HTML
+// comments blanked to same-length spaces) so stray `<`, `>`, `{`, `}` in those
+// regions — none of which are represented in `byId` — can't produce false matches;
+// spans returned still index into the real `source` (masking preserves length/offsets),
+// and blanking the frontmatter also means the cursor can simply start at 0.
 //
 // LIMITATIONS (a deliberate, documented simplification — not a general HTML/JSX parser;
-// remove-node refuses with "no-match" rather than guessing when these scanners can't
-// find a confident k-th occurrence, so failure is safe even where these limits are hit):
-//   - The ordinal count spans the WHOLE document in source order, not just the target's
-//     immediate siblings. A node nested *inside* an earlier same-tag sibling (e.g.
-//     `<div><div/></div><div/>`, removing the second top-level div) can shift the count
-//     and misidentify the target. Not exercised by any fixture in this repo today.
-//   - findNthExpressionBlock only counts *top-level* `{...}` blocks: an expression nested
-//     inside another expression's JSX children is consumed as part of the outer block's
-//     span (matching the existing "remove as a single opaque unit" requirement), so it
-//     can't separately target such a nested node — but buildTemplateNodeIndex doesn't
-//     index those as separate nodes anyway (JSX_CHILD_TYPES excludes "expression").
-//   - Shorthand `<>...</>` fragments (kind "fragment" with no tag name) have no lexical
-//     tag to search for and are refused outright, as are any other unhandled node kinds
-//     (e.g. "text") — this fix only covers "expression" and "element"/"component"/
-//     "slot"/"fragment-with-a-tag" removal, matching the reported bug's scope.
+// remove-node refuses with "no-match" (via `SpanResolutionError`) rather than guessing
+// when the walk can't find a node's marker, so failure is safe even where these limits
+// are hit):
+//   - An expression's own nested JSX children (e.g. the `<li>{i}</li>` inside
+//     `{items.map((i) => (<li>{i}</li>))}`) are consumed as part of the outer
+//     expression's span (matching the existing "remove as a single opaque unit"
+//     requirement) — their own spans are still resolved (for reusability by future
+//     callers like move-node) but bounded to fall strictly inside the outer expression.
+//   - Shorthand `<>...</>` fragments (kind "fragment" with no tag name — true of both
+//     the synthetic document root and any real `<>...</>` in the template) have no
+//     lexical tag to search for and are refused outright, as is "text" kind (which is
+//     also never spanned — a text node's `.text` is a truncated preview, not reliably
+//     re-locatable, and nothing needs its exact span).
 
 function maskOpaqueZones(source) {
   const maskRange = (str, start, end) => str.slice(0, start) + " ".repeat(end - start) + str.slice(end);
@@ -229,44 +233,6 @@ function readTagOpenerAt(s, i) {
   return { closing, name, afterName: j };
 }
 
-// The k-th (0-based) top-level `{...}` block in text position anywhere in `masked`.
-function findNthExpressionBlock(masked, k) {
-  let count = 0;
-  let i = 0;
-  const n = masked.length;
-  while (i < n) {
-    const ch = masked[i];
-    if (ch === "<") {
-      const opener = readTagOpenerAt(masked, i);
-      if (opener) {
-        if (opener.closing) {
-          const gt = masked.indexOf(">", opener.afterName);
-          i = gt === -1 ? n : gt + 1;
-          continue;
-        }
-        const tagInfo = scanTagOpen(masked, i);
-        if (tagInfo) {
-          i = tagInfo.end;
-          continue;
-        }
-      }
-    }
-    if (ch === "{") {
-      const end = scanBraceBlock(masked, i);
-      if (end === -1) {
-        i++;
-        continue;
-      }
-      if (count === k) return [i, end];
-      count++;
-      i = end;
-      continue;
-    }
-    i++;
-  }
-  return null;
-}
-
 // From just after a non-self-closing open tag's `<tagName ...>`, scans forward
 // depth-counting nested same-name tags to find the true matching `</tagName>`. Returns
 // the offset just past that close tag, or -1 if unterminated.
@@ -307,11 +273,14 @@ function findMatchingClose(masked, tagName, from) {
   return -1;
 }
 
-// The k-th (0-based) occurrence of an open tag named `tagName` anywhere in `masked`
-// (self-closing or not), with its true matching close.
-function findNthTagSpan(masked, tagName, k) {
-  let count = 0;
-  let i = 0;
+// Forward search from `from` for the next OPEN `<tagName ...>` (or self-closing
+// `<tagName ... />`) occurrence in `masked` — i.e. "the next occurrence of this marker
+// from here," not a k-th-occurrence count. Skips over any other tag (open or close)
+// encountered along the way, respecting quoted attribute values and brace-delimited
+// attribute expressions (via `scanTagOpen`) so a stray `<`/`>` inside either can't
+// terminate the skip early. Returns the index of the opening `<`, or -1 if not found.
+function findTagOpenFrom(masked, tagName, from) {
+  let i = from;
   const n = masked.length;
   while (i < n) {
     const opener = readTagOpenerAt(masked, i);
@@ -324,60 +293,95 @@ function findNthTagSpan(masked, tagName, k) {
       i = gt === -1 ? n : gt + 1;
       continue;
     }
+    if (opener.name === tagName) return i;
     const tagInfo = scanTagOpen(masked, i);
-    if (!tagInfo) return null;
-    if (opener.name === tagName) {
-      if (count === k) {
-        if (tagInfo.selfClosing) return [i, tagInfo.end];
-        const closeEnd = findMatchingClose(masked, tagName, tagInfo.end);
-        return closeEnd === -1 ? null : [i, closeEnd];
-      }
-      count++;
-    }
+    if (!tagInfo) return -1;
     i = tagInfo.end;
   }
-  return null;
+  return -1;
 }
 
-// Establishes the node's 0-based ordinal `k` among its parent's children that share the
-// same (kind, tag) grouping (expression nodes group by kind alone — tag is always null).
-function siblingOrdinal(byId, node) {
-  const parent = byId.get(node.parentId);
-  if (!parent) return null;
-  const sameGroup = parent.childIds
-    .map((id) => byId.get(id))
-    .filter((n) => n && (node.kind === "expression" ? n.kind === "expression" : n.kind === node.kind && n.tag === node.tag));
-  const k = sameGroup.findIndex((n) => n.id === node.id);
-  return k === -1 ? null : k;
+// Thrown by `resolveAllSpans` when a node's lexical marker can't be found from the
+// current cursor position. Callers must catch this and refuse the op (fail closed)
+// rather than guess — see the file-level comment above for why offsets can't be trusted.
+class SpanResolutionError extends Error {
+  constructor(nodeId) {
+    super(`could not lexically locate node ${nodeId}`);
+    this.nodeId = nodeId;
+  }
 }
 
-function findTrueSpan(byId, node, source) {
-  const k = siblingOrdinal(byId, node);
-  if (k === null) return null;
+// Reconstructs correct byte spans for every element/component/slot/fragment/expression
+// node in `byId` in one full depth-first walk, in lockstep with a monotonically
+// advancing cursor through `source` (see the file-level comment above for why this
+// replaces the old per-node k-th-occurrence search). Returns a Map<nodeId, [start, end]>
+// (only for kinds this function can resolve — text nodes and tagless fragments are
+// never spanned); throws `SpanResolutionError` if a node's marker can't be located.
+function resolveAllSpans(byId, rootId, source) {
   const masked = maskOpaqueZones(source);
-  if (node.kind === "expression") return findNthExpressionBlock(masked, k);
-  if ((node.kind === "element" || node.kind === "component" || node.kind === "slot" || node.kind === "fragment") && node.tag) {
-    return findNthTagSpan(masked, node.tag, k);
+  const spans = new Map();
+  let cursor = 0;
+
+  function consumeChildren(childIds, boundEnd) {
+    for (const childId of childIds) consume(childId, boundEnd);
   }
-  return null; // unhandled kind (e.g. "text", tagless fragment) — caller refuses
+
+  // `boundEnd`, when non-null, is the exclusive upper bound a node's own marker must be
+  // found before — used to keep an expression's nested JSX children from resolving past
+  // that expression's own closing brace.
+  function consume(nodeId, boundEnd) {
+    const node = byId.get(nodeId);
+    if (!node || node.kind === "text") return; // no span needed; cursor untouched
+
+    if (node.kind === "expression") {
+      const openIdx = masked.indexOf("{", cursor);
+      if (openIdx === -1 || (boundEnd != null && openIdx >= boundEnd)) throw new SpanResolutionError(nodeId);
+      const closeEnd = scanBraceBlock(masked, openIdx); // exclusive end, one past the matching "}"
+      if (closeEnd === -1) throw new SpanResolutionError(nodeId);
+      spans.set(nodeId, [openIdx, closeEnd]);
+      cursor = openIdx + 1;
+      consumeChildren(node.childIds, closeEnd - 1);
+      cursor = closeEnd;
+      return;
+    }
+
+    // element / component / slot / fragment — all tag-shaped, keyed by node.tag. A
+    // shorthand `<>...</>` fragment (kind "fragment" with no tag name, true of both the
+    // synthetic document root and any real `<>...</>` in the template) has no lexical
+    // marker to search for — refuse rather than guess.
+    if (!node.tag) throw new SpanResolutionError(nodeId);
+    const openIdx = findTagOpenFrom(masked, node.tag, cursor);
+    if (openIdx === -1 || (boundEnd != null && openIdx >= boundEnd)) throw new SpanResolutionError(nodeId);
+    const tagInfo = scanTagOpen(masked, openIdx);
+    if (!tagInfo) throw new SpanResolutionError(nodeId);
+    if (tagInfo.selfClosing || node.childIds.length === 0) {
+      if (tagInfo.selfClosing) {
+        spans.set(nodeId, [openIdx, tagInfo.end]);
+        cursor = tagInfo.end;
+        return;
+      }
+      // Childless in the model (no element/component/expression/non-blank-text child)
+      // but not self-closing — e.g. `<p></p>` or `<div>   </div>`. Still has a real
+      // close tag; find it directly from just past the open tag.
+      const closeEnd = findMatchingClose(masked, node.tag, tagInfo.end);
+      if (closeEnd === -1) throw new SpanResolutionError(nodeId);
+      spans.set(nodeId, [openIdx, closeEnd]);
+      cursor = closeEnd;
+      return;
+    }
+    cursor = tagInfo.end;
+    consumeChildren(node.childIds, null);
+    const closeEnd = findMatchingClose(masked, node.tag, cursor);
+    if (closeEnd === -1) throw new SpanResolutionError(nodeId);
+    spans.set(nodeId, [openIdx, closeEnd]);
+    cursor = closeEnd;
+  }
+
+  consumeChildren(byId.get(rootId).childIds, null);
+  return spans;
 }
 
-// Defends against a scanner returning a span that doesn't actually start with the
-// marker we searched for — belt-and-suspenders on top of the ordinal anchor.
-function spanLooksSane(source, node, span) {
-  if (!span) return false;
-  const [start, end] = span;
-  if (start == null || end == null || end <= start || end > source.length) return false;
-  if (node.kind === "expression") {
-    return source[start] === "{" && source[end - 1] === "}";
-  }
-  const prefix = `<${node.tag}`;
-  if (source.slice(start, start + prefix.length) !== prefix) return false;
-  const afterPrefixChar = source[start + prefix.length];
-  return afterPrefixChar === undefined || /[\s/>]/.test(afterPrefixChar);
-}
-
-function applyRemoveNode(file, source, byId, component) {
+function applyRemoveNode(file, source, byId, rootId, component) {
   const { nodeId } = component;
   if (typeof nodeId !== "string") {
     return refuse("invalid-input", "remove-node requires component.nodeId");
@@ -386,8 +390,18 @@ function applyRemoveNode(file, source, byId, component) {
   if (!node) return refuse("no-match", "no node found at the given id — the file may have changed");
   if (node.parentId === null) return refuse("invalid-input", "cannot remove the component's root");
 
-  const span = findTrueSpan(byId, node, source);
-  if (!spanLooksSane(source, node, span)) {
+  let spans;
+  try {
+    spans = resolveAllSpans(byId, rootId, source);
+  } catch (err) {
+    if (!(err instanceof SpanResolutionError)) throw err;
+    return refuse(
+      "no-match",
+      "could not lexically re-locate the node's true source span without trusting compiler offsets — refusing rather than risking corruption"
+    );
+  }
+  const span = spans.get(nodeId);
+  if (!span) {
     return refuse(
       "no-match",
       "could not lexically re-locate the node's true source span without trusting compiler offsets — refusing rather than risking corruption"

--- a/server/component-style-edit.mjs
+++ b/server/component-style-edit.mjs
@@ -3,7 +3,7 @@ import { join, normalize } from "node:path";
 import { parse } from "@astrojs/compiler";
 import { fileVersion } from "./file-version.mjs";
 import { indexCssRules } from "./css-rule-index.mjs";
-import { buildLineStarts } from "./component-node-index.mjs";
+import { buildLineStarts, offsetFromLineColumn } from "./component-node-index.mjs";
 
 /**
  * Write-side resolver for the four Component Editor style ops
@@ -61,7 +61,7 @@ export async function resolveComponentStyle(projectRoot, edit) {
     case "set-rule-selector":
       return applySetRuleSelector(relPath, rules, ruleSpan, selector);
     case "add-style-rule":
-      return applyAddStyleRule(relPath, source, styleElements, selector, media, declarations);
+      return applyAddStyleRule(relPath, source, styleElements, selector, media, declarations, lineStarts);
     default:
       return refuse("invalid-input", `unsupported component-style op: ${edit.op}`);
   }
@@ -130,7 +130,7 @@ function applySetRuleSelector(file, rules, ruleSpan, selector) {
   return { file, range: { start: rule.preludeSpan[0], end: rule.preludeSpan[1] }, replacement: selector };
 }
 
-function applyAddStyleRule(file, source, styleElements, selector, media, declarations) {
+function applyAddStyleRule(file, source, styleElements, selector, media, declarations, lineStarts) {
   if (typeof selector !== "string" || selector.trim() === "") {
     return refuse("invalid-input", "add-style-rule requires a non-empty component.selector");
   }
@@ -144,26 +144,34 @@ function applyAddStyleRule(file, source, styleElements, selector, media, declara
   if (!lastStyle) {
     return { file, range: { start: source.length, end: source.length }, replacement: `\n<style>\n${rule}\n</style>\n` };
   }
-  const insertAt = styleInsertionPoint(lastStyle, source);
+  const insertAt = styleInsertionPoint(lastStyle, source, lineStarts);
   return { file, range: { start: insertAt, end: insertAt }, replacement: `\n\n${rule}` };
 }
 
 /**
  * Where to splice a new rule into an existing <style> element: right before
  * its closing tag. Normally that's the text child's end offset — but a
- * genuinely empty `<style></style>` has no text child at all, and
- * `lastStyle.position.end.offset` is the offset *after* `</style>`, not
- * before it. Falling back to that would splice the new rule outside the
- * style element (rendered as literal page text, not CSS). Instead, derive
- * the pre-closing-tag offset from the closing tag's own length, verified
- * against the source so a malformed/unexpected shape still degrades to the
- * (safe, if imprecise) end-of-element offset rather than guessing wrong.
+ * genuinely empty `<style></style>` has no text child at all, and the style
+ * element's own end position is the offset *after* `</style>`, not before
+ * it. Falling back to that would splice the new rule outside the style
+ * element (rendered as literal page text, not CSS). Instead, derive the
+ * pre-closing-tag offset from the closing tag's own length, verified against
+ * the source so a malformed/unexpected shape still degrades to the (safe, if
+ * imprecise) end-of-element offset rather than guessing wrong.
+ *
+ * Every offset here is derived from `lineStarts` (line/column), never from
+ * the compiler's `.offset` — see the note in css-rule-index.mjs: `.offset`
+ * is a UTF-8 byte offset, not a JS-string index, so an emoji or other
+ * multi-byte-UTF-8 character earlier in the source would silently splice
+ * the new rule at the wrong position.
  */
-function styleInsertionPoint(styleEl, source) {
+function styleInsertionPoint(styleEl, source, lineStarts) {
   const textChild = (styleEl.children ?? []).find((c) => c.type === "text");
-  if (textChild?.position?.end?.offset != null) return textChild.position.end.offset;
+  const textEnd = offsetFromLineColumn(lineStarts, textChild?.position?.end);
+  if (textEnd != null) return textEnd;
   const closeTag = `</${styleEl.name}>`;
-  const candidate = styleEl.position.end.offset - closeTag.length;
-  if (source.slice(candidate, styleEl.position.end.offset) === closeTag) return candidate;
-  return styleEl.position.end.offset;
+  const elEnd = offsetFromLineColumn(lineStarts, styleEl.position?.end);
+  const candidate = elEnd - closeTag.length;
+  if (source.slice(candidate, elEnd) === closeTag) return candidate;
+  return elEnd;
 }

--- a/server/component-style-edit.mjs
+++ b/server/component-style-edit.mjs
@@ -3,6 +3,7 @@ import { join, normalize } from "node:path";
 import { parse } from "@astrojs/compiler";
 import { fileVersion } from "./file-version.mjs";
 import { indexCssRules } from "./css-rule-index.mjs";
+import { buildLineStarts } from "./component-node-index.mjs";
 
 /**
  * Write-side resolver for the four Component Editor style ops
@@ -47,9 +48,10 @@ export async function resolveComponentStyle(projectRoot, edit) {
     return refuse("parse-failed", `parse ${relPath}: ${err.message}`);
   }
 
+  const lineStarts = buildLineStarts(source);
   const styleElements = [];
   collectStyleElements(ast, styleElements);
-  const rules = styleElements.flatMap((el) => indexCssRules(el));
+  const rules = styleElements.flatMap((el) => indexCssRules(el, lineStarts));
 
   switch (edit.op) {
     case "set-style-property":

--- a/server/css-rule-index.mjs
+++ b/server/css-rule-index.mjs
@@ -1,4 +1,5 @@
 import { parse as parseCss, generate, walk } from "css-tree";
+import { offsetFromLineColumn } from "./component-node-index.mjs";
 
 /**
  * Span-precise CSS rule index for one <style> element. Shared by the
@@ -6,13 +7,23 @@ import { parse as parseCss, generate, walk } from "css-tree";
  * resolver (component-style-edit.mjs) so both agree byte-for-byte on rule
  * identity — selector text alone is not reliable (css-tree's generate()
  * re-serializes and can normalize whitespace/quoting away from the source).
+ *
+ * `lineStarts` (from component-node-index.mjs's `buildLineStarts(source)`) is
+ * required, not optional: @astrojs/compiler@4.0.0 reports `position.*.offset`
+ * as a UTF-8 byte offset, not a JS-string (UTF-16) index, so it can't be used
+ * directly as `baseOffset` — any multi-byte-UTF-8 character earlier in the
+ * source (emoji, accented Latin, CJK, etc.) would silently corrupt every rule
+ * and declaration span this function returns. `.line`/`.column` are reliable
+ * in UTF-16 terms, so `baseOffset` is derived from those instead — the same
+ * approach component-node-index.mjs and component-model.mjs already use for
+ * template/frontmatter/clientScript spans.
  */
-export function indexCssRules(styleElement) {
+export function indexCssRules(styleElement, lineStarts) {
   const lang = (styleElement.attributes ?? []).find((a) => a.name === "lang")?.value;
   if (lang && lang.trim().toLowerCase() !== "css") return []; // scss/less etc.: css-tree error-recovery emits garbage rows
   const textChild = (styleElement.children ?? []).find((c) => c.type === "text");
   if (!textChild?.value) return [];
-  const baseOffset = textChild.position?.start?.offset ?? 0;
+  const baseOffset = offsetFromLineColumn(lineStarts, textChild.position?.start) ?? 0;
 
   let cssAst;
   try {

--- a/server/frontmatter-imports.mjs
+++ b/server/frontmatter-imports.mjs
@@ -1,0 +1,51 @@
+// Regex-based frontmatter import add/remove — deliberately no TS parser in
+// the container, same discipline as props-interface.mjs's parseProps.
+// Only default imports (`import X from "...";`) are modeled: that's the only
+// shape Astro component usage generates (`import Badge from "./Badge.astro"`).
+
+const IMPORT_LINE_RE = /^import\s+(\w+)\s+from\s+["']([^"']+)["'];?\r?\n?/gm;
+
+/** Default-import lines only — named/namespace imports are left alone (never a component). */
+export function parseImports(frontmatterSource) {
+  const imports = [];
+  let m;
+  IMPORT_LINE_RE.lastIndex = 0;
+  while ((m = IMPORT_LINE_RE.exec(frontmatterSource)) !== null) {
+    imports.push({ localName: m[1], specifier: m[2], span: [m.index, m.index + m[0].length] });
+  }
+  return imports;
+}
+
+export function ensureImport(frontmatterSource, { localName, specifier }) {
+  const imports = parseImports(frontmatterSource);
+  if (imports.some((i) => i.specifier === specifier)) {
+    return { source: frontmatterSource, added: false };
+  }
+  const line = `import ${localName} from "${specifier}";\n`;
+  if (imports.length > 0) {
+    const insertAt = imports[imports.length - 1].span[1];
+    return {
+      source: frontmatterSource.slice(0, insertAt) + line + frontmatterSource.slice(insertAt),
+      added: true,
+    };
+  }
+  // No existing imports: insert right after the frontmatter's leading newline (or at the very
+  // start if the frontmatter source doesn't begin with one), so it lands as the first statement.
+  const insertAt = frontmatterSource.startsWith("\n") ? 1 : 0;
+  return {
+    source: frontmatterSource.slice(0, insertAt) + line + frontmatterSource.slice(insertAt),
+    added: true,
+  };
+}
+
+export function pruneImportIfUnused(frontmatterSource, templateSourceAfterEdit, localName) {
+  const imports = parseImports(frontmatterSource);
+  const target = imports.find((i) => i.localName === localName);
+  if (!target) return { source: frontmatterSource, removed: false };
+  const stillUsed = new RegExp(`<${localName}\\b`).test(templateSourceAfterEdit);
+  if (stillUsed) return { source: frontmatterSource, removed: false };
+  return {
+    source: frontmatterSource.slice(0, target.span[0]) + frontmatterSource.slice(target.span[1]),
+    removed: true,
+  };
+}

--- a/server/patcher.mjs
+++ b/server/patcher.mjs
@@ -2,7 +2,8 @@ import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative, extname, basename, dirname } from "node:path";
 import { rewriteAstroStyle } from "./style-edit.mjs";
 import { resolveComponentStyle } from "./component-style-edit.mjs";
-import { COMPONENT_STYLE_OPS } from "./apply-edit-schema.mjs";
+import { resolveComponentStructure } from "./component-structure-edit.mjs";
+import { COMPONENT_STYLE_OPS, COMPONENT_STRUCTURE_OPS } from "./apply-edit-schema.mjs";
 
 /**
  * @typedef {import('./apply-edit-schema.mjs').default} _unused
@@ -13,15 +14,16 @@ import { COMPONENT_STYLE_OPS } from "./apply-edit-schema.mjs";
 /**
  * Resolve an edit payload to a source-file patch.
  *
- * Tries resolvers in priority order: edit-style → component-style ops → .mdoc →
- * Keystatic YAML/JSON → .astro. Returns the first non-refusal. If all refuse,
- * returns the most informative refusal (from the highest-priority resolver
- * that had an opinion).
+ * Tries resolvers in priority order: edit-style → component-style ops →
+ * component-structure ops → .mdoc → Keystatic YAML/JSON → .astro. Returns the
+ * first non-refusal. If all refuse, returns the most informative refusal
+ * (from the highest-priority resolver that had an opinion).
  *
- * Async because `resolveComponentStyle` (component-style-edit.mjs) parses the
- * target .astro file with `@astrojs/compiler`, which is itself async. Every
- * other resolver here is synchronous; awaiting their (non-Promise) return
- * values is a no-op, so this doesn't change their behavior.
+ * Async because `resolveComponentStyle` (component-style-edit.mjs) and
+ * `resolveComponentStructure` (component-structure-edit.mjs) parse the target
+ * .astro file with `@astrojs/compiler`, which is itself async. Every other
+ * resolver here is synchronous; awaiting their (non-Promise) return values is
+ * a no-op, so this doesn't change their behavior.
  *
  * @param {string} projectRoot
  * @param {{ path: string, selector: object, op: string, value?: unknown, component?: object }} edit
@@ -33,6 +35,9 @@ export async function resolve(projectRoot, edit) {
   }
   if (COMPONENT_STYLE_OPS.has(edit.op)) {
     return resolveComponentStyle(projectRoot, edit);
+  }
+  if (COMPONENT_STRUCTURE_OPS.has(edit.op)) {
+    return resolveComponentStructure(projectRoot, edit);
   }
   const resolvers = [resolveMdoc, resolveKeystatic, resolveAstro];
   let bestRefusal = /** @type {ResolveRefusal | null} */ (null);

--- a/tests/apply-edit-dispatcher-component-structure.test.ts
+++ b/tests/apply-edit-dispatcher-component-structure.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parse } from "@astrojs/compiler";
+import { applyEdit } from "../server/apply-edit-dispatcher.mjs";
+import { buildTemplateNodeIndex } from "../server/component-node-index.mjs";
+import { fileVersion } from "../server/file-version.mjs";
+
+const CARD = `---\n---\n<article class="card"><h2>Title</h2></article>\n`;
+
+function parseContent(response) {
+  return JSON.parse(response.content[0].text);
+}
+
+async function nodeIndex(source) {
+  const { ast } = await parse(source, { position: true });
+  return buildTemplateNodeIndex(ast, source);
+}
+
+describe("applyEdit — component-structure ops", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-aed-cs-"));
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), CARD);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rejects a component-structure op with no component payload", async () => {
+    const response = await applyEdit(tmpDir, { id: "1", path: "x", op: "set-attr" });
+    expect(response.isError).toBe(true);
+    const body = parseContent(response);
+    expect(body.reason).toBe("invalid-input");
+  });
+
+  it("applies set-attr end to end and piggybacks a fresh model", async () => {
+    const baseVersion = fileVersion(CARD);
+    const { byId, rootId } = await nodeIndex(CARD);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Card.astro",
+      op: "set-attr",
+      component: { path: "src/components/Card.astro", baseVersion, nodeId: article.id, name: "class", value: "card--big" },
+    });
+    expect(response.isError).toBeFalsy();
+    const body = parseContent(response);
+    expect(body.type).toBe("anglesite:edit-applied");
+    const onDisk = readFileSync(join(tmpDir, "src", "components", "Card.astro"), "utf-8");
+    expect(onDisk).toContain('class="card--big"');
+    expect(body.model).toBeDefined();
+    expect(body.model.template.children[0].attrs).toContainEqual({ name: "class", value: "card--big" });
+  });
+
+  it("surfaces stale as a failed reply", async () => {
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Card.astro",
+      op: "set-attr",
+      component: { path: "src/components/Card.astro", baseVersion: "sha256:000000000000", nodeId: "n1", name: "class", value: "x" },
+    });
+    expect(response.isError).toBe(true);
+    const body = parseContent(response);
+    expect(body.reason).toBe("stale");
+  });
+
+  it("re-checks staleness after the resolver's async gap, refusing a concurrent write race", async () => {
+    const baseVersion = fileVersion(CARD);
+    const { byId, rootId } = await nodeIndex(CARD);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+
+    const editPromise = applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Card.astro",
+      op: "set-attr",
+      component: { path: "src/components/Card.astro", baseVersion, nodeId: article.id, name: "class", value: "card--big" },
+    });
+
+    // Simulate a second edit landing while this one is suspended at
+    // resolveComponentStructure's `await parse(...)` — mirrors the equivalent
+    // component-style race test.
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), CARD.replace("Title", "Renamed"));
+
+    const response = await editPromise;
+    expect(response.isError).toBe(true);
+    const body = parseContent(response);
+    expect(body.reason).toBe("stale");
+
+    const onDisk = readFileSync(join(tmpDir, "src", "components", "Card.astro"), "utf-8");
+    expect(onDisk).toContain("Renamed");
+  });
+});

--- a/tests/apply-edit-dispatcher-component-style.test.ts
+++ b/tests/apply-edit-dispatcher-component-style.test.ts
@@ -34,10 +34,11 @@ describe("applyEdit — component-style ops", () => {
   it("applies set-style-property and piggybacks a fresh model", async () => {
     const baseVersion = fileVersion(CARD);
     const { indexCssRules } = await import("../server/css-rule-index.mjs");
+    const { buildLineStarts } = await import("../server/component-node-index.mjs");
     const { parse } = await import("@astrojs/compiler");
     const { ast } = await parse(CARD, { position: true });
     const styleEl = ast.children.find((n) => n.type === "element" && n.name === "style");
-    const [cardRule] = indexCssRules(styleEl);
+    const [cardRule] = indexCssRules(styleEl, buildLineStarts(CARD));
 
     const response = await applyEdit(tmpDir, {
       id: "1",
@@ -67,10 +68,11 @@ describe("applyEdit — component-style ops", () => {
   it("re-checks staleness after the resolver's async gap, refusing a concurrent write race", async () => {
     const baseVersion = fileVersion(CARD);
     const { indexCssRules } = await import("../server/css-rule-index.mjs");
+    const { buildLineStarts } = await import("../server/component-node-index.mjs");
     const { parse } = await import("@astrojs/compiler");
     const { ast } = await parse(CARD, { position: true });
     const styleEl = ast.children.find((n) => n.type === "element" && n.name === "style");
-    const [cardRule] = indexCssRules(styleEl);
+    const [cardRule] = indexCssRules(styleEl, buildLineStarts(CARD));
 
     const editPromise = applyEdit(tmpDir, {
       id: "1",

--- a/tests/apply-edit-schema-structure.test.ts
+++ b/tests/apply-edit-schema-structure.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { editOps, componentEditSchema, applyEditInputShape, COMPONENT_STRUCTURE_OPS, COMPONENT_OPS } from "../server/apply-edit-schema.mjs";
+
+describe("component-structure op schema", () => {
+  it("registers the four new op names in both sets", () => {
+    for (const op of ["insert-node", "move-node", "remove-node", "set-attr"]) {
+      expect(editOps).toContain(op);
+      expect(COMPONENT_STRUCTURE_OPS.has(op)).toBe(true);
+      expect(COMPONENT_OPS.has(op)).toBe(true);
+    }
+    // style ops still in the union too
+    expect(COMPONENT_OPS.has("set-style-property")).toBe(true);
+  });
+
+  it("accepts a set-attr payload with a null value (removal)", () => {
+    const schema = z.object(applyEditInputShape);
+    const result = schema.safeParse({
+      id: "1",
+      path: "src/components/Card.astro",
+      op: "set-attr",
+      component: { path: "src/components/Card.astro", baseVersion: "sha256:abc123456789", nodeId: "n1", name: "class", value: null },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an insert-node payload with a component node spec", () => {
+    const result = componentEditSchema.safeParse({
+      path: "src/components/Card.astro",
+      baseVersion: "sha256:abc123456789",
+      parentId: "n0",
+      index: 0,
+      node: { kind: "component", tag: "Badge", componentPath: "src/components/Badge.astro" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a move-node payload", () => {
+    const result = componentEditSchema.safeParse({
+      path: "src/components/Card.astro",
+      baseVersion: "sha256:abc123456789",
+      nodeId: "n2",
+      newParentId: "n0",
+      newIndex: 1,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("still accepts a legacy set-style-property payload (value stays a plain string there)", () => {
+    const result = componentEditSchema.safeParse({
+      path: "src/components/Card.astro",
+      baseVersion: "sha256:abc123456789",
+      ruleSpan: [1, 2],
+      property: "color",
+      value: "red",
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/tests/component-model.test.ts
+++ b/tests/component-model.test.ts
@@ -344,5 +344,17 @@ const profile = { name: "x" };
       const [ss, se] = model.clientScript!.span as [number, number];
       expect(src.slice(ss, se)).toContain('console.log("after emoji")');
     });
+
+    it("keeps CSS rule/declaration spans correct when an emoji precedes the <style> element", async () => {
+      const src = `---\n---\n<div>\u{1F389} emoji before</div>\n<style>\n  .card { padding: 1rem; }\n</style>\n`;
+      writeFileSync(join(tmpDir, "src", "components", "EmojiStyle.astro"), src);
+      const model = await buildComponentModel(tmpDir, "src/components/EmojiStyle.astro");
+
+      expect(model.styles).toHaveLength(1);
+      const [rule] = model.styles;
+      expect(src.slice(...(rule.span as [number, number]))).toBe(".card { padding: 1rem; }");
+      const [ds, de] = rule.declarations[0].span as [number, number];
+      expect(src.slice(ds, de)).toBe("padding: 1rem");
+    });
   });
 });

--- a/tests/component-model.test.ts
+++ b/tests/component-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { buildComponentModel } from "../server/component-model.mjs";
@@ -313,5 +313,36 @@ const profile = { name: "x" };
     expect(model.styles).toHaveLength(1);
     expect(model.styles[0].selector).toBe(".deep");
     expect(model.clientScript?.source).toContain("deep script");
+  });
+
+  // @astrojs/compiler@4.0.0 reports `position.*.offset` as a UTF-8 byte offset, not a
+  // JS-string (UTF-16) index — an emoji or other multi-byte-UTF-8 character anywhere
+  // earlier in the source used to corrupt template/frontmatter/clientScript spans for
+  // everything that followed it.
+  describe("Unicode-safe spans end to end", () => {
+    it("keeps template node spans correct when an emoji precedes them in the template", async () => {
+      writeFileSync(
+        join(tmpDir, "src", "components", "Emoji.astro"),
+        `---\n---\n<div>\u{1F389} emoji before <p>Body</p><span>Keep</span></div>\n`,
+      );
+      const model = await buildComponentModel(tmpDir, "src/components/Emoji.astro");
+      const source = readFileSync(join(tmpDir, "src", "components", "Emoji.astro"), "utf-8");
+      const div = model.template.children[0];
+      const [, p, span] = div.children;
+      expect(source.slice(...(p.span as [number, number]))).toBe("<p>Body</p>");
+      expect(source.slice(...(span.span as [number, number]))).toBe("<span>Keep</span>");
+    });
+
+    it("keeps frontmatter and clientScript spans correct when the template (which comes first in source order for clientScript) contains an emoji", async () => {
+      const src = `---\ninterface Props { title: string; }\n---\n<div>\u{1F389} hi</div>\n<script>\n  console.log("after emoji");\n</script>\n`;
+      writeFileSync(join(tmpDir, "src", "components", "EmojiScript.astro"), src);
+      const model = await buildComponentModel(tmpDir, "src/components/EmojiScript.astro");
+
+      const [fs, fe] = model.frontmatter!.span as [number, number];
+      expect(src.slice(fs, fe)).toBe('---\ninterface Props { title: string; }\n---');
+
+      const [ss, se] = model.clientScript!.span as [number, number];
+      expect(src.slice(ss, se)).toContain('console.log("after emoji")');
+    });
   });
 });

--- a/tests/component-node-index.test.ts
+++ b/tests/component-node-index.test.ts
@@ -69,4 +69,70 @@ describe("buildTemplateNodeIndex", () => {
       expect(rec.kind).not.toBe("script");
     }
   });
+
+  // @astrojs/compiler@4.0.0 reports `position.*.offset` as a UTF-8 byte offset, not a
+  // JS-string (UTF-16) index. Any multi-byte-UTF-8 character earlier in the source
+  // (astral-plane emoji, but also plain accented/CJK characters) used to corrupt the
+  // span of every node that followed it. These regressions assert every node's span
+  // slices back to itself regardless of what precedes it in the source.
+  describe("Unicode-safe spans", () => {
+    function assertAllSpansSelfConsistent(byId, src) {
+      for (const rec of byId.values()) {
+        if (rec.span[0] == null || rec.span[1] == null) continue;
+        const slice = src.slice(rec.span[0], rec.span[1]);
+        if (rec.kind === "text") {
+          expect(slice).toContain(rec.text.length < 80 ? rec.text : rec.text.slice(0, 10));
+        } else if (rec.tag) {
+          expect(slice.startsWith(`<${rec.tag}`)).toBe(true);
+        }
+      }
+    }
+
+    it("keeps element spans correct when an emoji precedes them in a text node", async () => {
+      const src = `---\n---\n<div>\u{1F389} emoji before <p>Body</p><span>Keep</span></div>\n`;
+      const { ast } = await parse(src, { position: true });
+      const { byId, rootId } = buildTemplateNodeIndex(ast, src);
+      const div = byId.get(byId.get(rootId).childIds[0]);
+      const [text, p, span] = div.childIds.map((id) => byId.get(id));
+      expect(src.slice(...text.span)).toContain("emoji before");
+      expect(src.slice(...p.span)).toBe("<p>Body</p>");
+      expect(src.slice(...span.span)).toBe("<span>Keep</span>");
+      assertAllSpansSelfConsistent(byId, src);
+    });
+
+    it("keeps attribute-value spans correct when the value itself contains an emoji", async () => {
+      const src = `---\n---\n<div data-x="\u{1F389}"><p>Body</p><span>Keep</span></div>\n`;
+      const { ast } = await parse(src, { position: true });
+      const { byId, rootId } = buildTemplateNodeIndex(ast, src);
+      const div = byId.get(byId.get(rootId).childIds[0]);
+      const attr = div.attrs.find((a) => a.name === "data-x");
+      expect(src.slice(...attr.span)).toBe('data-x="\u{1F389}"');
+      const [p, span] = div.childIds.map((id) => byId.get(id));
+      expect(src.slice(...p.span)).toBe("<p>Body</p>");
+      expect(src.slice(...span.span)).toBe("<span>Keep</span>");
+      assertAllSpansSelfConsistent(byId, src);
+    });
+
+    it("keeps spans correct with multiple emoji inside nested elements", async () => {
+      const src = `---\n---\n<section>\u{1F389}\u{1F680}<article><h1>\u{2764}Title</h1><p>Body \u{1F600} text</p></article></section>\n`;
+      const { ast } = await parse(src, { position: true });
+      const { byId, rootId } = buildTemplateNodeIndex(ast, src);
+      const section = byId.get(byId.get(rootId).childIds[0]);
+      const article = section.childIds.map((id) => byId.get(id)).find((n) => n.tag === "article");
+      const [h1, p] = article.childIds.map((id) => byId.get(id));
+      expect(src.slice(...h1.span)).toBe("<h1>\u{2764}Title</h1>");
+      expect(src.slice(...p.span)).toBe("<p>Body \u{1F600} text</p>");
+      assertAllSpansSelfConsistent(byId, src);
+    });
+
+    it("keeps element spans correct when a plain (BMP) accented/CJK character precedes them", async () => {
+      const src = `---\n---\n<div>café 你好 before <p>Body</p></div>\n`;
+      const { ast } = await parse(src, { position: true });
+      const { byId, rootId } = buildTemplateNodeIndex(ast, src);
+      const div = byId.get(byId.get(rootId).childIds[0]);
+      const p = byId.get(div.childIds[1]);
+      expect(src.slice(...p.span)).toBe("<p>Body</p>");
+      assertAllSpansSelfConsistent(byId, src);
+    });
+  });
 });

--- a/tests/component-node-index.test.ts
+++ b/tests/component-node-index.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "@astrojs/compiler";
+import { buildTemplateNodeIndex } from "../server/component-node-index.mjs";
+
+const CARD = `---
+interface Props { title: string; }
+---
+<article class="card" data-size="lg">
+  <h2>{title}</h2>
+  <Badge label="new" />
+</article>
+`;
+
+describe("buildTemplateNodeIndex", () => {
+  it("assigns the synthetic root id n0, then depth-first ids to real nodes", async () => {
+    const { ast } = await parse(CARD, { position: true });
+    const { byId, rootId } = buildTemplateNodeIndex(ast, CARD);
+    expect(rootId).toBe("n0");
+    const root = byId.get("n0");
+    expect(root.kind).toBe("fragment");
+    expect(root.parentId).toBeNull();
+    expect(root.childIds).toHaveLength(1); // <article>
+
+    const article = byId.get(root.childIds[0]);
+    expect(article.kind).toBe("element");
+    expect(article.tag).toBe("article");
+    expect(article.parentId).toBe("n0");
+  });
+
+  it("captures attribute name/value/span", async () => {
+    const { ast } = await parse(CARD, { position: true });
+    const { byId, rootId } = buildTemplateNodeIndex(ast, CARD);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+    const classAttr = article.attrs.find((a) => a.name === "class");
+    expect(classAttr.value).toBe("card");
+    expect(CARD.slice(classAttr.span[0], classAttr.span[1])).toBe('class="card"');
+  });
+
+  it("classifies a capitalized tag as kind=component and indexes it as a child", async () => {
+    const { ast } = await parse(CARD, { position: true });
+    const { byId, rootId } = buildTemplateNodeIndex(ast, CARD);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+    const badgeId = article.childIds.find((id) => byId.get(id).kind === "component");
+    expect(byId.get(badgeId).tag).toBe("Badge");
+    expect(byId.get(badgeId).parentId).toBe(article.id);
+  });
+
+  it("gives the same ids across two independent parses of identical source (determinism)", async () => {
+    const { ast: ast1 } = await parse(CARD, { position: true });
+    const { ast: ast2 } = await parse(CARD, { position: true });
+    const idx1 = buildTemplateNodeIndex(ast1, CARD);
+    const idx2 = buildTemplateNodeIndex(ast2, CARD);
+    expect([...idx1.byId.keys()]).toEqual([...idx2.byId.keys()]);
+  });
+
+  it("skips style/script zones and filters non-JSX text out of expression children", async () => {
+    const src = `---\n---\n<div>{items.map((i) => (<li>{i}</li>))}</div>\n<style>.x{color:red;}</style>\n<script>console.log(1)</script>\n`;
+    const { ast } = await parse(src, { position: true });
+    const { byId, rootId } = buildTemplateNodeIndex(ast, src);
+    const div = byId.get(byId.get(rootId).childIds[0]);
+    expect(div.tag).toBe("div");
+    const expr = byId.get(div.childIds[0]);
+    expect(expr.kind).toBe("expression");
+    const li = byId.get(expr.childIds[0]);
+    expect(li.tag).toBe("li");
+    // style/script never appear as template children anywhere in the tree.
+    for (const rec of byId.values()) {
+      expect(rec.kind).not.toBe("style");
+      expect(rec.kind).not.toBe("script");
+    }
+  });
+});

--- a/tests/component-structure-edit.test.ts
+++ b/tests/component-structure-edit.test.ts
@@ -349,3 +349,183 @@ describe("resolveComponentStructure — remove-node", () => {
     expect(next).toContain("<p>Keep</p>");
   });
 });
+
+describe("resolveComponentStructure — insert-node", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-cse4-"));
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function apply(resolution, before) {
+    return before.slice(0, resolution.range.start) + resolution.replacement + before.slice(resolution.range.end);
+  }
+
+  it("inserts a plain element as the last child of a parent with existing children", async () => {
+    const src = `---\n---\n<article><h2>Title</h2></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+
+    const edit = {
+      op: "insert-node",
+      component: { path: "src/components/Card.astro", baseVersion, parentId: article.id, index: 1, node: { kind: "element", tag: "p" } },
+    };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    const next = apply(result, src);
+    expect(next).toContain("<h2>Title</h2><p></p>");
+
+    // Re-parses cleanly.
+    const { ast } = await parse(next, { position: true });
+    expect(ast).toBeDefined();
+  });
+
+  it("inserts a top-level element when parentId is the fragment root", async () => {
+    const src = `---\n---\n<article></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { rootId } = await nodeIndex(src);
+
+    const edit = {
+      op: "insert-node",
+      component: { path: "src/components/Card.astro", baseVersion, parentId: rootId, index: 1, node: { kind: "element", tag: "footer" } },
+    };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    const next = apply(result, src);
+    // Whitespace-insensitive: insertion lands right after </article>'s own resolved span,
+    // not necessarily preserving the original file's exact trailing-newline formatting.
+    expect(next).toMatch(/<article><\/article>\s*<footer><\/footer>/);
+  });
+
+  it("inserts a slot", async () => {
+    const src = `---\n---\n<article></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+
+    const edit = {
+      op: "insert-node",
+      component: { path: "src/components/Card.astro", baseVersion, parentId: article.id, index: 0, node: { kind: "slot", slotName: "footer" } },
+    };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    const next = apply(result, src);
+    expect(next).toContain('<slot name="footer" />');
+  });
+
+  it("inserts a component instance and adds its import", async () => {
+    const src = `---\n---\n<article></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+    writeFileSync(join(tmpDir, "src", "components", "Badge.astro"), `---\n---\n<span>Badge</span>\n`);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+
+    const edit = {
+      op: "insert-node",
+      component: {
+        path: "src/components/Card.astro",
+        baseVersion,
+        parentId: article.id,
+        index: 0,
+        node: { kind: "component", tag: "Badge", componentPath: "src/components/Badge.astro" },
+      },
+    };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    const next = apply(result, src);
+    expect(next).toContain('import Badge from "./Badge.astro";');
+    expect(next).toContain("<Badge />");
+
+    const { ast } = await parse(next, { position: true });
+    expect(ast).toBeDefined();
+  });
+
+  it("reuses an existing import instead of duplicating it", async () => {
+    const src = `---\nimport Badge from "./Badge.astro";\n---\n<article><Badge label="a" /></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+
+    const edit = {
+      op: "insert-node",
+      component: {
+        path: "src/components/Card.astro",
+        baseVersion,
+        parentId: article.id,
+        index: 1,
+        node: { kind: "component", tag: "Badge", componentPath: "src/components/Badge.astro" },
+      },
+    };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    const next = apply(result, src);
+    expect(next.match(/import Badge/g)).toHaveLength(1);
+  });
+
+  it("refuses invalid-input when a component node has no componentPath", async () => {
+    const src = `---\n---\n<article></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+
+    const edit = {
+      op: "insert-node",
+      component: { path: "src/components/Card.astro", baseVersion, parentId: article.id, index: 0, node: { kind: "component", tag: "Badge" } },
+    };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+
+  it("refuses no-match when parentId doesn't exist", async () => {
+    const src = `---\n---\n<article></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const edit = {
+      op: "insert-node",
+      component: { path: "src/components/Card.astro", baseVersion, parentId: "n999", index: 0, node: { kind: "element", tag: "p" } },
+    };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("no-match");
+  });
+
+  // Beyond the original plan's 7 cases: proves the resolveAllSpans-based insertion offset
+  // (and its forward/backward resolvable-sibling search) works correctly when a preceding
+  // sibling is a Unicode-containing text node rather than a spanned element — the case the
+  // now-superseded raw node.span approach could not have handled reliably (see Task 5's
+  // history: astral-plane Unicode earlier in the source corrupts the compiler's own byte
+  // offsets for everything that follows).
+  it("inserts before an element sibling that follows a Unicode-containing text node", async () => {
+    const src = `---\n---\n<article>🎉 some text <h2>Title</h2></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+    // children: [text("🎉 some text"), h2] — index 1 targets "right before the h2".
+    expect(article.childIds.length).toBe(2);
+
+    const edit = {
+      op: "insert-node",
+      component: { path: "src/components/Card.astro", baseVersion, parentId: article.id, index: 1, node: { kind: "element", tag: "p" } },
+    };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    const next = apply(result, src);
+
+    // The new <p> lands immediately before <h2>, not corrupting the preceding Unicode text
+    // or the h2's own content.
+    expect(next).toContain("🎉 some text <p></p><h2>Title</h2>");
+
+    const { ast } = await parse(next, { position: true });
+    expect(ast).toBeDefined();
+  });
+});

--- a/tests/component-structure-edit.test.ts
+++ b/tests/component-structure-edit.test.ts
@@ -146,6 +146,59 @@ describe("resolveComponentStructure — set-attr", () => {
     const next = source.slice(0, result.range.start) + result.replacement + source.slice(result.range.end);
     expect(next).toContain('<p class="lead"></p>');
   });
+
+  // set-attr must refuse non-tag-shaped nodes (text/expression/tagless-fragment) rather
+  // than splice attribute syntax into their span — see resolveAllSpans' precedent for
+  // refusing these kinds and the review finding that flagged this gap.
+  describe("kind guard", () => {
+    const KINDS = `---\n---\n<article>\n  <p>Hello world</p>\n  <h2>{title}</h2>\n</article>\n`;
+
+    it("refuses set-attr on a text node instead of splicing into running text", async () => {
+      writeFileSync(join(tmpDir, "src", "components", "Card.astro"), KINDS);
+      const baseVersion = fileVersion(KINDS);
+      const { byId, rootId } = await nodeIndex(KINDS);
+      const article = byId.get(byId.get(rootId).childIds[0]);
+      const p = byId.get(article.childIds[0]);
+      const text = byId.get(p.childIds[0]);
+      expect(text.kind).toBe("text");
+
+      const edit = { op: "set-attr", component: { path: "src/components/Card.astro", baseVersion, nodeId: text.id, name: "class", value: "x" } };
+      const result = await resolveComponentStructure(tmpDir, edit);
+      expect(result.refused).toBe(true);
+      expect(result.reason).toBe("invalid-input");
+
+      // The file on disk must be untouched — no test relies on `result.range`/`replacement`
+      // when refused, but assert the source itself never gets corrupted either way.
+      const onDisk = readFileSync(join(tmpDir, "src", "components", "Card.astro"), "utf-8");
+      expect(onDisk).toBe(KINDS);
+    });
+
+    it("refuses set-attr on an expression node instead of trusting its unreliable span", async () => {
+      writeFileSync(join(tmpDir, "src", "components", "Card.astro"), KINDS);
+      const baseVersion = fileVersion(KINDS);
+      const { byId, rootId } = await nodeIndex(KINDS);
+      const article = byId.get(byId.get(rootId).childIds[0]);
+      const h2 = byId.get(article.childIds[1]);
+      const expr = byId.get(h2.childIds[0]);
+      expect(expr.kind).toBe("expression");
+
+      const edit = { op: "set-attr", component: { path: "src/components/Card.astro", baseVersion, nodeId: expr.id, name: "class", value: "x" } };
+      const result = await resolveComponentStructure(tmpDir, edit);
+      expect(result.refused).toBe(true);
+      expect(result.reason).toBe("invalid-input");
+    });
+
+    it("still allows set-attr on element/component/slot nodes", async () => {
+      const baseVersion = fileVersion(CARD);
+      const { byId, rootId } = await nodeIndex(CARD);
+      const article = byId.get(byId.get(rootId).childIds[0]);
+      expect(article.kind).toBe("element");
+
+      const edit = { op: "set-attr", component: { path: "src/components/Card.astro", baseVersion, nodeId: article.id, name: "id", value: "ok" } };
+      const result = await resolveComponentStructure(tmpDir, edit);
+      expect(result.refused).toBeFalsy();
+    });
+  });
 });
 
 describe("resolveComponentStructure — remove-node", () => {

--- a/tests/component-structure-edit.test.ts
+++ b/tests/component-structure-edit.test.ts
@@ -89,6 +89,49 @@ describe("resolveComponentStructure — set-attr", () => {
     expect(result.reason).toBe("no-match");
   });
 
+  it("escapes double quotes and ampersands in an attribute value", async () => {
+    const baseVersion = fileVersion(CARD);
+    const { byId, rootId } = await nodeIndex(CARD);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+    const edit = {
+      op: "set-attr",
+      component: { path: "src/components/Card.astro", baseVersion, nodeId: article.id, name: "title", value: 'Say "hi" to us & co' },
+    };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    const next = apply(result);
+
+    // Re-parse the patched source and confirm exactly one "title" attribute exists
+    // (an unescaped quote would break out of the attribute and produce phantom
+    // extra attributes instead), and that its unescaped value round-trips.
+    const { ast } = await parse(next, { position: true });
+    const { byId: nextById, rootId: nextRootId } = buildTemplateNodeIndex(ast, next);
+    const nextArticle = nextById.get(nextById.get(nextRootId).childIds[0]);
+    const titleAttrs = nextArticle.attrs.filter((a) => a.name === "title");
+    expect(titleAttrs).toHaveLength(1);
+    expect(titleAttrs[0].value).toBe('Say "hi" to us & co');
+  });
+
+  it("removes an attribute from a one-per-line-formatted tag without leaving a blank line", async () => {
+    const multiline = `---\n---\n<article\n  class="card"\n  data-size="lg"\n  id="hero"\n>\n  <h2>title</h2>\n</article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), multiline);
+    const baseVersion = fileVersion(multiline);
+    const { byId, rootId } = await nodeIndex(multiline);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+
+    const edit = { op: "set-attr", component: { path: "src/components/Card.astro", baseVersion, nodeId: article.id, name: "data-size", value: null } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    const next = apply(result);
+
+    expect(next).not.toContain("data-size");
+    // Exclude the final split segment: it's the empty string after the file's own
+    // trailing newline, not a blank line the removal introduced.
+    const lines = next.split("\n");
+    expect(lines.slice(0, -1).some((line) => line.trim() === "")).toBe(false);
+    expect(next).toContain('  class="card"\n  id="hero"');
+  });
+
   it("adds an attribute to an element with no existing attributes", async () => {
     const bare = `---\n---\n<article><p></p></article>\n`;
     writeFileSync(join(tmpDir, "src", "components", "Card.astro"), bare);

--- a/tests/component-structure-edit.test.ts
+++ b/tests/component-structure-edit.test.ts
@@ -281,4 +281,37 @@ describe("resolveComponentStructure — remove-node", () => {
     const { ast } = await parse(next, { position: true });
     expect(ast).toBeDefined(); // re-parses cleanly, no tag-soup corruption
   });
+
+  it("does not confuse a nested same-tag descendant with a later top-level sibling", async () => {
+    const src = `---\n---\n<div><div>Inner</div></div><div>Target</div>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const topLevelDivs = byId.get(rootId).childIds.map((id) => byId.get(id));
+    const targetDiv = topLevelDivs[1]; // the second top-level <div>, containing "Target"
+
+    const edit = { op: "remove-node", component: { path: "src/components/Card.astro", baseVersion, nodeId: targetDiv.id } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    const next = apply(result, src);
+    expect(next).not.toContain("Target");
+    expect(next).toContain("Inner");
+  });
+
+  it("does not confuse a nested expression with a sibling expression at a shallower depth", async () => {
+    const src = `---\n---\n<div>{a}<span>{b}</span></div>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const div = byId.get(byId.get(rootId).childIds[0]);
+    const span = byId.get(div.childIds.find((id) => byId.get(id).tag === "span"));
+    const bExpr = byId.get(span.childIds.find((id) => byId.get(id).kind === "expression"));
+
+    const edit = { op: "remove-node", component: { path: "src/components/Card.astro", baseVersion, nodeId: bExpr.id } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    const next = apply(result, src);
+    expect(next).not.toContain("{b}");
+    expect(next).toContain("{a}");
+  });
 });

--- a/tests/component-structure-edit.test.ts
+++ b/tests/component-structure-edit.test.ts
@@ -314,4 +314,38 @@ describe("resolveComponentStructure — remove-node", () => {
     expect(next).not.toContain("{b}");
     expect(next).toContain("{a}");
   });
+
+  it("does not refuse removal when the file contains a bare void element elsewhere", async () => {
+    const src = `---\n---\n<div><img src="x.jpg"><p>Keep</p><p>Target</p></div>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const div = byId.get(byId.get(rootId).childIds[0]);
+    const paragraphs = div.childIds.map((id) => byId.get(id)).filter((n) => n.tag === "p");
+    const target = paragraphs[1];
+
+    const edit = { op: "remove-node", component: { path: "src/components/Card.astro", baseVersion, nodeId: target.id } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    const next = apply(result, src);
+    expect(next).not.toContain("Target");
+    expect(next).toContain("Keep");
+    expect(next).toContain('<img src="x.jpg">');
+  });
+
+  it("removes a bare void element directly", async () => {
+    const src = `---\n---\n<div><img src="x.jpg"><p>Keep</p></div>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const div = byId.get(byId.get(rootId).childIds[0]);
+    const img = byId.get(div.childIds.find((id) => byId.get(id).tag === "img"));
+
+    const edit = { op: "remove-node", component: { path: "src/components/Card.astro", baseVersion, nodeId: img.id } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    const next = apply(result, src);
+    expect(next).not.toContain("img");
+    expect(next).toContain("<p>Keep</p>");
+  });
 });

--- a/tests/component-structure-edit.test.ts
+++ b/tests/component-structure-edit.test.ts
@@ -528,4 +528,46 @@ describe("resolveComponentStructure — insert-node", () => {
     const { ast } = await parse(next, { position: true });
     expect(ast).toBeDefined();
   });
+
+  it("falls back to inserting after the preceding resolvable sibling when the target index lands on trailing text", async () => {
+    const src = `---\n---\n<article><h2>Title</h2> trailing text</article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+    // children are [h2, text] — index 1 targets the text node, which has no resolvable span.
+
+    const edit = {
+      op: "insert-node",
+      component: { path: "src/components/Card.astro", baseVersion, parentId: article.id, index: 1, node: { kind: "element", tag: "p" } },
+    };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    const next = apply(result, src);
+    expect(next).toContain("<h2>Title</h2><p></p> trailing text");
+
+    const { ast } = await parse(next, { position: true });
+    expect(ast).toBeDefined();
+  });
+
+  it("falls back to the childless insertion point when no child in the parent has a resolvable span", async () => {
+    const src = `---\n---\n<article>just some text, no elements</article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+
+    const edit = {
+      op: "insert-node",
+      component: { path: "src/components/Card.astro", baseVersion, parentId: article.id, index: 1, node: { kind: "element", tag: "p" } },
+    };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    const next = apply(result, src);
+    expect(next).toContain("just some text, no elements<p></p>");
+    expect(next.indexOf("<p></p>")).toBeLessThan(next.indexOf("</article>"));
+
+    const { ast } = await parse(next, { position: true });
+    expect(ast).toBeDefined();
+  });
 });

--- a/tests/component-structure-edit.test.ts
+++ b/tests/component-structure-edit.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parse } from "@astrojs/compiler";
+import { resolveComponentStructure } from "../server/component-structure-edit.mjs";
+import { buildTemplateNodeIndex } from "../server/component-node-index.mjs";
+import { fileVersion } from "../server/file-version.mjs";
+
+const CARD = `---
+interface Props { title: string; }
+---
+<article class="card" data-size="lg">
+  <h2>{title}</h2>
+</article>
+`;
+
+async function nodeIndex(source) {
+  const { ast } = await parse(source, { position: true });
+  return buildTemplateNodeIndex(ast, source);
+}
+
+describe("resolveComponentStructure — set-attr", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-cse2-"));
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), CARD);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function apply(resolution) {
+    const source = readFileSync(join(tmpDir, "src", "components", "Card.astro"), "utf-8");
+    return source.slice(0, resolution.range.start) + resolution.replacement + source.slice(resolution.range.end);
+  }
+
+  it("refuses invalid-input with no component payload", async () => {
+    const result = await resolveComponentStructure(tmpDir, { op: "set-attr" });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+
+  it("refuses stale when baseVersion does not match", async () => {
+    const edit = { op: "set-attr", component: { path: "src/components/Card.astro", baseVersion: "sha256:000000000000", nodeId: "n1", name: "class", value: "x" } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("stale");
+  });
+
+  it("replaces an existing attribute's value in place", async () => {
+    const baseVersion = fileVersion(CARD);
+    const { byId, rootId } = await nodeIndex(CARD);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+    const edit = { op: "set-attr", component: { path: "src/components/Card.astro", baseVersion, nodeId: article.id, name: "class", value: "card--big" } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    expect(apply(result)).toContain('class="card--big"');
+    expect(apply(result)).toContain('data-size="lg"');
+  });
+
+  it("adds a new attribute when absent", async () => {
+    const baseVersion = fileVersion(CARD);
+    const { byId, rootId } = await nodeIndex(CARD);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+    const edit = { op: "set-attr", component: { path: "src/components/Card.astro", baseVersion, nodeId: article.id, name: "id", value: "hero-card" } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(apply(result)).toMatch(/<article class="card" data-size="lg" id="hero-card">/);
+  });
+
+  it("removes an attribute when value is null", async () => {
+    const baseVersion = fileVersion(CARD);
+    const { byId, rootId } = await nodeIndex(CARD);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+    const edit = { op: "set-attr", component: { path: "src/components/Card.astro", baseVersion, nodeId: article.id, name: "data-size", value: null } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(apply(result)).not.toContain("data-size");
+    expect(apply(result)).toContain('class="card"');
+  });
+
+  it("refuses no-match when the nodeId no longer exists", async () => {
+    const baseVersion = fileVersion(CARD);
+    const edit = { op: "set-attr", component: { path: "src/components/Card.astro", baseVersion, nodeId: "n999", name: "class", value: "x" } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("no-match");
+  });
+
+  it("adds an attribute to an element with no existing attributes", async () => {
+    const bare = `---\n---\n<article><p></p></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), bare);
+    const baseVersion = fileVersion(bare);
+    const { byId, rootId } = await nodeIndex(bare);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+    const p = byId.get(article.childIds[0]);
+
+    const edit = { op: "set-attr", component: { path: "src/components/Card.astro", baseVersion, nodeId: p.id, name: "class", value: "lead" } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    const source = readFileSync(join(tmpDir, "src", "components", "Card.astro"), "utf-8");
+    const next = source.slice(0, result.range.start) + result.replacement + source.slice(result.range.end);
+    expect(next).toContain('<p class="lead"></p>');
+  });
+});

--- a/tests/component-structure-edit.test.ts
+++ b/tests/component-structure-edit.test.ts
@@ -247,4 +247,38 @@ describe("resolveComponentStructure — remove-node", () => {
     expect(next).not.toContain("<li>");
     expect(next).toContain("<ul></ul>");
   });
+
+  it("correctly removes the target expression node when Unicode precedes it, without touching a different expression", async () => {
+    const src = `---\n---\n<p>🎉 emoji {first} then {second}</p>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const p = byId.get(byId.get(rootId).childIds[0]);
+    const firstExpr = byId.get(p.childIds.find((id) => byId.get(id).kind === "expression"));
+
+    const edit = { op: "remove-node", component: { path: "src/components/Card.astro", baseVersion, nodeId: firstExpr.id } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    const next = apply(result, src);
+    expect(next).not.toContain("{first}");
+    expect(next).toContain("{second}");
+  });
+
+  it("correctly removes a plain element when Unicode precedes it, without corrupting a later sibling", async () => {
+    const src = `---\n---\n<div>🎉 emoji before <p>Body</p><span>Keep</span></div>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const div = byId.get(byId.get(rootId).childIds[0]);
+    const p = byId.get(div.childIds.find((id) => byId.get(id).tag === "p"));
+
+    const edit = { op: "remove-node", component: { path: "src/components/Card.astro", baseVersion, nodeId: p.id } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    const next = apply(result, src);
+    expect(next).not.toContain("Body");
+    expect(next).toContain("<span>Keep</span>");
+    const { ast } = await parse(next, { position: true });
+    expect(ast).toBeDefined(); // re-parses cleanly, no tag-soup corruption
+  });
 });

--- a/tests/component-structure-edit.test.ts
+++ b/tests/component-structure-edit.test.ts
@@ -147,3 +147,104 @@ describe("resolveComponentStructure — set-attr", () => {
     expect(next).toContain('<p class="lead"></p>');
   });
 });
+
+describe("resolveComponentStructure — remove-node", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-cse3-"));
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function apply(resolution, before) {
+    return before.slice(0, resolution.range.start) + resolution.replacement + before.slice(resolution.range.end);
+  }
+
+  it("removes a plain element subtree", async () => {
+    const src = `---\n---\n<article><h2>Title</h2><p>Body</p></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+    const p = byId.get(article.childIds[1]);
+
+    const edit = { op: "remove-node", component: { path: "src/components/Card.astro", baseVersion, nodeId: p.id } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    const next = apply(result, src);
+    expect(next).not.toContain("Body");
+    expect(next).toContain("<h2>Title</h2>");
+  });
+
+  it("removing the last usage of a component prunes its import", async () => {
+    const src = `---\nimport Badge from "./Badge.astro";\n---\n<article><Badge label="new" /></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+    const badge = byId.get(article.childIds[0]);
+
+    const edit = { op: "remove-node", component: { path: "src/components/Card.astro", baseVersion, nodeId: badge.id } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    const next = apply(result, src);
+    expect(next).not.toContain("Badge");
+    expect(next).not.toContain("import Badge");
+  });
+
+  it("keeps the import when another usage remains", async () => {
+    const src = `---\nimport Badge from "./Badge.astro";\n---\n<article><Badge label="a" /><Badge label="b" /></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+    const firstBadge = byId.get(article.childIds[0]);
+
+    const edit = { op: "remove-node", component: { path: "src/components/Card.astro", baseVersion, nodeId: firstBadge.id } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    const next = apply(result, src);
+    expect(next).toContain("import Badge");
+    expect(next).toContain('label="b"');
+    expect(next).not.toContain('label="a"');
+  });
+
+  it("refuses no-match for an unknown nodeId", async () => {
+    const src = `---\n---\n<article></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const edit = { op: "remove-node", component: { path: "src/components/Card.astro", baseVersion, nodeId: "n999" } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("no-match");
+  });
+
+  it("refuses invalid-input when trying to remove the fragment root", async () => {
+    const src = `---\n---\n<article></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const edit = { op: "remove-node", component: { path: "src/components/Card.astro", baseVersion, nodeId: "n0" } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+
+  it("removes an expression node as a single opaque unit (spec §2.2: move/remove as a unit only)", async () => {
+    const src = `---\n---\n<ul>{items.map((i) => (<li>{i}</li>))}</ul>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const ul = byId.get(byId.get(rootId).childIds[0]);
+    const expr = byId.get(ul.childIds[0]);
+    expect(expr.kind).toBe("expression");
+
+    const edit = { op: "remove-node", component: { path: "src/components/Card.astro", baseVersion, nodeId: expr.id } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    const next = apply(result, src);
+    // The whole {items.map(...)} block is gone in one piece — not just the <li> JSX inside it.
+    expect(next).not.toContain("items.map");
+    expect(next).not.toContain("<li>");
+    expect(next).toContain("<ul></ul>");
+  });
+});

--- a/tests/component-structure-edit.test.ts
+++ b/tests/component-structure-edit.test.ts
@@ -571,3 +571,129 @@ describe("resolveComponentStructure — insert-node", () => {
     expect(ast).toBeDefined();
   });
 });
+
+describe("resolveComponentStructure — move-node", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-cse5-"));
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function apply(resolution, before) {
+    return before.slice(0, resolution.range.start) + resolution.replacement + before.slice(resolution.range.end);
+  }
+
+  it("reorders two siblings under the same parent", async () => {
+    const src = `---\n---\n<article><h2>A</h2><h3>B</h3></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+    const [h2, h3] = article.childIds.map((id) => byId.get(id));
+
+    const edit = { op: "move-node", component: { path: "src/components/Card.astro", baseVersion, nodeId: h2.id, newParentId: article.id, newIndex: 1 } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    const next = apply(result, src);
+    expect(next.indexOf("<h3>B</h3>")).toBeLessThan(next.indexOf("<h2>A</h2>"));
+
+    const { ast } = await parse(next, { position: true });
+    expect(ast).toBeDefined();
+  });
+
+  it("reparents a node into a different element", async () => {
+    const src = `---\n---\n<article><h2>Title</h2></article><footer></footer>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const [article, footer] = byId.get(rootId).childIds.map((id) => byId.get(id));
+    const h2 = byId.get(article.childIds[0]);
+
+    const edit = { op: "move-node", component: { path: "src/components/Card.astro", baseVersion, nodeId: h2.id, newParentId: footer.id, newIndex: 0 } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    const next = apply(result, src);
+    expect(next).toContain("<footer><h2>Title</h2></footer>");
+    expect(next).not.toContain("<article><h2>Title</h2></article>");
+
+    const { ast } = await parse(next, { position: true });
+    expect(ast).toBeDefined();
+  });
+
+  it("refuses invalid-input when moving a node into its own subtree", async () => {
+    const src = `---\n---\n<article><section><h2>Title</h2></section></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+    const section = byId.get(article.childIds[0]);
+
+    const edit = { op: "move-node", component: { path: "src/components/Card.astro", baseVersion, nodeId: article.id, newParentId: section.id, newIndex: 0 } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+
+  it("refuses no-match when nodeId doesn't exist", async () => {
+    const src = `---\n---\n<article></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { rootId } = await nodeIndex(src);
+    const edit = { op: "move-node", component: { path: "src/components/Card.astro", baseVersion, nodeId: "n999", newParentId: rootId, newIndex: 0 } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("no-match");
+  });
+
+  // Beyond the brief's original 4 cases: the two tests above both move a node FORWARD (its
+  // new position lands after its old one in the source), so the offset-shift-on-insert-side
+  // arithmetic only ever exercises the "insertion point at/after the removal point" branch.
+  // This test exercises the opposite direction — moving the LAST of three siblings to become
+  // the FIRST — so the insertion point falls BEFORE the node's own current position, and no
+  // offset-shift is needed on the insert side (the removal happens entirely after the splice).
+  it("moves a node to an earlier position, where the insertion point precedes the node's own current span", async () => {
+    const src = `---\n---\n<article><h2>A</h2><h3>B</h3><p>C</p></article>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+    const [, , p] = article.childIds.map((id) => byId.get(id));
+
+    const edit = { op: "move-node", component: { path: "src/components/Card.astro", baseVersion, nodeId: p.id, newParentId: article.id, newIndex: 0 } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    const next = apply(result, src);
+    expect(next).toContain("<article><p>C</p><h2>A</h2><h3>B</h3></article>");
+
+    const { ast } = await parse(next, { position: true });
+    expect(ast).toBeDefined();
+  });
+
+  // Beyond the brief's original 4 cases: proves the insert-side fallback logic Task 6 added
+  // to applyInsertNode (forward search for a resolvable sibling, then backward fallback) also
+  // works correctly when move-node's destination parent has a text-kind sibling sitting right
+  // at the target index — the moved node must land after the resolvable <span>, not swallowed
+  // into (or corrupting) the unresolvable trailing text.
+  it("moves a node into a destination parent whose target index lands on a trailing text sibling", async () => {
+    const src = `---\n---\n<article><h2>Title</h2></article><footer><span>X</span> trailing text</footer>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), src);
+    const baseVersion = fileVersion(src);
+    const { byId, rootId } = await nodeIndex(src);
+    const [article, footer] = byId.get(rootId).childIds.map((id) => byId.get(id));
+    const h2 = byId.get(article.childIds[0]);
+    // footer's children are [span, text] — index 1 targets the unresolvable trailing text.
+    expect(footer.childIds.length).toBe(2);
+
+    const edit = { op: "move-node", component: { path: "src/components/Card.astro", baseVersion, nodeId: h2.id, newParentId: footer.id, newIndex: 1 } };
+    const result = await resolveComponentStructure(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    const next = apply(result, src);
+    expect(next).toContain("<span>X</span><h2>Title</h2> trailing text");
+    expect(next).not.toContain("<article><h2>Title</h2></article>");
+
+    const { ast } = await parse(next, { position: true });
+    expect(ast).toBeDefined();
+  });
+});

--- a/tests/component-style-edit.test.ts
+++ b/tests/component-style-edit.test.ts
@@ -156,4 +156,20 @@ describe("resolveComponentStyle", () => {
     expect(result.refused).toBe(true);
     expect(result.reason).toBe("no-match");
   });
+
+  // @astrojs/compiler@4.0.0 reports `position.*.offset` as a UTF-8 byte offset, not a
+  // JS-string (UTF-16) index — an emoji or other multi-byte-UTF-8 character earlier in
+  // the source used to splice add-style-rule's new rule at the wrong position, most
+  // visibly for an empty <style></style> block (see the analogous fix in css-rule-index.mjs).
+  it("add-style-rule appends inside an empty <style></style> block when an emoji precedes it", async () => {
+    const emojiEmptyStyle = `---\n---\n<article>\u{1F389} emoji</article>\n\n<style></style>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), emojiEmptyStyle);
+    const baseVersion = fileVersion(emojiEmptyStyle);
+    const edit = { op: "add-style-rule", component: { path: "src/components/Card.astro", baseVersion, selector: ".card", declarations: [{ property: "padding", value: "1rem" }] } };
+    const result = await resolveComponentStyle(tmpDir, edit);
+    const next = apply(result);
+    expect(next.indexOf(".card {")).toBeGreaterThan(next.indexOf("<style>"));
+    expect(next.indexOf(".card {")).toBeLessThan(next.indexOf("</style>"));
+    expect(next).toMatch(/\.card\s*{\s*padding: 1rem;\s*}/);
+  });
 });

--- a/tests/component-style-edit.test.ts
+++ b/tests/component-style-edit.test.ts
@@ -59,10 +59,11 @@ describe("resolveComponentStyle", () => {
     const baseVersion = fileVersion(CARD);
     // Recompute the real span via the resolver's own indexing to avoid hand-counting offsets:
     const { indexCssRules } = await import("../server/css-rule-index.mjs");
+    const { buildLineStarts } = await import("../server/component-node-index.mjs");
     const { parse } = await import("@astrojs/compiler");
     const { ast } = await parse(CARD, { position: true });
     const styleEl = ast.children.find((n) => n.type === "element" && n.name === "style");
-    const [cardRule] = indexCssRules(styleEl);
+    const [cardRule] = indexCssRules(styleEl, buildLineStarts(CARD));
 
     const edit = { op: "set-style-property", component: { path: "src/components/Card.astro", baseVersion, ruleSpan: cardRule.span, property: "color", value: "blue" } };
     const result = await resolveComponentStyle(tmpDir, edit);
@@ -74,10 +75,11 @@ describe("resolveComponentStyle", () => {
   it("set-style-property inserts a new declaration when the property is absent", async () => {
     const baseVersion = fileVersion(CARD);
     const { indexCssRules } = await import("../server/css-rule-index.mjs");
+    const { buildLineStarts } = await import("../server/component-node-index.mjs");
     const { parse } = await import("@astrojs/compiler");
     const { ast } = await parse(CARD, { position: true });
     const styleEl = ast.children.find((n) => n.type === "element" && n.name === "style");
-    const [cardRule] = indexCssRules(styleEl);
+    const [cardRule] = indexCssRules(styleEl, buildLineStarts(CARD));
 
     const edit = { op: "set-style-property", component: { path: "src/components/Card.astro", baseVersion, ruleSpan: cardRule.span, property: "margin", value: "0" } };
     const result = await resolveComponentStyle(tmpDir, edit);
@@ -87,10 +89,11 @@ describe("resolveComponentStyle", () => {
   it("remove-style-property deletes the declaration and its semicolon", async () => {
     const baseVersion = fileVersion(CARD);
     const { indexCssRules } = await import("../server/css-rule-index.mjs");
+    const { buildLineStarts } = await import("../server/component-node-index.mjs");
     const { parse } = await import("@astrojs/compiler");
     const { ast } = await parse(CARD, { position: true });
     const styleEl = ast.children.find((n) => n.type === "element" && n.name === "style");
-    const [cardRule] = indexCssRules(styleEl);
+    const [cardRule] = indexCssRules(styleEl, buildLineStarts(CARD));
 
     const edit = { op: "remove-style-property", component: { path: "src/components/Card.astro", baseVersion, ruleSpan: cardRule.span, property: "color" } };
     const result = await resolveComponentStyle(tmpDir, edit);
@@ -101,10 +104,11 @@ describe("resolveComponentStyle", () => {
   it("set-rule-selector renames only the prelude", async () => {
     const baseVersion = fileVersion(CARD);
     const { indexCssRules } = await import("../server/css-rule-index.mjs");
+    const { buildLineStarts } = await import("../server/component-node-index.mjs");
     const { parse } = await import("@astrojs/compiler");
     const { ast } = await parse(CARD, { position: true });
     const styleEl = ast.children.find((n) => n.type === "element" && n.name === "style");
-    const [cardRule] = indexCssRules(styleEl);
+    const [cardRule] = indexCssRules(styleEl, buildLineStarts(CARD));
 
     const edit = { op: "set-rule-selector", component: { path: "src/components/Card.astro", baseVersion, ruleSpan: cardRule.span, selector: ".card--big" } };
     const result = await resolveComponentStyle(tmpDir, edit);

--- a/tests/css-rule-index.test.ts
+++ b/tests/css-rule-index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { parse } from "@astrojs/compiler";
 import { indexCssRules } from "../server/css-rule-index.mjs";
+import { buildLineStarts } from "../server/component-node-index.mjs";
 
 const SOURCE = `<style>
   .card { padding: 1rem; color: red; }
@@ -10,15 +11,15 @@ const SOURCE = `<style>
 </style>
 `;
 
-async function styleElement() {
-  const { ast } = await parse(SOURCE, { position: true });
+async function styleElement(src: string = SOURCE) {
+  const { ast } = await parse(src, { position: true });
   return ast.children.find((n: any) => n.type === "element" && n.name === "style");
 }
 
 describe("indexCssRules", () => {
   it("captures selector, media, span, preludeSpan, blockInner, and declarations", async () => {
     const el = await styleElement();
-    const rules = indexCssRules(el);
+    const rules = indexCssRules(el, buildLineStarts(SOURCE));
     expect(rules).toHaveLength(2);
 
     const [card, media] = rules;
@@ -43,6 +44,18 @@ describe("indexCssRules", () => {
     const src = `<style lang="scss">.x { &:hover { color: blue; } }</style>`;
     const { ast } = await parse(src, { position: true });
     const el = ast.children.find((n: any) => n.type === "element" && n.name === "style");
-    expect(indexCssRules(el)).toEqual([]);
+    expect(indexCssRules(el, buildLineStarts(src))).toEqual([]);
+  });
+
+  // @astrojs/compiler@4.0.0 reports `position.*.offset` as a UTF-8 byte offset, not a
+  // JS-string (UTF-16) index — an emoji or other multi-byte-UTF-8 character earlier in
+  // the source used to corrupt every span this module returns (see the analogous fix in
+  // component-node-index.mjs's buildLineStarts/offsetFromLineColumn).
+  it("keeps spans correct when an emoji precedes the <style> element", async () => {
+    const src = `<div>\u{1F389} emoji</div>\n<style>\n  .card { padding: 1rem; }\n</style>\n`;
+    const el = await styleElement(src);
+    const [rule] = indexCssRules(el, buildLineStarts(src));
+    expect(src.slice(rule.span[0], rule.span[1])).toBe(".card { padding: 1rem; }");
+    expect(src.slice(rule.declarations[0].span[0], rule.declarations[0].span[1])).toBe("padding: 1rem");
   });
 });

--- a/tests/frontmatter-imports.test.ts
+++ b/tests/frontmatter-imports.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { parseImports, ensureImport, pruneImportIfUnused } from "../server/frontmatter-imports.mjs";
+
+const FM_WITH_IMPORTS = `
+import Badge from "./Badge.astro";
+import { formatDate } from "../lib/dates";
+interface Props { title: string; }
+`;
+
+describe("parseImports", () => {
+  it("finds default-import lines with local name, specifier, and line span", () => {
+    const imports = parseImports(FM_WITH_IMPORTS);
+    const badge = imports.find((i) => i.localName === "Badge");
+    expect(badge.specifier).toBe("./Badge.astro");
+    expect(FM_WITH_IMPORTS.slice(badge.span[0], badge.span[1])).toBe('import Badge from "./Badge.astro";\n');
+  });
+
+  it("ignores named imports (not component-shaped)", () => {
+    const imports = parseImports(FM_WITH_IMPORTS);
+    expect(imports.some((i) => i.specifier === "../lib/dates")).toBe(false);
+  });
+
+  it("returns [] for frontmatter with no imports", () => {
+    expect(parseImports("interface Props {}\n")).toEqual([]);
+  });
+});
+
+describe("ensureImport", () => {
+  it("appends a new import after the last existing import", () => {
+    const { source, added } = ensureImport(FM_WITH_IMPORTS, { localName: "Callout", specifier: "./Callout.astro" });
+    expect(added).toBe(true);
+    expect(source).toContain('import Callout from "./Callout.astro";');
+    expect(source.indexOf('import Callout')).toBeGreaterThan(source.indexOf('import Badge'));
+    expect(source.indexOf('import Callout')).toBeLessThan(source.indexOf('interface Props'));
+  });
+
+  it("inserts at the very start when there are no existing imports", () => {
+    const { source, added } = ensureImport("interface Props {}\n", { localName: "Callout", specifier: "./Callout.astro" });
+    expect(added).toBe(true);
+    expect(source.indexOf('import Callout')).toBeLessThan(source.indexOf('interface Props'));
+  });
+
+  it("is a no-op when an import for the same specifier already exists", () => {
+    const { source, added } = ensureImport(FM_WITH_IMPORTS, { localName: "Badge", specifier: "./Badge.astro" });
+    expect(added).toBe(false);
+    expect(source).toBe(FM_WITH_IMPORTS);
+  });
+});
+
+describe("pruneImportIfUnused", () => {
+  it("removes the import line when the tag no longer appears in the template", () => {
+    const { source, removed } = pruneImportIfUnused(FM_WITH_IMPORTS, "<article><h2>gone</h2></article>", "Badge");
+    expect(removed).toBe(true);
+    expect(source).not.toContain("Badge");
+  });
+
+  it("keeps the import when the tag is still used", () => {
+    const { source, removed } = pruneImportIfUnused(FM_WITH_IMPORTS, "<article><Badge label=\"x\" /></article>", "Badge");
+    expect(removed).toBe(false);
+    expect(source).toBe(FM_WITH_IMPORTS);
+  });
+
+  it("is a no-op when there is no import for that name", () => {
+    const { source, removed } = pruneImportIfUnused(FM_WITH_IMPORTS, "<article></article>", "Nope");
+    expect(removed).toBe(false);
+    expect(source).toBe(FM_WITH_IMPORTS);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `apply_edit` component-structure ops (`set-attr`, `remove-node`, `insert-node`) backed by a monotonic-cursor lexical span resolver (`resolveAllSpans`) that never trusts `@astrojs/compiler`'s reported byte offsets — it re-derives every node's true source span from tree shape + a forward lexical walk, refusing (`no-match`) rather than risking silent corruption when a span can't be found.
- Fixes a real `@astrojs/compiler@4.0.0` bug discovered during review: `position.*.offset` is a UTF-8 **byte** offset, not a JS-string (UTF-16) index, so any multi-byte-UTF-8 character (emoji, accented Latin, CJK, etc.) earlier in a component's source silently corrupted the `span`/`loc` of every node after it — in the already-shipped `get_component_model` read model (template nodes, attributes, frontmatter, client script) as well as CSS rule/declaration spans. All of these now derive offsets from the (reliably UTF-16-based) line/column fields instead of trusting `.offset`.

## Test plan
- [x] `npm test` — 142 files / 3004 tests passing
- [x] Unicode regression tests added to `tests/component-node-index.test.ts`, `tests/component-model.test.ts`, and `tests/css-rule-index.test.ts`, confirmed RED before the fix / GREEN after
- [x] `tests/component-structure-edit.test.ts` covers set-attr, remove-node, insert-node, and nested-sibling-collision regressions