### PR TITLE
Add set-props-interface / set-script-zone component-frontmatter ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.0] — 2026-07-16
+
+### Added
+- `apply_edit` gains two component-frontmatter ops — `set-props-interface`,
+  `set-script-zone` — for the Component Editor's Props form and code panes
+  (Slice 4). `set-props-interface` codegens/replaces a component's
+  `interface Props {...}` block and its `Astro.props` destructure from a
+  structured `{name, type, optional, default}[]` array (an empty array
+  removes both); `set-script-zone` replaces a whole script zone
+  (`frontmatter` or `client`) wholesale, for the code-pane "save" gesture,
+  synthesizing the zone if it doesn't exist yet. Both share the same
+  content-hash (`baseVersion`) staleness checking as the existing
+  component-style/component-structure ops, and piggyback a freshly rebuilt
+  `get_component_model` result on a successful reply.
+
 ## [1.5.0] — 2026-07-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Anglesite is a Claude plugin that scaffolds and manages websites for small businesses. It works with Claude Cowork (non-technical site owners, GUI) and Claude Code (developers, CLI). It generates Astro + Keystatic sites deployed to Cloudflare Workers (Static Assets, via the `@astrojs/cloudflare` adapter).
 
-**Version:** 1.5.0 · **License:** ISC · **Node:** >=22 · **Module system:** ESM
+**Version:** 1.6.0 · **License:** ISC · **Node:** >=22 · **Module system:** ESM
 
 ## Plugin structure
 

--- a/agent-skills/README.md
+++ b/agent-skills/README.md
@@ -9,7 +9,7 @@ material lives in its `references/` directory.
 > Generated — do not edit by hand. Edit the plugin sources in `skills/` and run
 > `npm run build:agent-skills`.
 
-**Version:** 1.5.0 · **License:** ISC · 56 skills
+**Version:** 1.6.0 · **License:** ISC · 56 skills
 
 ## Install
 

--- a/agent-skills/add-store/SKILL.md
+++ b/agent-skills/add-store/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npx wrangler *), Bash(npm run build), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/animate/SKILL.md
+++ b/agent-skills/animate/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/backup/SKILL.md
+++ b/agent-skills/backup/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(git status *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git log *), Bash(git diff *), Bash(git checkout *), Bash(git branch *), Bash(git tag *), Bash(git show *), Bash(git stash *), Bash(git fetch *), Bash(git rev-parse *), Bash(npx tsx *), Read
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/booking/SKILL.md
+++ b/agent-skills/booking/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob, Bash(npm run build), Bash(npx astro check)
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/business-info/SKILL.md
+++ b/agent-skills/business-info/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/buy-button/SKILL.md
+++ b/agent-skills/buy-button/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/check/SKILL.md
+++ b/agent-skills/check/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run *), Bash(npx astro check), Bash(npx pa11y *), Bash(npx pa11y-ci *), Bash(npx tsx scripts/link-check.ts *), Bash(npx tsx scripts/a11y-audit.ts *), Bash(npx tsx scripts/a14y-audit.ts *), Bash(npx a14y *), Bash(a14y *), Bash(grep *), Bash(find dist/ *), Bash(stat *), Bash(npm audit *), Bash(lsof *), Bash(netstat *), Bash(getent *), Bash(nslookup *), Bash(gh issue *), Bash(gh label *), Write, Read, Glob, mcp__cloudflare__accounts_list, mcp__cloudflare__search_cloudflare_documentation, mcp__cloudflare__workers_list, mcp__cloudflare__workers_get_worker, mcp__cloudflare__workers_get_worker_code
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[optional: describe the problem]"

--- a/agent-skills/consent/SKILL.md
+++ b/agent-skills/consent/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(grep *), Write, Read, Glob, Edit
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/contact/SKILL.md
+++ b/agent-skills/contact/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(npx astro check), Bash(grep *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/convert/SKILL.md
+++ b/agent-skills/convert/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: ["Bash(npm run build)", "Bash(npm install)", "Bash(npm run ai-alt)", "Bash(zsh *)", "Bash(node *)", "Bash(npx sharp-cli *)", "Bash(mkdir *)", "Bash(git add *)", "Bash(git commit *)", "Bash(ls *)", "Bash(wc *)", "Bash(cp *)", "Bash(find src/content/posts *)", "Bash(find public/images *)", "Bash(find */images *)", "Bash(find */public *)", "Bash(find */static *)", "Bash(find */source *)", "Bash(find */content *)", "Bash(find */docs *)", "Bash(find */_posts *)", "Bash(find */layouts *)", "Bash(find */templates *)", "Bash(find */_includes *)", "Write", "Read", "Glob", "Edit"]
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/copy-edit/SKILL.md
+++ b/agent-skills/copy-edit/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/creative-canvas/SKILL.md
+++ b/agent-skills/creative-canvas/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm install *), Bash(npm run dev), Bash(npm run build), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
   argument-hint: "[effect description or library name]"

--- a/agent-skills/deploy/SKILL.md
+++ b/agent-skills/deploy/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npm run deploy *), Bash(npm run preview *), Bash(npm run ai-linkcheck *), Bash(npm run ai-a11y *), Bash(npm run ai-a14y *), Bash(npm run ai-perf *), Bash(npm run ai-webmention-send *), Bash(npx wrangler *), Bash(grep *), Bash(find dist/ *), Bash(gh *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git checkout *), Bash(git merge *), Bash(git branch *), Bash(kill *), Write, Read, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__search_cloudflare_documentation
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/design-import/SKILL.md
+++ b/agent-skills/design-import/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: ["Bash(node *)", "Bash(npx sharp-cli *)", "Bash(npx playwright install *)", "Bash(npm install *)", "Bash(npm run dev *)", "Bash(npm run build)", "Bash(mkdir *)", "Bash(curl *)", "Bash(git add *)", "Bash(git commit *)", "Bash(git push *)", "Bash(ls *)", "Bash(npm ls *)", "Bash(grep *)", "WebFetch", "Write", "Read", "Edit", "Glob"]
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[Canva site URL, Figma file URL, or freedesignmd.com system URL]"

--- a/agent-skills/design-interview/SKILL.md
+++ b/agent-skills/design-interview/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run *), WebFetch, Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/domain/SKILL.md
+++ b/agent-skills/domain/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(curl *), Write, Read, mcp__cloudflare__search_cloudflare_documentation
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[email, bluesky, or service name]"

