### PR TITLE
fix: regenerate stale agent-skills export for 1.6.0 version bump

### DIFF
--- a/agent-skills/update/references/template/package.json
+++ b/agent-skills/update/references/template/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dwk/anglesite",
   "type": "module",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary

- The v1.6.0 release commit (`d4b8a72`) bumped `template/package.json`'s version to 1.6.0 but the generated `agent-skills/` export wasn't rebuilt afterward, so the `agent-skills-export` CI job on `main` fails its "Verify Open Agent Skills export is up to date" check.
- Regenerated via `npm run build:agent-skills`; the only drift was `agent-skills/update/references/template/package.json`'s bundled version string (1.5.0 → 1.6.0).

## Paired PR check

- [x] This change is **self-contained** to the plugin (skills / hooks / template / docs / MCP server with no consumer-visible contract change).
- [ ] This change **needs a paired PR** in [`Anglesite/Anglesite-app`](https://github.com/Anglesite/Anglesite-app)

## Test plan

- [x] `npm run build:agent-skills` now produces a clean diff (no further changes on re-run)
- [x] `npm test` — all suites pass except a pre-existing, environment-specific failure in `test/apply-edit-dispatcher.test.js` (root bypasses directory-permission bits in this sandbox, so the "write-failed" simulation can't trigger; unrelated to this change and not exercised as root in CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_015G9zKWUXRN5waZ4rtHPQae)_