--- a/agent-skills/donations/SKILL.md
+++ b/agent-skills/donations/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/email/SKILL.md
+++ b/agent-skills/email/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(curl *), Write, Read
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/experiment/SKILL.md
+++ b/agent-skills/experiment/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/export/SKILL.md
+++ b/agent-skills/export/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(mkdir *), Bash(cp *), Bash(rsync *), Bash(zip *), Bash(ls *), Bash(find *), Bash(du *), Bash(grep *), Bash(date *), Bash(git rev-parse *), Bash(npx wrangler r2 *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, Read, Write
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/forms/SKILL.md
+++ b/agent-skills/forms/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(npx astro check), Bash(grep *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/freedesignmd/SKILL.md
+++ b/agent-skills/freedesignmd/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: WebFetch, Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/giscus/SKILL.md
+++ b/agent-skills/giscus/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx astro check), Bash(grep *), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/i18n/SKILL.md
+++ b/agent-skills/i18n/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx astro check), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/import/SKILL.md
+++ b/agent-skills/import/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: ["WebFetch", "Bash(curl *)", "Bash(npx sharp-cli *)", "Bash(mkdir *)", "Bash(npm run build)", "Bash(npm install)", "Bash(npm run ai-alt)", "Bash(zsh *)", "Bash(node *)", "Bash(git add *)", "Bash(git commit *)", "Bash(git push *)", "Bash(ls *)", "Bash(wc *)", "Bash(grep *)", "Bash(find src/content/posts *)", "Bash(find public/images *)", "Bash(find */images *)", "Bash(find */public *)", "Bash(find */static *)", "Bash(find */source *)", "Bash(find */content *)", "Bash(find */docs *)", "Bash(find */_posts *)", "Bash(cp *)", "Write", "Read", "Glob", "Edit"]
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[website URL or local path]"

--- a/agent-skills/inbox/SKILL.md
+++ b/agent-skills/inbox/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run *), Bash(npx wrangler *), Bash(grep *), Write, Read, Edit, Glob, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__d1_database_create, mcp__cloudflare__d1_databases_list, mcp__cloudflare__d1_database_get, mcp__cloudflare__d1_database_query
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/indieweb/SKILL.md
+++ b/agent-skills/indieweb/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npm install *), Bash(npx wrangler *), Bash(openssl *), Bash(grep *), Bash(gh *), Bash(node *), Bash(mktemp *), Bash(printf *), Bash(rm *), Write, Read, Edit, Glob, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__d1_database_create, mcp__cloudflare__d1_databases_list, mcp__cloudflare__d1_database_get, mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_buckets_list
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/lemon-squeezy/SKILL.md
+++ b/agent-skills/lemon-squeezy/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/membership/SKILL.md
+++ b/agent-skills/membership/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(npx astro check), Bash(grep *), Bash(node *), Write, Read, Edit, Glob, mcp__cloudflare__kv_namespace_create, mcp__cloudflare__kv_namespace_get, mcp__cloudflare__kv_namespaces_list, mcp__cloudflare__accounts_list
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/menu/SKILL.md
+++ b/agent-skills/menu/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run dev), Bash(npm run build), Read, Write, Glob, Grep
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/new-page/SKILL.md
+++ b/agent-skills/new-page/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
   argument-hint: "[page name or purpose]"

--- a/agent-skills/newsletter/SKILL.md
+++ b/agent-skills/newsletter/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(curl *), Bash(grep *), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/og-images/SKILL.md
+++ b/agent-skills/og-images/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run ai-images), Bash(npm run ai-og), Bash(npx wrangler r2 *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, Read, Glob, Write
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/optimize-images/SKILL.md
+++ b/agent-skills/optimize-images/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run ai-optimize), Bash(npx wrangler r2 *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/paddle/SKILL.md
+++ b/agent-skills/paddle/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Edit, Glob, Bash(npm run build), Bash(npx astro check)
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/photography/SKILL.md
+++ b/agent-skills/photography/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Read, Glob, Write
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/podcast/SKILL.md
+++ b/agent-skills/podcast/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npm run dev), Bash(npx wrangler r2 *), Bash(wc -c *), Bash(stat *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, mcp__cloudflare__r2_bucket_delete, Read, Write, Edit, Glob, Grep
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/print/SKILL.md
+++ b/agent-skills/print/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob, Bash(npm run ai-qr)
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/pwa/SKILL.md
+++ b/agent-skills/pwa/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(node *), Write, Read, Glob, Edit
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/qr/SKILL.md
+++ b/agent-skills/qr/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run ai-qr), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/redirects/SKILL.md
+++ b/agent-skills/redirects/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Read, Write, Edit, Glob, Bash(grep *), Bash(find *), Bash(wc *), Bash(sort *), Bash(awk *), Bash(test *), Bash(ls *), Bash(cat *)
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[add | remove | list | validate | import | review]"

--- a/agent-skills/repurpose/SKILL.md
+++ b/agent-skills/repurpose/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/reputation/SKILL.md
+++ b/agent-skills/reputation/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(date *), Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/search/SKILL.md
+++ b/agent-skills/search/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm install *), Bash(npm run build), Bash(npx astro check), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/seasonal/SKILL.md
+++ b/agent-skills/seasonal/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(date *), Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/seo/SKILL.md
+++ b/agent-skills/seo/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npm run ai-seo*), Bash(npx astro check), Bash(grep *), Bash(find dist/ *), Bash(git log *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[page /about | schema | sitemap | og-images]"

--- a/agent-skills/share/SKILL.md
+++ b/agent-skills/share/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Write, Read, Glob, Edit
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/shopify-buy-button/SKILL.md
+++ b/agent-skills/shopify-buy-button/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Edit, Glob, Bash(npm run build), Bash(npx astro check)
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/snipcart/SKILL.md
+++ b/agent-skills/snipcart/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Edit, Glob, Bash(npm run build), Bash(npx astro check)
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/social-media/SKILL.md
+++ b/agent-skills/social-media/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/start/SKILL.md
+++ b/agent-skills/start/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(zsh *), Bash(npm install), Bash(npm run *), Bash(gh *), Bash(git remote *), Bash(git push *), Bash(git branch *), Bash(git add *), Bash(git commit *), WebFetch, Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/stats/SKILL.md
+++ b/agent-skills/stats/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(curl *), Bash(grep *), Bash(git log *), Bash(cat perf-trend.json), Write, Edit, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/testimonials/SKILL.md
+++ b/agent-skills/testimonials/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/themes/SKILL.md
+++ b/agent-skills/themes/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: WebFetch, Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/tracking/SKILL.md
+++ b/agent-skills/tracking/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm install *), Bash(npm run build), Bash(npx astro check), Bash(grep *), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/update/SKILL.md
+++ b/agent-skills/update/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(zsh *), Bash(npm run *), Bash(npm install *), Bash(npm update *), Bash(npm outdated *), Bash(npm audit *), Bash(npx astro check), Bash(git add *), Bash(git commit *), Bash(git diff *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.5.0"
+  version: "1.6.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/update/references/package.json
+++ b/agent-skills/update/references/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anglesite",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "AI webmaster that scaffolds, designs, and deploys Astro + Keystatic sites on Cloudflare Workers.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anglesite",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "AI webmaster that scaffolds, designs, and deploys Astro + Keystatic sites on Cloudflare Workers.",
   "scripts": {

--- a/server/apply-edit-schema.mjs
+++ b/server/apply-edit-schema.mjs
@@ -56,6 +56,8 @@ export const editOps = [
   "move-node",
   "remove-node",
   "set-attr",
+  "set-props-interface",
+  "set-script-zone",
 ];
 
 /** The subset of `editOps` that operate on a component's scoped `<style>` via `component`
@@ -72,8 +74,12 @@ export const COMPONENT_STYLE_OPS = new Set([
  *  via `component` rather than on a page element via `selector`. */
 export const COMPONENT_STRUCTURE_OPS = new Set(["insert-node", "move-node", "remove-node", "set-attr"]);
 
-/** Union of style and structure component ops — used by the dispatcher's shared checks. */
-export const COMPONENT_OPS = new Set([...COMPONENT_STYLE_OPS, ...COMPONENT_STRUCTURE_OPS]);
+/** The subset of `editOps` that codegen/replace a component's frontmatter or client-script
+ *  zone via `component` — the Props form and STTextView code-pane saves. */
+export const COMPONENT_FRONTMATTER_OPS = new Set(["set-props-interface", "set-script-zone"]);
+
+/** Union of style, structure, and frontmatter component ops — used by the dispatcher's shared checks. */
+export const COMPONENT_OPS = new Set([...COMPONENT_STYLE_OPS, ...COMPONENT_STRUCTURE_OPS, ...COMPONENT_FRONTMATTER_OPS]);
 
 /** Structured payload for the four component-style ops. Identifies the target rule by its exact
  *  byte span (from `get_component_model`'s `styles[].span`) plus a `baseVersion` content-hash
@@ -108,6 +114,21 @@ export const componentEditSchema = z.object({
     })
     .optional()
     .describe("New node spec for insert-node"),
+  props: z
+    .array(
+      z.object({
+        name: z.string(),
+        type: z.string(),
+        optional: z.boolean(),
+        default: z.string().nullable().optional(),
+      }),
+    )
+    .optional()
+    .describe(
+      "Full Props array for set-props-interface — codegens/replaces the frontmatter's `interface Props {...}` and its `Astro.props` destructure. An empty array removes both.",
+    ),
+  zone: z.enum(["frontmatter", "client"]).optional().describe("Script zone for set-script-zone: the frontmatter TS or the client <script>"),
+  source: z.string().optional().describe("Replacement source text for set-script-zone's target zone"),
 });
 
 /** The MCP tool's input shape, as passed to `server.tool(name, description, shape, handler)`. */
@@ -137,13 +158,13 @@ export const applyEditInputShape = {
   op: z
     .enum(editOps)
     .describe(
-      "Edit operation: replace-text (innerText), replace-attr (value is {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>), apply-instruction (reserved: sent only by the Anglesite-app Foundation Models chat path; always returns edit-failed/needs-agent — do not use from external callers), set-style-property/remove-style-property/add-style-rule/set-rule-selector (component-style ops), insert-node/move-node/remove-node/set-attr (component-structure ops — see componentEditSchema)",
+      "Edit operation: replace-text (innerText), replace-attr (value is {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>), apply-instruction (reserved: sent only by the Anglesite-app Foundation Models chat path; always returns edit-failed/needs-agent — do not use from external callers), set-style-property/remove-style-property/add-style-rule/set-rule-selector (component-style ops), insert-node/move-node/remove-node/set-attr (component-structure ops), set-props-interface/set-script-zone (component-frontmatter ops — see componentEditSchema)",
     ),
   value: z
     .unknown()
     .optional()
     .describe(
-      "Operation payload; varies by op (string for replace-text, {name, value} for replace-attr, {filename, mimeType, dataURL} for replace-image-src, {property, value} for edit-style, string for apply-instruction — the NL instruction text). Omitted for the component-style ops, whose payload is `component`.",
+      "Operation payload; varies by op (string for replace-text, {name, value} for replace-attr, {filename, mimeType, dataURL} for replace-image-src, {property, value} for edit-style, string for apply-instruction — the NL instruction text). Omitted for the component ops, whose payload is `component`.",
     ),
   dry_run: z
     .boolean()

--- a/server/component-frontmatter-edit.mjs
+++ b/server/component-frontmatter-edit.mjs
@@ -131,7 +131,7 @@ function replacePropsDestructure(fmBody, newDestructure) {
   return fmBody.slice(0, trimmedEnd) + (trimmedEnd > 0 ? "\n" : "") + newDestructure + fmBody.slice(trimmedEnd);
 }
 
-function applySetScriptZone(file, source, component) {
+async function applySetScriptZone(file, source, component) {
   const { zone, source: newSource } = component;
   if (zone !== "frontmatter" && zone !== "client") {
     return refuse("invalid-input", 'set-script-zone requires component.zone to be "frontmatter" or "client"');
@@ -142,14 +142,33 @@ function applySetScriptZone(file, source, component) {
   return zone === "frontmatter" ? applySetFrontmatterZone(file, source, newSource) : applySetClientScriptZone(file, source, newSource);
 }
 
-function applySetFrontmatterZone(file, source, newSource) {
-  const fmMatch = source.match(FRONTMATTER_RE);
-  if (!fmMatch) {
+// The code-pane's "Props & Data" content is `get_component_model`'s `frontmatter.source` —
+// `component-model.mjs`'s `fmNode.value` — so this MUST replace exactly that same span, not an
+// independently-regex-derived one, or a verbatim no-op save would drift the file (e.g. gain a
+// stray trailing newline each time). `fmNode.value` is the text strictly between the opening
+// and closing `---` fences: parsing gives `fmNode.position.start/end` spanning the WHOLE
+// `---\n...\n---` block (verified empirically — see component-model.test.ts's emoji-safety
+// test), so the value's bounds are simply that span narrowed by exactly 3 characters (`---`'s
+// literal length) on each side — independent of the fence's line-ending style, since the
+// narrowing never has to find or count the newline itself.
+async function applySetFrontmatterZone(file, source, newSource) {
+  let ast;
+  try {
+    ({ ast } = await parse(source, { position: true }));
+  } catch (err) {
+    return refuse("parse-failed", `parse ${file}: ${err.message}`);
+  }
+  const fmNode = (ast.children ?? []).find((n) => n.type === "frontmatter");
+  if (!fmNode) {
     return { file, range: { start: 0, end: 0 }, replacement: `---\n${newSource}\n---\n` };
   }
-  const [, open, fmBody] = fmMatch;
-  const fmBodyStart = fmMatch.index + open.length;
-  return { file, range: { start: fmBodyStart, end: fmBodyStart + fmBody.length }, replacement: newSource };
+  const lineStarts = buildLineStarts(source);
+  const fmStart = offsetFromLineColumn(lineStarts, fmNode.position?.start);
+  const fmEnd = offsetFromLineColumn(lineStarts, fmNode.position?.end);
+  if (fmStart == null || fmEnd == null) {
+    return refuse("no-match", "could not resolve the frontmatter's source span");
+  }
+  return { file, range: { start: fmStart + 3, end: fmEnd - 3 }, replacement: newSource };
 }
 
 async function applySetClientScriptZone(file, source, newSource) {

--- a/server/component-frontmatter-edit.mjs
+++ b/server/component-frontmatter-edit.mjs
@@ -1,0 +1,184 @@
+import { readFileSync } from "node:fs";
+import { join, normalize } from "node:path";
+import { parse } from "@astrojs/compiler";
+import { fileVersion } from "./file-version.mjs";
+import { buildLineStarts, offsetFromLineColumn } from "./component-node-index.mjs";
+import { generatePropsInterface, generatePropsDestructure } from "./props-interface.mjs";
+import { parseImports } from "./frontmatter-imports.mjs";
+
+/**
+ * Write-side resolver for the two Component Editor "Props & code" ops
+ * (set-props-interface, set-script-zone). Mirrors component-style-edit.mjs's
+ * shape: read fresh from disk, check `baseVersion`, turn the requested op
+ * into a precise byte-range splice.
+ */
+
+function refuse(reason, detail) {
+  return { refused: true, reason, detail };
+}
+
+function validPath(relPath) {
+  return typeof relPath === "string" && relPath.endsWith(".astro") && !normalize(relPath).startsWith("..") && !relPath.startsWith("/");
+}
+
+// Matches the block `parseProps` (props-interface.mjs) locates for reading.
+const PROPS_INTERFACE_RE = /(?:interface\s+Props|type\s+Props\s*=)\s*\{[\s\S]*?\n\}/;
+const PROPS_DESTRUCTURE_RE = /const\s*\{[\s\S]*?\}\s*=\s*Astro\.props;?/;
+const FRONTMATTER_RE = /^(---\r?\n)([\s\S]*?)(\r?\n---)/;
+
+export async function resolveComponentFrontmatter(projectRoot, edit) {
+  const { component } = edit;
+  if (!component || typeof component !== "object") {
+    return refuse("invalid-input", "component payload is required for this op");
+  }
+  const { path: relPath, baseVersion } = component;
+  if (!validPath(relPath)) {
+    return refuse("invalid-input", `not a project-relative .astro path: ${relPath}`);
+  }
+
+  const absPath = join(projectRoot, relPath);
+  let source;
+  try {
+    source = readFileSync(absPath, "utf-8");
+  } catch (err) {
+    return refuse("read-failed", `read ${relPath}: ${err.message}`);
+  }
+
+  if (fileVersion(source) !== baseVersion) {
+    return refuse("stale", `${relPath} changed since the model was fetched`);
+  }
+
+  switch (edit.op) {
+    case "set-props-interface":
+      return applySetPropsInterface(relPath, source, component);
+    case "set-script-zone":
+      return applySetScriptZone(relPath, source, component);
+    default:
+      return refuse("invalid-input", `unsupported component-frontmatter op: ${edit.op}`);
+  }
+}
+
+function applySetPropsInterface(file, source, component) {
+  const { props } = component;
+  if (!Array.isArray(props)) {
+    return refuse("invalid-input", "set-props-interface requires component.props (array)");
+  }
+  for (const p of props) {
+    if (!p || typeof p !== "object" || typeof p.name !== "string" || typeof p.type !== "string" || typeof p.optional !== "boolean") {
+      return refuse("invalid-input", "each prop requires name (string), type (string), and optional (boolean)");
+    }
+  }
+
+  const newInterface = generatePropsInterface(props);
+  const newDestructure = generatePropsDestructure(props);
+  const fmMatch = source.match(FRONTMATTER_RE);
+
+  if (!fmMatch) {
+    if (!newInterface) {
+      return refuse("no-match", "component has no frontmatter and no props to add");
+    }
+    const block = [newInterface, newDestructure].filter(Boolean).join("\n");
+    return { file, range: { start: 0, end: 0 }, replacement: `---\n${block}\n---\n` };
+  }
+
+  const [, open, fmBody] = fmMatch;
+  const fmBodyStart = fmMatch.index + open.length;
+
+  let newBody = replacePropsInterfaceBlock(fmBody, newInterface);
+  newBody = replacePropsDestructure(newBody, newDestructure);
+
+  return { file, range: { start: fmBodyStart, end: fmBodyStart + fmBody.length }, replacement: newBody };
+}
+
+function replacePropsInterfaceBlock(fmBody, newInterface) {
+  const match = fmBody.match(PROPS_INTERFACE_RE);
+  if (match) {
+    if (!newInterface) {
+      let end = match.index + match[0].length;
+      if (fmBody[end] === "\n") end++;
+      return fmBody.slice(0, match.index) + fmBody.slice(end);
+    }
+    return fmBody.slice(0, match.index) + newInterface + fmBody.slice(match.index + match[0].length);
+  }
+  if (!newInterface) return fmBody;
+  // No existing interface — insert after the last import (mirrors ensureImport's
+  // placement convention), or at the top of the frontmatter body if there are none.
+  const imports = parseImports(fmBody);
+  const insertAt = imports.length > 0 ? imports[imports.length - 1].span[1] : fmBody.startsWith("\n") ? 1 : 0;
+  return fmBody.slice(0, insertAt) + newInterface + "\n" + fmBody.slice(insertAt);
+}
+
+function replacePropsDestructure(fmBody, newDestructure) {
+  const match = fmBody.match(PROPS_DESTRUCTURE_RE);
+  if (match) {
+    if (!newDestructure) {
+      let end = match.index + match[0].length;
+      if (fmBody[end] === "\n") end++;
+      return fmBody.slice(0, match.index) + fmBody.slice(end);
+    }
+    return fmBody.slice(0, match.index) + newDestructure + fmBody.slice(match.index + match[0].length);
+  }
+  if (!newDestructure) return fmBody;
+  // No existing destructure — insert right after the Props interface block when present
+  // (the natural place a hand-written destructure would sit), else at the end of the body.
+  const ifaceMatch = fmBody.match(PROPS_INTERFACE_RE);
+  if (ifaceMatch) {
+    let insertAt = ifaceMatch.index + ifaceMatch[0].length;
+    if (fmBody[insertAt] === "\n") insertAt++;
+    return fmBody.slice(0, insertAt) + newDestructure + "\n" + fmBody.slice(insertAt);
+  }
+  const trimmedEnd = fmBody.replace(/\s+$/, "").length;
+  return fmBody.slice(0, trimmedEnd) + (trimmedEnd > 0 ? "\n" : "") + newDestructure + fmBody.slice(trimmedEnd);
+}
+
+function applySetScriptZone(file, source, component) {
+  const { zone, source: newSource } = component;
+  if (zone !== "frontmatter" && zone !== "client") {
+    return refuse("invalid-input", 'set-script-zone requires component.zone to be "frontmatter" or "client"');
+  }
+  if (typeof newSource !== "string") {
+    return refuse("invalid-input", "set-script-zone requires component.source (string)");
+  }
+  return zone === "frontmatter" ? applySetFrontmatterZone(file, source, newSource) : applySetClientScriptZone(file, source, newSource);
+}
+
+function applySetFrontmatterZone(file, source, newSource) {
+  const fmMatch = source.match(FRONTMATTER_RE);
+  if (!fmMatch) {
+    return { file, range: { start: 0, end: 0 }, replacement: `---\n${newSource}\n---\n` };
+  }
+  const [, open, fmBody] = fmMatch;
+  const fmBodyStart = fmMatch.index + open.length;
+  return { file, range: { start: fmBodyStart, end: fmBodyStart + fmBody.length }, replacement: newSource };
+}
+
+async function applySetClientScriptZone(file, source, newSource) {
+  let ast;
+  try {
+    ({ ast } = await parse(source, { position: true }));
+  } catch (err) {
+    return refuse("parse-failed", `parse ${file}: ${err.message}`);
+  }
+  const lineStarts = buildLineStarts(source);
+  const scriptElements = [];
+  collectScriptElements(ast, scriptElements);
+  const textNode = scriptElements.map((el) => (el.children ?? []).find((c) => c.type === "text")).find((t) => t?.value);
+
+  if (textNode) {
+    const start = offsetFromLineColumn(lineStarts, textNode.position?.start);
+    const end = offsetFromLineColumn(lineStarts, textNode.position?.end);
+    if (start == null || end == null) {
+      return refuse("no-match", "could not resolve the client script's source span");
+    }
+    return { file, range: { start, end }, replacement: newSource };
+  }
+
+  // No existing non-empty client script — append a new <script> block, mirroring
+  // add-style-rule's "create the container if absent" fallback in component-style-edit.mjs.
+  return { file, range: { start: source.length, end: source.length }, replacement: `\n<script>\n${newSource}\n</script>\n` };
+}
+
+function collectScriptElements(node, out) {
+  if (node.type === "element" && node.name === "script") out.push(node);
+  for (const child of node.children ?? []) collectScriptElements(child, out);
+}

--- a/server/patcher.mjs
+++ b/server/patcher.mjs
@@ -3,7 +3,8 @@ import { join, relative, extname, basename, dirname } from "node:path";
 import { rewriteAstroStyle } from "./style-edit.mjs";
 import { resolveComponentStyle } from "./component-style-edit.mjs";
 import { resolveComponentStructure } from "./component-structure-edit.mjs";
-import { COMPONENT_STYLE_OPS, COMPONENT_STRUCTURE_OPS } from "./apply-edit-schema.mjs";
+import { resolveComponentFrontmatter } from "./component-frontmatter-edit.mjs";
+import { COMPONENT_STYLE_OPS, COMPONENT_STRUCTURE_OPS, COMPONENT_FRONTMATTER_OPS } from "./apply-edit-schema.mjs";
 
 /**
  * @typedef {import('./apply-edit-schema.mjs').default} _unused
@@ -15,15 +16,17 @@ import { COMPONENT_STYLE_OPS, COMPONENT_STRUCTURE_OPS } from "./apply-edit-schem
  * Resolve an edit payload to a source-file patch.
  *
  * Tries resolvers in priority order: edit-style → component-style ops →
- * component-structure ops → .mdoc → Keystatic YAML/JSON → .astro. Returns the
- * first non-refusal. If all refuse, returns the most informative refusal
- * (from the highest-priority resolver that had an opinion).
+ * component-structure ops → component-frontmatter ops → .mdoc → Keystatic
+ * YAML/JSON → .astro. Returns the first non-refusal. If all refuse, returns
+ * the most informative refusal (from the highest-priority resolver that had
+ * an opinion).
  *
- * Async because `resolveComponentStyle` (component-style-edit.mjs) and
- * `resolveComponentStructure` (component-structure-edit.mjs) parse the target
- * .astro file with `@astrojs/compiler`, which is itself async. Every other
- * resolver here is synchronous; awaiting their (non-Promise) return values is
- * a no-op, so this doesn't change their behavior.
+ * Async because `resolveComponentStyle` (component-style-edit.mjs),
+ * `resolveComponentStructure` (component-structure-edit.mjs), and
+ * `resolveComponentFrontmatter` (component-frontmatter-edit.mjs) parse the
+ * target .astro file with `@astrojs/compiler`, which is itself async. Every
+ * other resolver here is synchronous; awaiting their (non-Promise) return
+ * values is a no-op, so this doesn't change their behavior.
  *
  * @param {string} projectRoot
  * @param {{ path: string, selector: object, op: string, value?: unknown, component?: object }} edit
@@ -38,6 +41,9 @@ export async function resolve(projectRoot, edit) {
   }
   if (COMPONENT_STRUCTURE_OPS.has(edit.op)) {
     return resolveComponentStructure(projectRoot, edit);
+  }
+  if (COMPONENT_FRONTMATTER_OPS.has(edit.op)) {
+    return resolveComponentFrontmatter(projectRoot, edit);
   }
   const resolvers = [resolveMdoc, resolveKeystatic, resolveAstro];
   let bestRefusal = /** @type {ResolveRefusal | null} */ (null);

--- a/server/props-interface.mjs
+++ b/server/props-interface.mjs
@@ -66,3 +66,27 @@ function isBalanced(value) {
   }
   return open.length === 0 && quote === null;
 }
+
+// Write-side counterpart to `parseProps`, for the `set-props-interface` op
+// (component-frontmatter-edit.mjs). Regex/string codegen only — same
+// "no TS compiler in the container" discipline as the read side above.
+// `props` is the same `{name, type, optional, default}[]` shape `parseProps`
+// returns, so `parseProps(generatePropsInterface(p) + "\n" + generatePropsDestructure(p))`
+// round-trips (module the destructure emitting property-shorthand names).
+
+/** The `interface Props {...}` block text, or `null` for an empty props array
+ *  (meaning: no Props interface at all). */
+export function generatePropsInterface(props) {
+  if (!Array.isArray(props) || props.length === 0) return null;
+  const lines = props.map((p) => `  ${p.name}${p.optional ? "?" : ""}: ${p.type};`);
+  return `interface Props {\n${lines.join("\n")}\n}`;
+}
+
+/** The `const { ... } = Astro.props;` destructure line, or `null` for an
+ *  empty props array. Every prop is destructured (not just ones with
+ *  defaults) so the frontmatter has bindings to reference by name. */
+export function generatePropsDestructure(props) {
+  if (!Array.isArray(props) || props.length === 0) return null;
+  const parts = props.map((p) => (p.default != null && p.default !== "" ? `${p.name} = ${p.default}` : p.name));
+  return `const { ${parts.join(", ")} } = Astro.props;`;
+}

--- a/tests/apply-edit-dispatcher-component-frontmatter.test.ts
+++ b/tests/apply-edit-dispatcher-component-frontmatter.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { applyEdit } from "../server/apply-edit-dispatcher.mjs";
+import { fileVersion } from "../server/file-version.mjs";
+
+const CARD = `---
+interface Props {
+  title: string;
+}
+const { title } = Astro.props;
+---
+<article class="card"><h2>{title}</h2></article>
+
+<script>
+  console.log("card mounted");
+</script>
+`;
+
+function parseContent(response) {
+  return JSON.parse(response.content[0].text);
+}
+
+describe("applyEdit — component-frontmatter ops", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-aed-fm-"));
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), CARD);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rejects a component-frontmatter op with no component payload", async () => {
+    const response = await applyEdit(tmpDir, { id: "1", path: "x", op: "set-props-interface", value: {} });
+    expect(response.isError).toBe(true);
+    expect(parseContent(response).reason).toBe("invalid-input");
+  });
+
+  it("applies set-props-interface and piggybacks a fresh model", async () => {
+    const baseVersion = fileVersion(CARD);
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Card.astro",
+      op: "set-props-interface",
+      component: {
+        path: "src/components/Card.astro",
+        baseVersion,
+        props: [
+          { name: "title", type: "string", optional: false, default: null },
+          { name: "subtitle", type: "string", optional: true, default: null },
+        ],
+      },
+    });
+    expect(response.isError).toBeFalsy();
+    const body = parseContent(response);
+    expect(body.type).toBe("anglesite:edit-applied");
+    expect(body.model).toBeDefined();
+    expect(body.model.frontmatter.props).toEqual([
+      { name: "title", type: "string", optional: false, default: null },
+      { name: "subtitle", type: "string", optional: true, default: null },
+    ]);
+  });
+
+  it("applies set-script-zone against the client zone and piggybacks a fresh model", async () => {
+    const baseVersion = fileVersion(CARD);
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Card.astro",
+      op: "set-script-zone",
+      component: { path: "src/components/Card.astro", baseVersion, zone: "client", source: 'console.log("remounted");' },
+    });
+    expect(response.isError).toBeFalsy();
+    const body = parseContent(response);
+    expect(body.model.clientScript.source).toContain("remounted");
+  });
+
+  it("surfaces stale as a failed reply", async () => {
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Card.astro",
+      op: "set-props-interface",
+      component: { path: "src/components/Card.astro", baseVersion: "sha256:000000000000", props: [] },
+    });
+    expect(response.isError).toBe(true);
+    expect(parseContent(response).reason).toBe("stale");
+  });
+
+  it("re-checks staleness after set-script-zone's async gap, refusing a concurrent write race", async () => {
+    const baseVersion = fileVersion(CARD);
+
+    const editPromise = applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Card.astro",
+      op: "set-script-zone",
+      component: { path: "src/components/Card.astro", baseVersion, zone: "client", source: 'console.log("remounted");' },
+    });
+
+    // Same race shape as apply-edit-dispatcher-component-style.test.ts: a second edit
+    // lands while this call is suspended at resolveComponentFrontmatter's own
+    // (synchronous) work — here the resolver itself doesn't await before the client-zone
+    // branch's `await parse(...)`, so this write races the dispatcher's second baseVersion
+    // check the same way.
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), CARD.replace("card mounted", "card remounted twice"));
+
+    const response = await editPromise;
+    expect(response.isError).toBe(true);
+    expect(parseContent(response).reason).toBe("stale");
+
+    const onDisk = readFileSync(join(tmpDir, "src", "components", "Card.astro"), "utf-8");
+    expect(onDisk).toContain("card remounted twice");
+  });
+});

--- a/tests/apply-edit-schema-frontmatter.test.ts
+++ b/tests/apply-edit-schema-frontmatter.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { editOps, componentEditSchema, applyEditInputShape, COMPONENT_FRONTMATTER_OPS, COMPONENT_OPS } from "../server/apply-edit-schema.mjs";
+
+describe("component-frontmatter op schema", () => {
+  it("registers the two new op names", () => {
+    for (const op of ["set-props-interface", "set-script-zone"]) {
+      expect(editOps).toContain(op);
+      expect(COMPONENT_FRONTMATTER_OPS.has(op)).toBe(true);
+      expect(COMPONENT_OPS.has(op)).toBe(true);
+    }
+  });
+
+  it("accepts a set-props-interface component payload", () => {
+    const schema = z.object(applyEditInputShape);
+    const result = schema.safeParse({
+      id: "1",
+      path: "src/components/Card.astro",
+      op: "set-props-interface",
+      component: {
+        path: "src/components/Card.astro",
+        baseVersion: "sha256:abc123456789",
+        props: [{ name: "title", type: "string", optional: false, default: null }],
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an empty props array (removal)", () => {
+    const result = componentEditSchema.safeParse({
+      path: "src/components/Card.astro",
+      baseVersion: "sha256:abc123456789",
+      props: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a prop entry missing required fields", () => {
+    const result = componentEditSchema.safeParse({
+      path: "src/components/Card.astro",
+      baseVersion: "sha256:abc123456789",
+      props: [{ name: "title" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a set-script-zone component payload for both zones", () => {
+    const schema = z.object(applyEditInputShape);
+    for (const zone of ["frontmatter", "client"]) {
+      const result = schema.safeParse({
+        id: "1",
+        path: "src/components/Card.astro",
+        op: "set-script-zone",
+        component: { path: "src/components/Card.astro", baseVersion: "sha256:abc123456789", zone, source: "const x = 1;" },
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects an unknown zone value", () => {
+    const result = componentEditSchema.safeParse({
+      path: "src/components/Card.astro",
+      baseVersion: "sha256:abc123456789",
+      zone: "bogus",
+      source: "x",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/component-frontmatter-edit.test.ts
+++ b/tests/component-frontmatter-edit.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resolveComponentFrontmatter } from "../server/component-frontmatter-edit.mjs";
+import { buildComponentModel } from "../server/component-model.mjs";
+import { fileVersion } from "../server/file-version.mjs";
+
+const CARD = `---
+interface Props {
+  title: string;
+  count?: number;
+}
+const { title, count = 1 } = Astro.props;
+---
+<article class="card">
+  <h2>{title}</h2>
+</article>
+
+<script>
+  console.log("card mounted");
+</script>
+`;
+
+const BARE = `---\n---\n<p>hello</p>\n`;
+
+describe("resolveComponentFrontmatter", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-cfe-"));
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+    writeFileSync(join(tmpDir, "src", "components", "Card.astro"), CARD);
+    writeFileSync(join(tmpDir, "src", "components", "Bare.astro"), BARE);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function apply(file, resolution) {
+    const source = readFileSync(join(tmpDir, "src", "components", file), "utf-8");
+    return source.slice(0, resolution.range.start) + resolution.replacement + source.slice(resolution.range.end);
+  }
+
+  it("refuses with invalid-input when component payload is missing", async () => {
+    const result = await resolveComponentFrontmatter(tmpDir, { op: "set-props-interface" });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+
+  it("refuses with stale when baseVersion does not match", async () => {
+    const edit = {
+      op: "set-props-interface",
+      component: { path: "src/components/Card.astro", baseVersion: "sha256:000000000000", props: [] },
+    };
+    const result = await resolveComponentFrontmatter(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("stale");
+  });
+
+  it("refuses with read-failed when the file can't be read", async () => {
+    const edit = {
+      op: "set-props-interface",
+      component: { path: "src/components/Missing.astro", baseVersion: "sha256:000000000000", props: [] },
+    };
+    const result = await resolveComponentFrontmatter(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("read-failed");
+  });
+
+  describe("set-props-interface", () => {
+    it("replaces an existing Props interface and destructure in place", async () => {
+      const baseVersion = fileVersion(CARD);
+      const edit = {
+        op: "set-props-interface",
+        component: {
+          path: "src/components/Card.astro",
+          baseVersion,
+          props: [
+            { name: "title", type: "string", optional: false, default: null },
+            { name: "count", type: "number", optional: true, default: "2" },
+            { name: "label", type: "string", optional: true, default: '"hi"' },
+          ],
+        },
+      };
+      const result = await resolveComponentFrontmatter(tmpDir, edit);
+      expect(result.refused).toBeFalsy();
+      const next = apply("Card.astro", result);
+      expect(next).toContain("interface Props {\n  title: string;\n  count?: number;\n  label?: string;\n}");
+      expect(next).toContain('const { title, count = 2, label = "hi" } = Astro.props;');
+      // Template and client script untouched.
+      expect(next).toContain("<h2>{title}</h2>");
+      expect(next).toContain('console.log("card mounted")');
+
+      // Re-parsing the result reports the same props back (idempotence).
+      writeFileSync(join(tmpDir, "src", "components", "Card.astro"), next);
+      const model = await buildComponentModel(tmpDir, "src/components/Card.astro");
+      expect(model.frontmatter?.props).toEqual(edit.component.props);
+    });
+
+    it("adds a Props interface + destructure to a component with no props yet", async () => {
+      const baseVersion = fileVersion(BARE);
+      const edit = {
+        op: "set-props-interface",
+        component: {
+          path: "src/components/Bare.astro",
+          baseVersion,
+          props: [{ name: "title", type: "string", optional: false, default: null }],
+        },
+      };
+      const result = await resolveComponentFrontmatter(tmpDir, edit);
+      expect(result.refused).toBeFalsy();
+      const next = apply("Bare.astro", result);
+      expect(next).toContain("interface Props {\n  title: string;\n}");
+      expect(next).toContain("const { title } = Astro.props;");
+      expect(next).toContain("<p>hello</p>");
+    });
+
+    it("removes the Props interface and destructure when props is empty", async () => {
+      const baseVersion = fileVersion(CARD);
+      const edit = {
+        op: "set-props-interface",
+        component: { path: "src/components/Card.astro", baseVersion, props: [] },
+      };
+      const result = await resolveComponentFrontmatter(tmpDir, edit);
+      expect(result.refused).toBeFalsy();
+      const next = apply("Card.astro", result);
+      expect(next).not.toContain("interface Props");
+      expect(next).not.toContain("Astro.props");
+      expect(next).toContain("<h2>{title}</h2>");
+    });
+
+    it("refuses invalid-input for a malformed prop entry", async () => {
+      const baseVersion = fileVersion(CARD);
+      const edit = {
+        op: "set-props-interface",
+        component: { path: "src/components/Card.astro", baseVersion, props: [{ name: "title" }] },
+      };
+      const result = await resolveComponentFrontmatter(tmpDir, edit);
+      expect(result.refused).toBe(true);
+      expect(result.reason).toBe("invalid-input");
+    });
+  });
+
+  describe("set-script-zone", () => {
+    it("replaces the frontmatter zone wholesale", async () => {
+      const baseVersion = fileVersion(CARD);
+      const newFrontmatter = "const greeting = \"hi\";";
+      const edit = {
+        op: "set-script-zone",
+        component: { path: "src/components/Card.astro", baseVersion, zone: "frontmatter", source: newFrontmatter },
+      };
+      const result = await resolveComponentFrontmatter(tmpDir, edit);
+      expect(result.refused).toBeFalsy();
+      const next = apply("Card.astro", result);
+      expect(next).toContain(`---\n${newFrontmatter}\n---`);
+      expect(next).toContain("<h2>{title}</h2>");
+    });
+
+    it("synthesizes a frontmatter block when none exists", async () => {
+      const baseVersion = fileVersion(BARE);
+      const edit = {
+        op: "set-script-zone",
+        component: { path: "src/components/Bare.astro", baseVersion, zone: "frontmatter", source: "const x = 1;" },
+      };
+      // BARE already has an (empty) frontmatter block, so this exercises the
+      // existing-frontmatter path — covered separately below with a component
+      // that truly has none.
+      const result = await resolveComponentFrontmatter(tmpDir, edit);
+      expect(result.refused).toBeFalsy();
+      const next = apply("Bare.astro", result);
+      expect(next).toContain("---\nconst x = 1;\n---");
+    });
+
+    it("replaces the client script zone in place", async () => {
+      const baseVersion = fileVersion(CARD);
+      const edit = {
+        op: "set-script-zone",
+        component: { path: "src/components/Card.astro", baseVersion, zone: "client", source: 'console.log("remounted");' },
+      };
+      const result = await resolveComponentFrontmatter(tmpDir, edit);
+      expect(result.refused).toBeFalsy();
+      const next = apply("Card.astro", result);
+      expect(next).toContain('console.log("remounted");');
+      expect(next).not.toContain("card mounted");
+      expect(next).toContain("<h2>{title}</h2>");
+    });
+
+    it("appends a new <script> block when the component has no client script yet", async () => {
+      const baseVersion = fileVersion(BARE);
+      const edit = {
+        op: "set-script-zone",
+        component: { path: "src/components/Bare.astro", baseVersion, zone: "client", source: 'console.log("hi");' },
+      };
+      const result = await resolveComponentFrontmatter(tmpDir, edit);
+      expect(result.refused).toBeFalsy();
+      const next = apply("Bare.astro", result);
+      expect(next).toContain("<script>");
+      expect(next).toContain('console.log("hi");');
+
+      writeFileSync(join(tmpDir, "src", "components", "Bare.astro"), next);
+      const model = await buildComponentModel(tmpDir, "src/components/Bare.astro");
+      expect(model.clientScript?.source).toContain('console.log("hi");');
+    });
+
+    it("refuses invalid-input for an unknown zone", async () => {
+      const baseVersion = fileVersion(CARD);
+      const edit = {
+        op: "set-script-zone",
+        component: { path: "src/components/Card.astro", baseVersion, zone: "bogus", source: "x" },
+      };
+      const result = await resolveComponentFrontmatter(tmpDir, edit);
+      expect(result.refused).toBe(true);
+      expect(result.reason).toBe("invalid-input");
+    });
+  });
+});

--- a/tests/component-frontmatter-edit.test.ts
+++ b/tests/component-frontmatter-edit.test.ts
@@ -146,7 +146,11 @@ describe("resolveComponentFrontmatter", () => {
   describe("set-script-zone", () => {
     it("replaces the frontmatter zone wholesale", async () => {
       const baseVersion = fileVersion(CARD);
-      const newFrontmatter = "const greeting = \"hi\";";
+      // Mirrors what a real code-pane save looks like: the pane is seeded from
+      // get_component_model's frontmatter.source, which already carries its own leading/
+      // trailing newline (the text strictly between the `---` fences) — so a realistic edit
+      // includes that framing itself rather than relying on the resolver to add it.
+      const newFrontmatter = "\nconst greeting = \"hi\";\n";
       const edit = {
         op: "set-script-zone",
         component: { path: "src/components/Card.astro", baseVersion, zone: "frontmatter", source: newFrontmatter },
@@ -154,11 +158,28 @@ describe("resolveComponentFrontmatter", () => {
       const result = await resolveComponentFrontmatter(tmpDir, edit);
       expect(result.refused).toBeFalsy();
       const next = apply("Card.astro", result);
-      expect(next).toContain(`---\n${newFrontmatter}\n---`);
+      expect(next).toContain(`---${newFrontmatter}---`);
       expect(next).toContain("<h2>{title}</h2>");
     });
 
-    it("synthesizes a frontmatter block when none exists", async () => {
+    it("is a byte-exact round trip against get_component_model's frontmatter.source (regression: a verbatim no-op save must not drift the file)", async () => {
+      const before = await buildComponentModel(tmpDir, "src/components/Card.astro");
+      const edit = {
+        op: "set-script-zone",
+        component: {
+          path: "src/components/Card.astro",
+          baseVersion: before.version,
+          zone: "frontmatter",
+          source: before.frontmatter.source,
+        },
+      };
+      const result = await resolveComponentFrontmatter(tmpDir, edit);
+      expect(result.refused).toBeFalsy();
+      const next = apply("Card.astro", result);
+      expect(next).toBe(CARD);
+    });
+
+    it("replaces an empty frontmatter zone verbatim, without adding padding", async () => {
       const baseVersion = fileVersion(BARE);
       const edit = {
         op: "set-script-zone",
@@ -170,7 +191,22 @@ describe("resolveComponentFrontmatter", () => {
       const result = await resolveComponentFrontmatter(tmpDir, edit);
       expect(result.refused).toBeFalsy();
       const next = apply("Bare.astro", result);
+      expect(next).toContain("---const x = 1;---");
+    });
+
+    it("synthesizes a frontmatter block when the component has none at all", async () => {
+      const noFrontmatter = "<p>plain</p>\n";
+      writeFileSync(join(tmpDir, "src", "components", "NoFrontmatter.astro"), noFrontmatter);
+      const baseVersion = fileVersion(noFrontmatter);
+      const edit = {
+        op: "set-script-zone",
+        component: { path: "src/components/NoFrontmatter.astro", baseVersion, zone: "frontmatter", source: "const x = 1;" },
+      };
+      const result = await resolveComponentFrontmatter(tmpDir, edit);
+      expect(result.refused).toBeFalsy();
+      const next = apply("NoFrontmatter.astro", result);
       expect(next).toContain("---\nconst x = 1;\n---");
+      expect(next).toContain("<p>plain</p>");
     });
 
     it("replaces the client script zone in place", async () => {

--- a/tests/props-interface.test.ts
+++ b/tests/props-interface.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { parseProps, generatePropsInterface, generatePropsDestructure } from "../server/props-interface.mjs";
+
+describe("generatePropsInterface / generatePropsDestructure", () => {
+  it("returns null for an empty props array", () => {
+    expect(generatePropsInterface([])).toBeNull();
+    expect(generatePropsDestructure([])).toBeNull();
+  });
+
+  it("codegens a multi-prop interface and destructure", () => {
+    const props = [
+      { name: "title", type: "string", optional: false, default: null },
+      { name: "count", type: "number", optional: true, default: "1" },
+    ];
+    expect(generatePropsInterface(props)).toBe("interface Props {\n  title: string;\n  count?: number;\n}");
+    expect(generatePropsDestructure(props)).toBe('const { title, count = 1 } = Astro.props;');
+  });
+
+  it("round-trips through parseProps", () => {
+    const props = [
+      { name: "title", type: "string", optional: false, default: null },
+      { name: "count", type: "number", optional: true, default: "1" },
+      { name: "label", type: "string", optional: true, default: '"hello, world"' },
+    ];
+    const source = `${generatePropsInterface(props)}\n${generatePropsDestructure(props)}`;
+    expect(parseProps(source)).toEqual(props);
+  });
+
+  it("omits a prop's default segment from the destructure when default is null", () => {
+    const props = [{ name: "title", type: "string", optional: false, default: null }];
+    expect(generatePropsDestructure(props)).toBe("const { title } = Astro.props;");
+  });
+});


### PR DESCRIPTION
## Summary

- `apply_edit` gains two component-frontmatter ops for Component Editor slice 4 (Anglesite-app#494): `set-props-interface` (codegen/replace the frontmatter's `interface Props {...}` block + `Astro.props` destructure from a structured `{name, type, optional, default}[]` array) and `set-script-zone` (replace a whole script zone — `frontmatter` or `client` — wholesale, for a code-pane save; synthesizes the zone if it doesn't exist yet).
- Both ops share the existing component ops' `baseVersion` content-hash staleness check (resolver-level + the dispatcher's post-parse re-check) and piggyback a freshly rebuilt `get_component_model` result on a successful reply, matching the style/structure op conventions.
- `props-interface.mjs` gains the write-side counterpart to `parseProps`: `generatePropsInterface`/`generatePropsDestructure`, which round-trip through `parseProps`.
- Version bump to 1.6.0 + CHANGELOG entry.

## Paired PR check

- [x] This change **needs a paired PR** in [`Anglesite/Anglesite-app`](https://github.com/Anglesite/Anglesite-app) (MCP message schema — new ops in `applyEditInputShape`/`componentEditSchema`). Link: Anglesite/Anglesite-app#494 (app-side PR to follow in this same session).

## Test plan

- [x] `npx vitest run` — full suite passes except 2 pre-existing failures in `test/apply-edit-dispatcher.test.js` (write-failed-when-directory-unwritable), unrelated to this change — this sandbox runs as root, which bypasses the `chmod 0o555` the test relies on to simulate a locked filesystem.
- [x] New tests: `tests/props-interface.test.ts` (codegen + round-trip through `parseProps`), `tests/component-frontmatter-edit.test.ts` (resolver-level round-trips incl. stale/read-failed/invalid-input/create-if-absent/remove-if-empty), `tests/apply-edit-schema-frontmatter.test.ts` (zod schema), `tests/apply-edit-dispatcher-component-frontmatter.test.ts` (dispatcher-level incl. a concurrency race test mirroring the existing component-style one).


---
_Generated by [Claude Code](https://claude.ai/code/session_015B14HqxNFD7ZoB2rJb6cmt)_