### PR TITLE
feat(mcp): add extract-component op (Component Editor slice 5 prep)

### DIFF
--- a/server/apply-edit-dispatcher.mjs
+++ b/server/apply-edit-dispatcher.mjs
@@ -5,8 +5,13 @@
  *   1. For `replace-image-src` with a raw `{filename, mimeType, dataURL}` value: pre-process
  *      via `processImageDrop` — write the bytes under `public/images/`, run optimize, build the
  *      `{src, srcset}` value the patcher's resolver expects. Throws map to `image-optimize-failed`.
- *   2. `resolve(projectRoot, edit)` (patcher.mjs) returns either `{file, range, replacement}`
- *      or `{refused: true, reason, detail?}`.
+ *   2. `resolve(projectRoot, edit)` (patcher.mjs) returns one of:
+ *        - `{file, range, replacement}` — the single-file case every op except extract-component
+ *          resolves to.
+ *        - `{extract: true, newFile: {path, content}, original: {file, range, replacement}}` —
+ *          extract-component's two-file case (component-extract-edit.mjs), handled by
+ *          `applyExtractComponent` below instead of the generic single-splice path.
+ *        - `{refused: true, reason, detail?}`.
  *   3. On refusal: forward as an `edit-failed` MCP response.
  *   4. On success: read the source, splice in the replacement, atomically write back (write to
  *      a sibling temp file then `rename`), invoke an optional `onApplied` hook so #298's
@@ -45,8 +50,8 @@ function failed(id, reason, detail) {
   return { content: [createEditFailedContent(id, reason, detail)], isError: true };
 }
 
-function applied(id, file, range, commit, result, model) {
-  return { content: [createEditAppliedContent(id, file, range, commit, result, model)] };
+function applied(id, file, range, commit, result, model, newFile) {
+  return { content: [createEditAppliedContent(id, file, range, commit, result, model, newFile)] };
 }
 
 /** Splice `replacement` into `source` at the resolved byte range. */
@@ -179,12 +184,99 @@ async function processImageDrop(projectRoot, edit) {
 }
 
 /**
+ * Handle extract-component's two-file write. `resolution` is component-extract-edit.mjs's
+ * `{extract: true, newFile: {path, content}, original: {file, range, replacement}}`.
+ *
+ * Design decision — write order and partial-failure handling: the brand-new component file is
+ * written FIRST, then the source file is patched second. This ordering makes the failure-of-the-
+ * second-write case cheap and safe to roll back: the new file never existed before this op, so
+ * "undo the first write" is just deleting it. The reverse order (patch source first, write new
+ * file second) would risk leaving the source file referencing a component
+ * (`<NewName ... />` + its import) that doesn't exist on disk if the second write then failed —
+ * a broken build, and a harder state to describe as "rolled back." There's still no cross-file
+ * transaction (this repo's `atomicWrite` only gives single-file atomicity via temp-sibling +
+ * rename — same accepted limitation `create-content.mjs`'s writes have), but new-file-first
+ * plus a best-effort unlink on second-write failure closes the realistic failure window: the
+ * only way to land in a truly inconsistent state is the unlink itself failing (e.g. permissions
+ * changed between the two writes), which is reported via `write-failed` either way.
+ *
+ * Once both writes succeed, both files are committed onto ONE `anglesite/edits` commit via
+ * `opts.onApplied({files: [...]})` (see edit-history.mjs's multi-file `recordEdit` mode) — so
+ * "one semantic op → one commit" holds here too, and a single `undo_edit` call reverts the whole
+ * extraction (both the new file's removal and the source file's restoration) atomically.
+ */
+async function applyExtractComponent(projectRoot, edit, resolution, opts) {
+  const { newFile, original } = resolution;
+  const absNewFile = join(projectRoot, newFile.path);
+  const absOriginal = join(projectRoot, original.file);
+
+  // Re-validate staleness against a FRESH read, immediately before writing — same TOCTOU
+  // discipline the generic single-file path applies below for every other COMPONENT_OPS member
+  // (component-extract-edit.mjs's own `await parse(...)` opens the same async yield point a
+  // concurrent edit could land in).
+  let freshSource;
+  try {
+    freshSource = readFileSync(absOriginal, "utf-8");
+  } catch (err) {
+    return failed(edit.id, "write-failed", `read ${original.file}: ${err.message}`);
+  }
+  if (fileVersion(freshSource) !== edit.component.baseVersion) {
+    return failed(edit.id, "stale", `${original.file} changed since the model was fetched`);
+  }
+  // The resolver already checked this once; re-check immediately before writing to narrow the
+  // race window against a concurrent extract targeting the same new name.
+  if (existsSync(absNewFile)) {
+    return failed(edit.id, "already-exists", `${newFile.path} already exists`);
+  }
+
+  try {
+    mkdirSync(dirname(absNewFile), { recursive: true });
+    atomicWrite(absNewFile, newFile.content);
+  } catch (err) {
+    return failed(edit.id, "write-failed", `${newFile.path}: ${err.message}`);
+  }
+
+  const next = spliceSource(freshSource, original.range, original.replacement);
+  try {
+    atomicWrite(absOriginal, next);
+  } catch (err) {
+    // Roll back the new file — see the design note above: new-file-first ordering makes this a
+    // plain unlink of something that never existed before this op, not a content restore.
+    try { unlinkSync(absNewFile); } catch {} // best-effort
+    return failed(edit.id, "write-failed", `${original.file}: ${err.message}`);
+  }
+
+  let commit;
+  if (opts.onApplied) {
+    try {
+      commit = await opts.onApplied({
+        files: [newFile.path, original.file],
+        projectRoot,
+        message: `anglesite: extract ${newFile.path} from ${original.file}`,
+      });
+    } catch {
+      commit = undefined; // patch landed; history-keeping failure shouldn't fail an already-applied edit
+    }
+  }
+
+  let model;
+  try {
+    model = await buildComponentModel(projectRoot, edit.component.path);
+  } catch {
+    model = undefined;
+  }
+
+  return applied(edit.id, original.file, original.range, commit, undefined, model, newFile.path);
+}
+
+/**
  * Apply an edit. Returns an MCP tool response (`{content, isError?}`) whose first content entry
  * is the JSON-encoded `edit-applied` / `edit-failed` body.
  *
  * @param {string} projectRoot
  * @param {object} edit  payload from the `apply_edit` tool (already zod-validated)
- * @param {{ onApplied?: (info: {file:string, range:{start:number,end:number}, projectRoot:string}) => Promise<string|undefined> | string | undefined }} [opts]
+ * @param {{ onApplied?: (info: {file:string, range:{start:number,end:number}, projectRoot:string}
+ *   | {files:string[], projectRoot:string, message?:string}) => Promise<string|undefined> | string | undefined }} [opts]
  */
 export async function applyEdit(projectRoot, edit, opts = {}) {
   // The app's Foundation Models chat path (ApplyEditTool, #251) forwards NL instructions
@@ -206,6 +298,11 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
   if (edit.dry_run && edit.op === "replace-image-src") {
     return failed(edit.id, "not-implemented", "dry-run preview is not supported for image edits");
   }
+  // Same reasoning for extract-component: its two-file write doesn't fit the single-window
+  // {before, after} preview shape every other op's dry_run uses, so refuse rather than fake one.
+  if (edit.dry_run && edit.op === "extract-component") {
+    return failed(edit.id, "not-implemented", "dry-run preview is not supported for extract-component");
+  }
 
   let effectiveEdit = edit;
   let imageResult;
@@ -225,6 +322,10 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
   const resolution = await resolveEdit(projectRoot, effectiveEdit);
   if (resolution.refused) {
     return failed(edit.id, resolution.reason, resolution.detail);
+  }
+
+  if (resolution.extract) {
+    return applyExtractComponent(projectRoot, edit, resolution, opts);
   }
 
   const { file, range, replacement } = resolution;

--- a/server/apply-edit-schema.mjs
+++ b/server/apply-edit-schema.mjs
@@ -58,6 +58,7 @@ export const editOps = [
   "set-attr",
   "set-props-interface",
   "set-script-zone",
+  "extract-component",
 ];
 
 /** The subset of `editOps` that operate on a component's scoped `<style>` via `component`
@@ -78,8 +79,22 @@ export const COMPONENT_STRUCTURE_OPS = new Set(["insert-node", "move-node", "rem
  *  zone via `component` — the Props form and STTextView code-pane saves. */
 export const COMPONENT_FRONTMATTER_OPS = new Set(["set-props-interface", "set-script-zone"]);
 
-/** Union of style, structure, and frontmatter component ops — used by the dispatcher's shared checks. */
-export const COMPONENT_OPS = new Set([...COMPONENT_STYLE_OPS, ...COMPONENT_STRUCTURE_OPS, ...COMPONENT_FRONTMATTER_OPS]);
+/** The subset of `editOps` that extracts an outline subtree into a brand-new component file —
+ *  currently just `extract-component` (Component Editor slice 5). Its own Set (rather than
+ *  folding it into COMPONENT_STRUCTURE_OPS) because it's dispatched differently: every other
+ *  component op resolves to a single-file `{file, range, replacement}` splice, while this one
+ *  resolves to a two-file write (see `component-extract-edit.mjs` and the dispatcher's
+ *  `resolution.extract` branch). */
+export const COMPONENT_EXTRACT_OPS = new Set(["extract-component"]);
+
+/** Union of style, structure, frontmatter, and extract component ops — used by the dispatcher's
+ *  shared checks (payload presence, baseVersion re-check, model refetch). */
+export const COMPONENT_OPS = new Set([
+  ...COMPONENT_STYLE_OPS,
+  ...COMPONENT_STRUCTURE_OPS,
+  ...COMPONENT_FRONTMATTER_OPS,
+  ...COMPONENT_EXTRACT_OPS,
+]);
 
 /** Structured payload for the four component-style ops. Identifies the target rule by its exact
  *  byte span (from `get_component_model`'s `styles[].span`) plus a `baseVersion` content-hash
@@ -129,6 +144,12 @@ export const componentEditSchema = z.object({
     ),
   zone: z.enum(["frontmatter", "client"]).optional().describe("Script zone for set-script-zone: the frontmatter TS or the client <script>"),
   source: z.string().optional().describe("Replacement source text for set-script-zone's target zone"),
+  newName: z
+    .string()
+    .optional()
+    .describe(
+      "New component's PascalCase base name for extract-component (no extension, no path) — the extracted subtree lands at src/components/<newName>.astro and the source file gets an instance of it (<newName ... />) plus a matching import.",
+    ),
 });
 
 /** The MCP tool's input shape, as passed to `server.tool(name, description, shape, handler)`. */
@@ -158,7 +179,7 @@ export const applyEditInputShape = {
   op: z
     .enum(editOps)
     .describe(
-      "Edit operation: replace-text (innerText), replace-attr (value is {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>), apply-instruction (reserved: sent only by the Anglesite-app Foundation Models chat path; always returns edit-failed/needs-agent — do not use from external callers), set-style-property/remove-style-property/add-style-rule/set-rule-selector (component-style ops), insert-node/move-node/remove-node/set-attr (component-structure ops), set-props-interface/set-script-zone (component-frontmatter ops — see componentEditSchema)",
+      "Edit operation: replace-text (innerText), replace-attr (value is {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>), apply-instruction (reserved: sent only by the Anglesite-app Foundation Models chat path; always returns edit-failed/needs-agent — do not use from external callers), set-style-property/remove-style-property/add-style-rule/set-rule-selector (component-style ops), insert-node/move-node/remove-node/set-attr (component-structure ops), set-props-interface/set-script-zone (component-frontmatter ops), extract-component (nodeId + newName — writes a new src/components/<newName>.astro from the selected subtree, hoists obvious literal props, and replaces the selection in the source file with an instance + import — see componentEditSchema)",
     ),
   value: z
     .unknown()
@@ -188,12 +209,16 @@ export function createEditFailedContent(id, reason, detail) {
  *  overlay can apply directly: e.g. `replace-image-src` returns `{ src, srcset? }` so the
  *  overlay swaps both attributes on success without re-deriving them from the patch text.
  *  `model` is a fresh `buildComponentModel` result piggybacked on component-style-op success so
- *  the app never needs a second round-trip to `get_component_model` after a write. */
-export function createEditAppliedContent(id, file, range, commit, result, model) {
+ *  the app never needs a second round-trip to `get_component_model` after a write. `newFile` is
+ *  additive (extract-component only): the project-relative path of the brand-new component file
+ *  the op created, alongside `file`/`range` which still describe the SOURCE file's own edit —
+ *  every other op's reply shape is unchanged by this field's addition. */
+export function createEditAppliedContent(id, file, range, commit, result, model, newFile) {
   const body = { type: "anglesite:edit-applied", id, file, range };
   if (commit !== undefined) body.commit = commit;
   if (result !== undefined) body.result = result;
   if (model !== undefined) body.model = model;
+  if (newFile !== undefined) body.newFile = newFile;
   return { type: "text", text: JSON.stringify(body) };
 }
 

--- a/server/component-extract-edit.mjs
+++ b/server/component-extract-edit.mjs
@@ -47,6 +47,19 @@ import {
  *    generic `text1`, `text2`, … sequence in document order. Every hoisted prop is `type:
  *    "string"` — no number/boolean inference (no prior art for it in this codebase, and the
  *    payoff isn't worth the complexity for a first cut). Name collisions get a numeric suffix.
+ *
+ * 3. Dynamic content is refused outright, not silently copied. `collectCandidates` already never
+ *    offers an expression/dynamic-attribute as a HOISTABLE prop — but that alone isn't enough:
+ *    without a separate check, anything that isn't specifically hoisted (including any
+ *    `{expression}` — text interpolation, a dynamic attribute binding, a spread, a template
+ *    literal) would still get copied byte-for-byte into the new file by `hoistProps`'s markup
+ *    splice. Its referenced identifiers (frontmatter variables, props destructured from
+ *    `Astro.props`, loop variables from an enclosing `.map()`, …) are NOT in scope in the new
+ *    file, which only gets the hoisted-prop destructure — so the new file would fail to build.
+ *    `findDynamicContent` walks the subtree up front and refuses with the same `dynamic-expression`
+ *    reason `patcher.mjs`'s `resolveAstro` already uses for "can't safely act on dynamic content,"
+ *    matching every sibling structural op's fail-closed convention rather than attempting to
+ *    hoist expressions as pass-through props in this same change.
  */
 
 function refuse(reason, detail) {
@@ -75,6 +88,34 @@ const RESERVED_WORDS = new Set([
   "with", "yield", "let", "static", "enum", "await", "implements", "interface", "package",
   "private", "protected", "public", "null", "true", "false",
 ]);
+
+// Every @astrojs/compiler attribute kind OTHER than "quoted" (a plain string literal) and
+// "empty" (a valueless boolean attribute like `disabled` — no referenced identifier at all) is
+// dynamic: it either directly names a variable ("expression": `src={imageUrl}`, "shorthand":
+// `{value}`), splices one in ("template-literal": `` `hi${x}` ``), or spreads a whole object
+// ("spread": `{...rest}`). Any of these inside the extracted subtree references an identifier
+// that won't exist in the new file — see `findDynamicContent`.
+const DYNAMIC_ATTR_KINDS = new Set(["expression", "shorthand", "spread", "template-literal"]);
+
+/**
+ * True if the subtree rooted at `nodeId` contains ANY dynamic content: an "expression"-kind
+ * node (text interpolation, `{items.map(...)}`, etc.) anywhere in the tree, or a dynamic-kind
+ * attribute (see `DYNAMIC_ATTR_KINDS`) on any element/component descendant. Used to refuse the
+ * whole op up front — see design decision 3 in the file header for why silently copying such
+ * content into the new file (rather than refusing) would produce a file that fails to build.
+ */
+function findDynamicContent(byId, nodeId) {
+  function visit(id) {
+    const n = byId.get(id);
+    if (!n) return false;
+    if (n.kind === "expression") return true;
+    if (n.kind === "element" || n.kind === "component") {
+      if (n.attrs.some((attr) => DYNAMIC_ATTR_KINDS.has(attr.kind))) return true;
+    }
+    return n.childIds.some((childId) => visit(childId));
+  }
+  return visit(nodeId);
+}
 
 async function loadFresh(projectRoot, relPath, baseVersion) {
   const absPath = join(projectRoot, relPath);
@@ -270,6 +311,12 @@ export async function resolveComponentExtract(projectRoot, edit) {
   if (node.parentId === null) return refuse("invalid-input", "cannot extract the component's own root");
   if (node.kind !== "element" && node.kind !== "component") {
     return refuse("invalid-input", `extract-component requires an element or component node, got kind=${node.kind}`);
+  }
+  if (findDynamicContent(byId, nodeId)) {
+    return refuse(
+      "dynamic-expression",
+      "extract-component cannot safely extract a subtree containing dynamic content ({expression} interpolation, a dynamic attribute binding, a spread, or a template literal) — the identifiers it references would not be in scope in the new file",
+    );
   }
 
   const newRelPath = `src/components/${newName}.astro`;

--- a/server/component-extract-edit.mjs
+++ b/server/component-extract-edit.mjs
@@ -1,0 +1,355 @@
+import { readFileSync, existsSync } from "node:fs";
+import { join, normalize, dirname } from "node:path";
+import { parse } from "@astrojs/compiler";
+import { fileVersion } from "./file-version.mjs";
+import { buildTemplateNodeIndex } from "./component-node-index.mjs";
+import { ensureImport, parseImports } from "./frontmatter-imports.mjs";
+import { generatePropsInterface, generatePropsDestructure } from "./props-interface.mjs";
+import {
+  resolveAllSpans,
+  SpanResolutionError,
+  escapeAttr,
+  importSpecifier,
+  collectComponentTags,
+} from "./component-structure-edit.mjs";
+
+/**
+ * Write-side resolver for `extract-component` (Component Editor slice 5, Anglesite-app#495):
+ * lifts a selected outline subtree out of an existing `.astro` component into a brand-new
+ * `src/components/<newName>.astro` file, hoists "obvious" literal props, and replaces the
+ * selection in the SOURCE file with an instance of the new component plus a matching import.
+ *
+ * Unlike every other component op (component-style-edit.mjs, component-structure-edit.mjs,
+ * component-frontmatter-edit.mjs), this one touches TWO files. It returns a distinct shape —
+ * `{ extract: true, newFile, original }` — instead of the single-file `{file, range,
+ * replacement}` every other resolver returns; apply-edit-dispatcher.mjs branches on
+ * `resolution.extract` to run the two-file write instead of the generic single-splice path. See
+ * that file's `applyExtractComponent` for the write-order/rollback contract.
+ *
+ * Two design decisions worth calling out (also covered in the PR description):
+ *
+ * 1. Span discipline for the SUBTREE ROOT: like remove-node/insert-node/move-node, this NEVER
+ *    trusts the extracted node's own `node.span` directly — it re-derives the true boundary via
+ *    `resolveAllSpans`'s lexical walk (see component-structure-edit.mjs's file-level comment for
+ *    why). Individual literal candidates WITHIN that already-verified boundary (attribute values,
+ *    text-node content) DO use their own `attr.span`/`node.span` directly, matching the already-
+ *    shipped `set-attr` resolver's precedent — the failure mode for a slightly-off literal span is
+ *    "this one candidate doesn't get offered as a prop" (each is sanity-checked against its
+ *    expected text before being trusted; see `collectCandidates`), never file corruption, so the
+ *    stakes don't justify a second resolveAllSpans-grade walk for every attribute and text node.
+ *
+ * 2. Prop-hoisting heuristic: a literal is "obvious" enough to hoist only when its exact string
+ *    value occurs exactly ONCE among all quoted-attribute-values and text-node contents in the
+ *    subtree (kind: "quoted" per @astrojs/compiler's own attribute-kind enum — expression/
+ *    shorthand/spread/template-literal attrs are never literals and are skipped outright; text
+ *    nodes modeled by buildTemplateNodeIndex are, by construction, always static). Attribute
+ *    props are named after the (camelCased, reserved-word-safe) attribute name; text props get a
+ *    generic `text1`, `text2`, … sequence in document order. Every hoisted prop is `type:
+ *    "string"` — no number/boolean inference (no prior art for it in this codebase, and the
+ *    payoff isn't worth the complexity for a first cut). Name collisions get a numeric suffix.
+ */
+
+function refuse(reason, detail) {
+  return { refused: true, reason, detail };
+}
+
+function validPath(relPath) {
+  return typeof relPath === "string" && relPath.endsWith(".astro") && !normalize(relPath).startsWith("..") && !relPath.startsWith("/");
+}
+
+// PascalCase only: this becomes both a JSX tag (Astro/JSX treats a lowercase tag as a native
+// HTML element, never a component) and a frontmatter `import <Name> from "...";` local binding,
+// so it has to be a valid bare identifier too.
+const COMPONENT_NAME_RE = /^[A-Z][A-Za-z0-9]*$/;
+
+const VALID_IDENTIFIER_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+// Reserved words that would make `const { <name> } = Astro.props;` (generatePropsDestructure's
+// shorthand form) a syntax error if used as a destructured binding name. "class" and "for" are
+// the realistic collisions (both extremely common HTML attribute names); the rest are included
+// for completeness rather than because they're likely attribute names.
+const RESERVED_WORDS = new Set([
+  "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete", "do",
+  "else", "export", "extends", "finally", "for", "function", "if", "import", "in", "instanceof",
+  "new", "return", "super", "switch", "this", "throw", "try", "typeof", "var", "void", "while",
+  "with", "yield", "let", "static", "enum", "await", "implements", "interface", "package",
+  "private", "protected", "public", "null", "true", "false",
+]);
+
+async function loadFresh(projectRoot, relPath, baseVersion) {
+  const absPath = join(projectRoot, relPath);
+  let source;
+  try {
+    source = readFileSync(absPath, "utf-8");
+  } catch (err) {
+    return { error: refuse("read-failed", `read ${relPath}: ${err.message}`) };
+  }
+  if (fileVersion(source) !== baseVersion) {
+    return { error: refuse("stale", `${relPath} changed since the model was fetched`) };
+  }
+  let ast;
+  try {
+    ({ ast } = await parse(source, { position: true }));
+  } catch (err) {
+    return { error: refuse("parse-failed", `parse ${relPath}: ${err.message}`) };
+  }
+  const { byId, rootId } = buildTemplateNodeIndex(ast, source);
+  return { source, ast, byId, rootId };
+}
+
+function camelizeAttrName(name) {
+  const camel = name.replace(/-([a-z0-9])/g, (_, c) => c.toUpperCase());
+  return RESERVED_WORDS.has(camel) ? `${camel}Value` : camel;
+}
+
+/**
+ * Depth-first walk of the subtree rooted at `nodeId`, collecting literal-value candidates:
+ * quoted attribute values (on element/component nodes — NOT slot, whose attrs like `name` are
+ * structural) and text-node content. Each candidate's span comes directly from the model's own
+ * `attr.span`/`node.span` (line/column-derived — see the file header for why that's trusted
+ * here but not for the subtree root's own boundary) and is sanity-checked against the value it's
+ * supposed to contain before being trusted; a mismatch just drops that one candidate rather than
+ * risking a bad splice. Never descends into an "expression" node's children — content generated
+ * inside a JS expression (e.g. `{items.map(i => <li>{i}</li>)}`) is per-iteration/dynamic, never
+ * a simple hoistable literal.
+ */
+function collectCandidates(byId, nodeId, source, nodeSpan) {
+  const candidates = [];
+
+  function visit(id) {
+    const n = byId.get(id);
+    if (!n) return;
+    if (n.kind === "expression") return;
+
+    if (n.kind === "text") {
+      const text = n.text; // trimmed by buildTemplateNodeIndex; may be silently truncated at 80 chars
+      if (text && text.length < 80 && n.span[0] != null && n.span[1] != null) {
+        const raw = source.slice(n.span[0], n.span[1]);
+        const trimmed = raw.trim();
+        if (trimmed === text) {
+          const start = n.span[0] + (raw.length - raw.trimStart().length);
+          const end = start + trimmed.length;
+          if (start >= nodeSpan[0] && end <= nodeSpan[1]) {
+            candidates.push({ value: text, kind: "text", span: [start, end] });
+          }
+        }
+      }
+    } else if (n.kind === "element" || n.kind === "component") {
+      for (const attr of n.attrs) {
+        if (attr.kind !== "quoted" || attr.value == null) continue;
+        if (attr.span[0] == null || attr.span[1] == null) continue;
+        if (attr.span[0] < nodeSpan[0] || attr.span[1] > nodeSpan[1]) continue;
+        if (!source.slice(attr.span[0], attr.span[1]).startsWith(`${attr.name}=`)) continue;
+        candidates.push({ value: attr.value, kind: "attr", attrName: attr.name, span: attr.span });
+      }
+    }
+
+    for (const childId of n.childIds) visit(childId);
+  }
+
+  visit(nodeId);
+  return candidates;
+}
+
+/**
+ * From the candidate pool, keeps only values referenced exactly once, assigns each a prop name
+ * (deduped against collisions), and produces: the new component's markup (literals replaced by
+ * `{propName}` references), its `props` array (for props-interface.mjs codegen), and the
+ * `instanceAttrs` the SOURCE file's replacement instance tag should carry (the original literal
+ * values, passed straight through so the extraction is behavior-preserving by default).
+ */
+function hoistProps(byId, nodeId, source, nodeSpan) {
+  const candidates = collectCandidates(byId, nodeId, source, nodeSpan);
+
+  const countByValue = new Map();
+  for (const c of candidates) countByValue.set(c.value, (countByValue.get(c.value) ?? 0) + 1);
+  const hoistable = candidates.filter((c) => countByValue.get(c.value) === 1).sort((a, b) => a.span[0] - b.span[0]);
+
+  const usedNames = new Set();
+  function reserveName(base) {
+    let name = base;
+    let n = 2;
+    while (usedNames.has(name)) {
+      name = `${base}${n}`;
+      n++;
+    }
+    usedNames.add(name);
+    return name;
+  }
+
+  let textCounter = 0;
+  const props = [];
+  const instanceAttrs = [];
+  const replacements = [];
+
+  for (const c of hoistable) {
+    let propName;
+    let replacementText;
+    if (c.kind === "attr") {
+      const candidateName = camelizeAttrName(c.attrName);
+      if (!VALID_IDENTIFIER_RE.test(candidateName)) continue; // can't name a prop after this attr — leave it as a literal
+      propName = reserveName(candidateName);
+      replacementText = `${c.attrName}={${propName}}`;
+    } else {
+      textCounter++;
+      propName = reserveName(`text${textCounter}`);
+      replacementText = `{${propName}}`;
+    }
+    props.push({ name: propName, type: "string", optional: false, default: null });
+    instanceAttrs.push({ name: propName, value: c.value });
+    replacements.push({ span: c.span, text: replacementText });
+  }
+
+  let cursor = nodeSpan[0];
+  let markup = "";
+  for (const r of replacements) {
+    markup += source.slice(cursor, r.span[0]);
+    markup += r.text;
+    cursor = r.span[1];
+  }
+  markup += source.slice(cursor, nodeSpan[1]);
+
+  return { markup, props, instanceAttrs };
+}
+
+/**
+ * For every component-kind tag used inside the extracted subtree (via `collectComponentTags`,
+ * the same walk `remove-node` uses for import pruning), find its default import in the SOURCE
+ * file's frontmatter and carry it into the new file — re-expressed as a specifier relative to
+ * the NEW file's own location when the original specifier was itself relative (the two files
+ * don't generally live in the same directory-depth relationship the original specifier
+ * assumed); a bare package specifier (`"some-astro-lib/Icon.astro"`) or a tsconfig path alias
+ * (`"@components/Button.astro"`) is passed through UNCHANGED instead — rewriting those through
+ * `dirname(relPath)` would silently reinterpret them as project-relative paths and point
+ * nowhere. Returns the joined `import X from "...";` lines (or "" if nothing to carry).
+ */
+function carriedImportLines(byId, nodeId, source, relPath, newRelPath) {
+  const usedTags = [...new Set(collectComponentTags(byId, nodeId))];
+  if (usedTags.length === 0) return "";
+
+  const fmMatch = source.match(/^(---\r?\n)([\s\S]*?)(\r?\n---)/);
+  if (!fmMatch) return "";
+  const sourceImports = parseImports(fmMatch[2]);
+
+  const lines = [];
+  for (const tag of usedTags) {
+    const imp = sourceImports.find((i) => i.localName === tag);
+    if (!imp) continue; // plain custom element, or the source file's own import is missing/broken
+    if (!imp.specifier.startsWith(".")) {
+      lines.push(`import ${tag} from "${imp.specifier}";`);
+      continue;
+    }
+    const importedProjectRelPath = normalize(join(dirname(relPath), imp.specifier));
+    lines.push(`import ${tag} from "${importSpecifier(newRelPath, importedProjectRelPath)}";`);
+  }
+  return lines.join("\n");
+}
+
+export async function resolveComponentExtract(projectRoot, edit) {
+  const { component } = edit;
+  if (!component || typeof component !== "object") {
+    return refuse("invalid-input", "component payload is required for this op");
+  }
+  const { path: relPath, baseVersion, nodeId, newName } = component;
+  if (!validPath(relPath)) {
+    return refuse("invalid-input", `not a project-relative .astro path: ${relPath}`);
+  }
+  if (typeof nodeId !== "string") {
+    return refuse("invalid-input", "extract-component requires component.nodeId");
+  }
+  if (typeof newName !== "string" || !COMPONENT_NAME_RE.test(newName)) {
+    return refuse("invalid-input", 'extract-component requires component.newName as a PascalCase identifier, e.g. "CardTitle"');
+  }
+
+  const loaded = await loadFresh(projectRoot, relPath, baseVersion);
+  if (loaded.error) return loaded.error;
+  const { source, byId, rootId } = loaded;
+
+  const node = byId.get(nodeId);
+  if (!node) return refuse("no-match", "no node found at the given id — the file may have changed");
+  if (node.parentId === null) return refuse("invalid-input", "cannot extract the component's own root");
+  if (node.kind !== "element" && node.kind !== "component") {
+    return refuse("invalid-input", `extract-component requires an element or component node, got kind=${node.kind}`);
+  }
+
+  const newRelPath = `src/components/${newName}.astro`;
+  if (newRelPath === relPath) {
+    return refuse("invalid-input", "newName must not match the source component's own file");
+  }
+  if (existsSync(join(projectRoot, newRelPath))) {
+    return refuse("already-exists", `${newRelPath} already exists`);
+  }
+
+  // `ensureImport` (frontmatter-imports.mjs) dedups by SPECIFIER, not by local name — it would
+  // happily append a SECOND `import <newName> from "./<newName>.astro";` alongside an existing,
+  // unrelated `import <newName> from "<somewhere else>";`, producing a duplicate-declaration
+  // syntax error in the source file at build time. Refuse up front instead of generating broken
+  // output; the newRelPath specifier itself can never already be bound to a DIFFERENT specifier
+  // for the same local name, since `existsSync` above already proved that file doesn't exist yet.
+  const sourceFmMatch = source.match(/^(---\r?\n)([\s\S]*?)(\r?\n---)/);
+  if (sourceFmMatch) {
+    const collision = parseImports(sourceFmMatch[2]).find((i) => i.localName === newName);
+    if (collision) {
+      return refuse(
+        "invalid-input",
+        `newName "${newName}" collides with an existing import of a different component ("${collision.specifier}") in ${relPath}`,
+      );
+    }
+  }
+
+  let spans;
+  try {
+    spans = resolveAllSpans(byId, rootId, source);
+  } catch (err) {
+    if (!(err instanceof SpanResolutionError)) throw err;
+    return refuse(
+      "no-match",
+      "could not lexically re-locate the node's true source span without trusting compiler offsets — refusing rather than risking corruption",
+    );
+  }
+  const nodeSpan = spans.get(nodeId);
+  if (!nodeSpan) {
+    return refuse(
+      "no-match",
+      "could not lexically re-locate the node's true source span without trusting compiler offsets — refusing rather than risking corruption",
+    );
+  }
+
+  const { markup, props, instanceAttrs } = hoistProps(byId, nodeId, source, nodeSpan);
+
+  // Carry over imports for any component-kind descendants used INSIDE the extracted subtree
+  // (e.g. extracting a wrapper that itself renders `<Badge ... />`) — without this the new file
+  // would reference an undefined component. Best-effort, mirroring remove-node's own
+  // best-effort import bookkeeping in the other direction: a used tag with no matching default
+  // import in the SOURCE file's frontmatter (a plain custom element, or an already-broken source
+  // file) is left alone rather than guessed at.
+  const newFileImportLines = carriedImportLines(byId, nodeId, source, relPath, newRelPath);
+
+  const iface = generatePropsInterface(props);
+  const destructure = generatePropsDestructure(props);
+  const fmParts = [newFileImportLines, iface, destructure].filter(Boolean);
+  const fmLines = fmParts.join("\n");
+  const newFileContent = fmLines ? `---\n${fmLines}\n---\n${markup}\n` : `---\n---\n${markup}\n`;
+
+  const attrsText = instanceAttrs.map(({ name, value }) => ` ${name}="${escapeAttr(value)}"`).join("");
+  const instanceMarkup = `<${newName}${attrsText} />`;
+  const withInstance = source.slice(0, nodeSpan[0]) + instanceMarkup + source.slice(nodeSpan[1]);
+
+  const fmMatch = withInstance.match(/^(---\r?\n)([\s\S]*?)(\r?\n---)/);
+  let rewrittenOriginal;
+  if (!fmMatch) {
+    const importLine = `import ${newName} from "${importSpecifier(relPath, newRelPath)}";\n`;
+    rewrittenOriginal = `---\n${importLine}---\n${withInstance}`;
+  } else {
+    const [, open, fmBody] = fmMatch;
+    const fmBodyStart = fmMatch.index + open.length;
+    const { source: newFmBody } = ensureImport(fmBody, { localName: newName, specifier: importSpecifier(relPath, newRelPath) });
+    rewrittenOriginal = withInstance.slice(0, fmBodyStart) + newFmBody + withInstance.slice(fmBodyStart + fmBody.length);
+  }
+
+  return {
+    extract: true,
+    newFile: { path: newRelPath, content: newFileContent },
+    original: { file: relPath, range: { start: 0, end: source.length }, replacement: rewrittenOriginal },
+  };
+}

--- a/server/component-node-index.mjs
+++ b/server/component-node-index.mjs
@@ -61,9 +61,18 @@ function attrsOf(n, lineStarts) {
   // pre-refactor NodeBuilder preserved that `""` in the model's public JSON.
   // Special-casing empty attrs to `null` here would silently change
   // component-model.mjs's output for a case none of its existing tests cover.
+  //
+  // `kind` (@astrojs/compiler's own attribute-kind enum: quoted/empty/expression/spread/
+  // shorthand/template-literal) is carried internally so component-extract-edit.mjs can tell a
+  // literal string attribute (`class="card"`, kind "quoted") apart from a dynamic one
+  // (`class={x}`, kind "expression") when deciding what's "obvious" enough to hoist into a
+  // prop. It's intentionally NOT surfaced by component-model.mjs's public JSON —
+  // `toPublicNode` there whitelists `{name, value}` only, so adding this field here doesn't
+  // change the get_component_model wire contract.
   return (n.attributes ?? []).map((a) => ({
     name: a.name,
     value: a.value ?? null,
+    kind: a.kind,
     span: attrSpan(a, lineStarts),
   }));
 }

--- a/server/component-structure-edit.mjs
+++ b/server/component-structure-edit.mjs
@@ -5,6 +5,16 @@ import { fileVersion } from "./file-version.mjs";
 import { buildTemplateNodeIndex } from "./component-node-index.mjs";
 import { ensureImport, pruneImportIfUnused } from "./frontmatter-imports.mjs";
 
+// `resolveAllSpans`/`SpanResolutionError`/`VOID_ELEMENTS`/`escapeAttr`/`importSpecifier`/
+// `collectComponentTags` are exported (in addition to being used locally) so
+// component-extract-edit.mjs — which needs the exact same "never trust node.span directly for a
+// node's own boundary" span-resolution discipline to locate the extracted subtree, the same
+// attribute-escaping and relative-import-specifier helpers `insert-node`'s component-import case
+// uses, and the same component-tag walk `remove-node` uses for import pruning (extract-component
+// uses it the other direction: carrying imports for component-kind descendants INTO the new
+// file) — can reuse this module's single, carefully-tested implementation rather than a second,
+// drift-prone copy.
+
 function refuse(reason, detail) {
   return { refused: true, reason, detail };
 }
@@ -12,7 +22,7 @@ function refuse(reason, detail) {
 // Matches escapeAttr in create-content.mjs: escape "&" first (so it doesn't
 // double-escape the entities this introduces), then escape '"' so the value
 // can't break out of the double-quoted attribute it's interpolated into.
-function escapeAttr(s) {
+export function escapeAttr(s) {
   return String(s).replace(/&/g, "&amp;").replace(/"/g, "&quot;");
 }
 
@@ -316,7 +326,7 @@ function findTagOpenFrom(masked, tagName, from) {
 // Thrown by `resolveAllSpans` when a node's lexical marker can't be found from the
 // current cursor position. Callers must catch this and refuse the op (fail closed)
 // rather than guess — see the file-level comment above for why offsets can't be trusted.
-class SpanResolutionError extends Error {
+export class SpanResolutionError extends Error {
   constructor(nodeId) {
     super(`could not lexically locate node ${nodeId}`);
     this.nodeId = nodeId;
@@ -325,7 +335,7 @@ class SpanResolutionError extends Error {
 
 // HTML void elements: never have a closing tag, self-closing or not — same terminal
 // handling as an explicit self-closing tag (<img />). https://html.spec.whatwg.org/#void-elements
-const VOID_ELEMENTS = new Set([
+export const VOID_ELEMENTS = new Set([
   "area", "base", "br", "col", "embed", "hr", "img", "input",
   "link", "meta", "param", "source", "track", "wbr",
 ]);
@@ -336,7 +346,7 @@ const VOID_ELEMENTS = new Set([
 // replaces the old per-node k-th-occurrence search). Returns a Map<nodeId, [start, end]>
 // (only for kinds this function can resolve — text nodes and tagless fragments are
 // never spanned); throws `SpanResolutionError` if a node's marker can't be located.
-function resolveAllSpans(byId, rootId, source) {
+export function resolveAllSpans(byId, rootId, source) {
   const masked = maskOpaqueZones(source);
   const spans = new Map();
   let cursor = 0;
@@ -464,7 +474,7 @@ function applyRemoveNode(file, source, byId, rootId, component) {
   return { file, range: { start: 0, end: source.length }, replacement: rewritten };
 }
 
-function collectComponentTags(byId, nodeId) {
+export function collectComponentTags(byId, nodeId) {
   const names = [];
   function walk(id) {
     const n = byId.get(id);
@@ -489,7 +499,7 @@ function buildMarkup(nodeSpec) {
 /** Relative import specifier from the target component's own directory to the component
  *  being inserted, Astro-style (keeps the .astro extension, always POSIX-separated, always
  *  prefixed with ./ or ../ so it never gets mistaken for a bare-specifier package import). */
-function importSpecifier(targetRelPath, componentRelPath) {
+export function importSpecifier(targetRelPath, componentRelPath) {
   const rel = relative(dirname(targetRelPath), componentRelPath).split(sep).join("/");
   return rel.startsWith(".") ? rel : `./${rel}`;
 }

--- a/server/edit-history.mjs
+++ b/server/edit-history.mjs
@@ -40,18 +40,32 @@ function isGitRepo(projectRoot) {
   return tryRunGit(projectRoot, ["rev-parse", "--git-dir"]) !== undefined;
 }
 
-function formatMessage({ file, range, message }) {
-  const headline = message && message.trim() ? message.trim() : `anglesite: edit ${file}`;
+function formatMessage({ file, files, range, message }) {
+  const headline = message && message.trim() ? message.trim() : `anglesite: edit ${file ?? files?.[0]}`;
+  // Multi-file commits (currently only extract-component, which adds a brand-new
+  // src/components/<Name>.astro alongside patching the file the extraction was made from) have
+  // no single meaningful byte range, so the trailer lists every touched path instead.
+  if (files && files.length > 1) {
+    return `${headline}\n\nfiles:\n${files.map((f) => `  ${f}`).join("\n")}\n`;
+  }
   return `${headline}\n\nfile: ${file}\nrange: ${range.start}-${range.end}\n`;
 }
 
 /**
  * @param {string} projectRoot
- * @param {{ file: string, range: {start:number,end:number}, message?: string }} info
+ * @param {{ file: string, range: {start:number,end:number}, message?: string }
+ *        | { files: string[], message?: string }} info
+ *   Single-file form (`file`/`range`) is the original, still-default shape every non-extract op
+ *   uses. `files` (2+ paths) commits ALL of them onto ONE anglesite/edits commit — used by
+ *   extract-component so "one semantic op → one commit" (the invariant every other op already
+ *   gets for free) holds for its two-file write too, and so a single `undo_edit` call reverts
+ *   the whole op atomically instead of needing one call per touched file.
  * @returns {Promise<string | undefined>} commit SHA, or undefined on any failure
  */
-export async function recordEdit(projectRoot, { file, range, message }) {
+export async function recordEdit(projectRoot, { file, files, range, message }) {
   if (!isGitRepo(projectRoot)) return undefined;
+  const fileList = files ?? (file ? [file] : []);
+  if (fileList.length === 0) return undefined;
 
   try {
     // 1. Ensure refs/heads/anglesite/edits exists, initializing from HEAD on first edit.
@@ -69,19 +83,18 @@ export async function recordEdit(projectRoot, { file, range, message }) {
     const env = { GIT_INDEX_FILE: tmpIndex };
     try {
       runGit(projectRoot, ["read-tree", EDITS_REF], env);
-      // hash-object -w writes a blob from the on-disk file content into the object DB,
-      // regardless of whether `file` is tracked or .gitignored.
-      const blob = runGit(projectRoot, ["hash-object", "-w", "--", file]);
-      // --cacheinfo lets us add/replace by blob SHA without consulting the working index.
-      runGit(
-        projectRoot,
-        ["update-index", "--add", "--cacheinfo", `100644,${blob},${file}`],
-        env,
-      );
+      for (const f of fileList) {
+        // hash-object -w writes a blob from the on-disk file content into the object DB,
+        // regardless of whether `f` is tracked or .gitignored, already existed, or is brand new.
+        const blob = runGit(projectRoot, ["hash-object", "-w", "--", f]);
+        // --cacheinfo lets us add/replace by blob SHA without consulting the working index;
+        // --add covers both "replace an existing path" and "add a path new to this tree".
+        runGit(projectRoot, ["update-index", "--add", "--cacheinfo", `100644,${blob},${f}`], env);
+      }
       const tree = runGit(projectRoot, ["write-tree"], env);
       const parent = runGit(projectRoot, ["rev-parse", EDITS_REF]);
       const commit = runGit(projectRoot, [
-        "commit-tree", tree, "-p", parent, "-m", formatMessage({ file, range, message }),
+        "commit-tree", tree, "-p", parent, "-m", formatMessage({ file, files, range, message }),
       ]);
       // CAS update with OLDVALUE so two concurrent recordEdits can't silently clobber each other.
       runGit(projectRoot, ["update-ref", EDITS_REF, commit, parent]);

--- a/server/index-tools.mjs
+++ b/server/index-tools.mjs
@@ -113,15 +113,19 @@ export function buildServer(projectRoot) {
   // hidden-branch history that backs per-edit undo in `edit-history.mjs` (#298). The dispatcher
   // invokes `onApplied` after a successful patch — `recordEdit` commits onto refs/heads/anglesite/edits
   // without touching HEAD/index/working-tree and returns the SHA, which the dispatcher threads
-  // back as `commit` on the edit-applied response.
+  // back as `commit` on the edit-applied response. `onApplied` is called with `{file, range}` for
+  // every single-file op, or `{files, message}` for extract-component's two-file write (Component
+  // Editor slice 5, Anglesite-app#495) — `recordEdit`'s `files` mode commits both onto ONE commit.
   server.tool(
     "apply_edit",
     "Apply an edit to the underlying source for a previewed page element. The selector is the structured ElementInfo payload built by the WKWebView overlay; the server resolves it via selector.mjs and patches the matching source file. Successful edits are also committed onto the hidden anglesite/edits branch for per-edit undo.",
     applyEditInputShape,
     async (input) =>
       applyEdit(projectRoot, input, {
-        onApplied: ({ file, range }) =>
-          recordEdit(projectRoot, { file, range, message: `anglesite: edit ${file}` }),
+        onApplied: ({ file, range, files, message }) =>
+          files
+            ? recordEdit(projectRoot, { files, message })
+            : recordEdit(projectRoot, { file, range, message: `anglesite: edit ${file}` }),
       }),
   );
 

--- a/server/patcher.mjs
+++ b/server/patcher.mjs
@@ -4,7 +4,13 @@ import { rewriteAstroStyle } from "./style-edit.mjs";
 import { resolveComponentStyle } from "./component-style-edit.mjs";
 import { resolveComponentStructure } from "./component-structure-edit.mjs";
 import { resolveComponentFrontmatter } from "./component-frontmatter-edit.mjs";
-import { COMPONENT_STYLE_OPS, COMPONENT_STRUCTURE_OPS, COMPONENT_FRONTMATTER_OPS } from "./apply-edit-schema.mjs";
+import { resolveComponentExtract } from "./component-extract-edit.mjs";
+import {
+  COMPONENT_STYLE_OPS,
+  COMPONENT_STRUCTURE_OPS,
+  COMPONENT_FRONTMATTER_OPS,
+  COMPONENT_EXTRACT_OPS,
+} from "./apply-edit-schema.mjs";
 
 /**
  * @typedef {import('./apply-edit-schema.mjs').default} _unused
@@ -16,21 +22,22 @@ import { COMPONENT_STYLE_OPS, COMPONENT_STRUCTURE_OPS, COMPONENT_FRONTMATTER_OPS
  * Resolve an edit payload to a source-file patch.
  *
  * Tries resolvers in priority order: edit-style → component-style ops →
- * component-structure ops → component-frontmatter ops → .mdoc → Keystatic
- * YAML/JSON → .astro. Returns the first non-refusal. If all refuse, returns
- * the most informative refusal (from the highest-priority resolver that had
- * an opinion).
+ * component-structure ops → component-frontmatter ops → component-extract op →
+ * .mdoc → Keystatic YAML/JSON → .astro. Returns the first non-refusal. If all
+ * refuse, returns the most informative refusal (from the highest-priority
+ * resolver that had an opinion).
  *
  * Async because `resolveComponentStyle` (component-style-edit.mjs),
- * `resolveComponentStructure` (component-structure-edit.mjs), and
- * `resolveComponentFrontmatter` (component-frontmatter-edit.mjs) parse the
- * target .astro file with `@astrojs/compiler`, which is itself async. Every
- * other resolver here is synchronous; awaiting their (non-Promise) return
- * values is a no-op, so this doesn't change their behavior.
+ * `resolveComponentStructure` (component-structure-edit.mjs),
+ * `resolveComponentFrontmatter` (component-frontmatter-edit.mjs), and
+ * `resolveComponentExtract` (component-extract-edit.mjs) parse the target
+ * .astro file with `@astrojs/compiler`, which is itself async. Every other
+ * resolver here is synchronous; awaiting their (non-Promise) return values is
+ * a no-op, so this doesn't change their behavior.
  *
  * @param {string} projectRoot
  * @param {{ path: string, selector: object, op: string, value?: unknown, component?: object }} edit
- * @returns {Promise<ResolveResult | ResolveRefusal>}
+ * @returns {Promise<ResolveResult | ResolveRefusal | { extract: true, newFile: object, original: ResolveResult }>}
  */
 export async function resolve(projectRoot, edit) {
   if (edit.op === "edit-style") {
@@ -44,6 +51,9 @@ export async function resolve(projectRoot, edit) {
   }
   if (COMPONENT_FRONTMATTER_OPS.has(edit.op)) {
     return resolveComponentFrontmatter(projectRoot, edit);
+  }
+  if (COMPONENT_EXTRACT_OPS.has(edit.op)) {
+    return resolveComponentExtract(projectRoot, edit);
   }
   const resolvers = [resolveMdoc, resolveKeystatic, resolveAstro];
   let bestRefusal = /** @type {ResolveRefusal | null} */ (null);

--- a/server/undo-edit.mjs
+++ b/server/undo-edit.mjs
@@ -14,7 +14,7 @@
  *   - working-tree-modified: at least one touched file differs on disk vs. HEAD's blob
  */
 import { execFileSync } from "node:child_process";
-import { writeFileSync } from "node:fs";
+import { writeFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 
 const EDITS_REF = "refs/heads/anglesite/edits";
@@ -76,10 +76,25 @@ export async function undoEdit(projectRoot, { commit, force = false } = {}) {
     }
   }
 
-  // 6. Write parent's blob content for each file back to disk.
+  // 6. Write parent's blob content for each file back to disk — or, for a file that HEAD
+  //    introduced (didn't exist in `parent` at all), delete it instead of trying to "restore"
+  //    content that never existed. Every op before extract-component only ever modified files
+  //    already present in the base tree, so this branch was unreachable until extract-component
+  //    started committing a brand-new src/components/<Name>.astro alongside the edited source
+  //    file in the SAME commit (Anglesite/Anglesite-app#495) — without it, undoing an extract
+  //    would crash on the `git show` below instead of cleanly removing the new file.
   for (const file of files) {
-    const content = runGitBuffer(projectRoot, ["show", `${parent}:${file}`]);
-    writeFileSync(join(projectRoot, file), content);
+    const existedInParent = tryRunGit(projectRoot, ["cat-file", "-e", `${parent}:${file}`]) !== undefined;
+    if (existedInParent) {
+      const content = runGitBuffer(projectRoot, ["show", `${parent}:${file}`]);
+      writeFileSync(join(projectRoot, file), content);
+    } else {
+      try {
+        unlinkSync(join(projectRoot, file));
+      } catch {
+        // Already gone on disk — nothing to do.
+      }
+    }
   }
 
   // 7. Advance the hidden branch with a new commit whose tree matches parent's tree.

--- a/test/edit-history.test.js
+++ b/test/edit-history.test.js
@@ -94,3 +94,31 @@ describe("recordEdit", () => {
     }
   });
 });
+
+describe("recordEdit — multi-file (extract-component)", () => {
+  it("commits two files (one brand new) onto ONE anglesite/edits commit", async () => {
+    mkdirSync(join(repo, "src/components"), { recursive: true });
+    writeFileSync(join(repo, "src/components/Hero.astro"), "---\n---\n<Card />\n");
+    writeFileSync(join(repo, "src/components/Card.astro"), "---\n---\n<article>New</article>\n");
+
+    const sha = await recordEdit(repo, {
+      files: ["src/components/Card.astro", "src/components/Hero.astro"],
+      message: "anglesite: extract src/components/Card.astro from src/components/Hero.astro",
+    });
+
+    expect(sha).toMatch(/^[0-9a-f]{40}$/);
+    expect(git(["rev-parse", "refs/heads/anglesite/edits"])).toBe(sha);
+    expect(git(["show", `${sha}:src/components/Card.astro`])).toBe("---\n---\n<article>New</article>");
+    expect(git(["show", `${sha}:src/components/Hero.astro`])).toBe("---\n---\n<Card />");
+    // Exactly one commit was created for both files — not two.
+    const parents = git(["rev-list", "--parents", "-n", "1", sha]).split(/\s+/);
+    expect(parents).toHaveLength(2); // [sha, one parent]
+  });
+
+  it("falls back to single-file behavior when files is omitted (back-compat)", async () => {
+    writeFileSync(join(repo, "README.md"), "edited\n");
+    const sha = await recordEdit(repo, { file: "README.md", range: { start: 0, end: 7 }, message: "edit" });
+    expect(sha).toMatch(/^[0-9a-f]{40}$/);
+    expect(git(["show", `${sha}:README.md`])).toBe("edited");
+  });
+});

--- a/test/undo-edit.test.js
+++ b/test/undo-edit.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
@@ -138,5 +138,31 @@ describe("undoEdit", () => {
     } finally {
       rmSync(notARepo, { recursive: true, force: true });
     }
+  });
+
+  it("deletes a brand-new file introduced by the commit being undone, instead of crashing (extract-component)", async () => {
+    // Mirrors what apply-edit-dispatcher's extract-component path commits: a pre-existing file
+    // patched, plus a brand-new file that didn't exist in the parent commit at all. Hero.astro
+    // has to be established as "pre-existing" via its OWN prior recordEdit commit first, so the
+    // extract's own commit has a parent where Hero.astro already exists but Card.astro doesn't.
+    mkdirSync(join(repo, "src/components"), { recursive: true });
+    writeFileSync(join(repo, "src/components/Hero.astro"), "---\n---\n<h1>Welcome</h1>\n");
+    await recordEdit(repo, {
+      file: "src/components/Hero.astro", range: { start: 0, end: 0 }, message: "add Hero.astro",
+    });
+
+    writeFileSync(join(repo, "src/components/Hero.astro"), "---\n---\n<Card />\n");
+    writeFileSync(join(repo, "src/components/Card.astro"), "---\n---\n<h1>Welcome</h1>\n");
+    const sha = await recordEdit(repo, {
+      files: ["src/components/Card.astro", "src/components/Hero.astro"],
+      message: "anglesite: extract src/components/Card.astro from src/components/Hero.astro",
+    });
+    expect(sha).toMatch(/^[0-9a-f]{40}$/);
+
+    const result = await undoEdit(repo, {});
+    expect(result.status).toBe("undone");
+
+    expect(existsSync(join(repo, "src/components/Card.astro"))).toBe(false);
+    expect(readFileSync(join(repo, "src/components/Hero.astro"), "utf-8")).toBe("---\n---\n<h1>Welcome</h1>\n");
   });
 });

--- a/tests/apply-edit-dispatcher-component-extract.test.ts
+++ b/tests/apply-edit-dispatcher-component-extract.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, chmodSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { parse } from "@astrojs/compiler";
+import { applyEdit } from "../server/apply-edit-dispatcher.mjs";
+import { buildTemplateNodeIndex } from "../server/component-node-index.mjs";
+import { recordEdit } from "../server/edit-history.mjs";
+import { undoEdit } from "../server/undo-edit.mjs";
+import { fileVersion } from "../server/file-version.mjs";
+
+const HERO = `---
+---
+<section class="hero">
+  <h2 class="title">Welcome</h2>
+  <img src="/hero.jpg" alt="Nice photo" />
+</section>
+`;
+
+function parseContent(response) {
+  return JSON.parse(response.content[0].text);
+}
+
+async function findTag(source, tag) {
+  const { ast } = await parse(source, { position: true });
+  const { byId, rootId } = buildTemplateNodeIndex(ast, source);
+  const section = byId.get(byId.get(rootId).childIds[0]);
+  const node = section.childIds.map((id) => byId.get(id)).find((n) => n.tag === tag);
+  return node;
+}
+
+describe("applyEdit — extract-component (no git repo)", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-aed-ce-"));
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+    writeFileSync(join(tmpDir, "src", "components", "Hero.astro"), HERO);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rejects extract-component with no component payload", async () => {
+    const response = await applyEdit(tmpDir, { id: "1", path: "x", op: "extract-component" });
+    expect(response.isError).toBe(true);
+    expect(parseContent(response).reason).toBe("invalid-input");
+  });
+
+  it("writes BOTH files' on-disk content and reports newFile, with no onApplied hook (no commit)", async () => {
+    const baseVersion = fileVersion(HERO);
+    const h2 = await findTag(HERO, "h2");
+
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Hero.astro",
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: h2.id, newName: "CardTitle" },
+    });
+
+    expect(response.isError).toBeFalsy();
+    const body = parseContent(response);
+    expect(body.type).toBe("anglesite:edit-applied");
+    expect(body.file).toBe("src/components/Hero.astro");
+    expect(body.newFile).toBe("src/components/CardTitle.astro");
+    expect(body.commit).toBeUndefined();
+    expect(body.model).toBeDefined();
+
+    const newFileOnDisk = readFileSync(join(tmpDir, "src/components/CardTitle.astro"), "utf-8");
+    expect(newFileOnDisk).toContain("interface Props");
+    expect(newFileOnDisk).toContain("classValue: string");
+    expect(newFileOnDisk).toContain("text1: string");
+
+    const originalOnDisk = readFileSync(join(tmpDir, "src/components/Hero.astro"), "utf-8");
+    expect(originalOnDisk).toContain('import CardTitle from "./CardTitle.astro";');
+    expect(originalOnDisk).toContain('<CardTitle classValue="title" text1="Welcome" />');
+    expect(originalOnDisk).not.toContain("<h2");
+    // The refetched model reflects the NEW state of the source file (the instance, not the h2).
+    expect(body.model.path).toBe("src/components/Hero.astro");
+  });
+
+  it("surfaces stale as a failed reply and touches neither file", async () => {
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Hero.astro",
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion: "sha256:000000000000", nodeId: "n1", newName: "CardTitle" },
+    });
+    expect(response.isError).toBe(true);
+    expect(parseContent(response).reason).toBe("stale");
+    expect(existsSync(join(tmpDir, "src/components/CardTitle.astro"))).toBe(false);
+    expect(readFileSync(join(tmpDir, "src/components/Hero.astro"), "utf-8")).toBe(HERO);
+  });
+
+  it("refuses already-exists and writes nothing when the target file appears between resolve and write", async () => {
+    const baseVersion = fileVersion(HERO);
+    const h2 = await findTag(HERO, "h2");
+    // Simulate the race the dispatcher's own pre-write existsSync re-check guards: the resolver
+    // saw no file, but by the time applyExtractComponent runs its own check, one exists.
+    // (In a single-threaded test this just means: the file is already there before the call.)
+    writeFileSync(join(tmpDir, "src/components/CardTitle.astro"), "---\n---\n<p>taken</p>\n");
+
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Hero.astro",
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: h2.id, newName: "CardTitle" },
+    });
+    expect(response.isError).toBe(true);
+    expect(parseContent(response).reason).toBe("already-exists");
+    // Pre-existing file is untouched, and the original source file is untouched too.
+    expect(readFileSync(join(tmpDir, "src/components/CardTitle.astro"), "utf-8")).toBe("---\n---\n<p>taken</p>\n");
+    expect(readFileSync(join(tmpDir, "src/components/Hero.astro"), "utf-8")).toBe(HERO);
+  });
+
+  it("rejects dry_run with not-implemented and touches no file", async () => {
+    const baseVersion = fileVersion(HERO);
+    const h2 = await findTag(HERO, "h2");
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Hero.astro",
+      op: "extract-component",
+      dry_run: true,
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: h2.id, newName: "CardTitle" },
+    });
+    expect(response.isError).toBe(true);
+    expect(parseContent(response).reason).toBe("not-implemented");
+    expect(existsSync(join(tmpDir, "src/components/CardTitle.astro"))).toBe(false);
+  });
+
+  it("rolls back the new file if the second (source-patch) write fails", async () => {
+    // Put the SOURCE component in its own subdirectory, separate from src/components/ (where
+    // the new file always lands per component-extract-edit.mjs's fixed `src/components/<newName>
+    // .astro` convention) — that lets this test chmod ONLY the source's directory read-only,
+    // isolating a second-write failure from the first write (which lands in a still-writable
+    // directory) instead of failing both writes at once.
+    rmSync(join(tmpDir, "src/components/Hero.astro"));
+    mkdirSync(join(tmpDir, "src/components/nested"), { recursive: true });
+    writeFileSync(join(tmpDir, "src/components/nested/Hero.astro"), HERO);
+
+    const baseVersion = fileVersion(HERO);
+    const h2 = await findTag(HERO, "h2");
+    const nestedDir = join(tmpDir, "src/components/nested");
+    const originalMode = statSync(nestedDir).mode;
+    chmodSync(nestedDir, 0o555);
+    try {
+      const response = await applyEdit(tmpDir, {
+        id: "1",
+        path: "src/components/nested/Hero.astro",
+        op: "extract-component",
+        component: { path: "src/components/nested/Hero.astro", baseVersion, nodeId: h2.id, newName: "CardTitle" },
+      });
+      expect(response.isError).toBe(true);
+      expect(parseContent(response).reason).toBe("write-failed");
+    } finally {
+      chmodSync(nestedDir, originalMode);
+    }
+    // The new file's write succeeded first, then got rolled back when the source patch failed —
+    // proving a failed extract never leaves an orphaned new component with no source reference.
+    expect(existsSync(join(tmpDir, "src/components/CardTitle.astro"))).toBe(false);
+    expect(readFileSync(join(tmpDir, "src/components/nested/Hero.astro"), "utf-8")).toBe(HERO);
+  });
+});
+
+describe("applyEdit — extract-component (real git repo: commit + undo)", () => {
+  let repo;
+
+  function git(args) {
+    return execFileSync("git", args, { cwd: repo, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+  }
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), "anglesite-aed-ce-git-"));
+    execFileSync("git", ["init", "-q", "-b", "main", repo]);
+    git(["config", "user.email", "test@example.com"]);
+    git(["config", "user.name", "Test"]);
+    mkdirSync(join(repo, "src", "components"), { recursive: true });
+    writeFileSync(join(repo, "src/components/Hero.astro"), HERO);
+    git(["add", "."]);
+    git(["commit", "-q", "-m", "initial"]);
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("commits both files onto ONE anglesite/edits commit, and a single undo_edit call reverts the whole extraction", async () => {
+    const baseVersion = fileVersion(HERO);
+    const h2 = await findTag(HERO, "h2");
+
+    const response = await applyEdit(
+      repo,
+      {
+        id: "1",
+        path: "src/components/Hero.astro",
+        op: "extract-component",
+        component: { path: "src/components/Hero.astro", baseVersion, nodeId: h2.id, newName: "CardTitle" },
+      },
+      {
+        onApplied: ({ file, range, files, message }) =>
+          files
+            ? recordEdit(repo, { files, message })
+            : recordEdit(repo, { file, range, message: `anglesite: edit ${file}` }),
+      },
+    );
+
+    expect(response.isError).toBeFalsy();
+    const body = parseContent(response);
+    expect(body.commit).toMatch(/^[0-9a-f]{40}$/);
+
+    // Exactly one commit was created for this op — parents has [sha, oneParent].
+    const parents = git(["rev-list", "--parents", "-n", "1", body.commit]).split(/\s+/);
+    expect(parents).toHaveLength(2);
+    expect(git(["show", `${body.commit}:src/components/CardTitle.astro`])).toContain("interface Props");
+    expect(git(["show", `${body.commit}:src/components/Hero.astro`])).toContain("<CardTitle");
+
+    const undone = await undoEdit(repo, {});
+    expect(undone.status).toBe("undone");
+    expect(existsSync(join(repo, "src/components/CardTitle.astro"))).toBe(false);
+    expect(readFileSync(join(repo, "src/components/Hero.astro"), "utf-8")).toBe(HERO);
+  });
+});

--- a/tests/apply-edit-dispatcher-component-extract.test.ts
+++ b/tests/apply-edit-dispatcher-component-extract.test.ts
@@ -94,6 +94,30 @@ describe("applyEdit — extract-component (no git repo)", () => {
     expect(readFileSync(join(tmpDir, "src/components/Hero.astro"), "utf-8")).toBe(HERO);
   });
 
+  it("surfaces dynamic-expression as a failed reply and touches neither file, instead of silently writing a new file that fails to build", async () => {
+    const WITH_EXPRESSION = `---
+const title = "Welcome";
+---
+<section>
+  <h2>{title}</h2>
+</section>
+`;
+    writeFileSync(join(tmpDir, "src", "components", "Hero.astro"), WITH_EXPRESSION);
+    const baseVersion = fileVersion(WITH_EXPRESSION);
+    const h2 = await findTag(WITH_EXPRESSION, "h2");
+
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Hero.astro",
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: h2.id, newName: "CardTitle" },
+    });
+    expect(response.isError).toBe(true);
+    expect(parseContent(response).reason).toBe("dynamic-expression");
+    expect(existsSync(join(tmpDir, "src/components/CardTitle.astro"))).toBe(false);
+    expect(readFileSync(join(tmpDir, "src/components/Hero.astro"), "utf-8")).toBe(WITH_EXPRESSION);
+  });
+
   it("refuses already-exists and writes nothing when the target file appears between resolve and write", async () => {
     const baseVersion = fileVersion(HERO);
     const h2 = await findTag(HERO, "h2");

--- a/tests/apply-edit-schema-extract.test.ts
+++ b/tests/apply-edit-schema-extract.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import {
+  editOps,
+  componentEditSchema,
+  applyEditInputShape,
+  COMPONENT_EXTRACT_OPS,
+  COMPONENT_OPS,
+  createEditAppliedContent,
+} from "../server/apply-edit-schema.mjs";
+
+describe("extract-component op schema", () => {
+  it("registers the op name in editOps, COMPONENT_EXTRACT_OPS, and the COMPONENT_OPS union", () => {
+    expect(editOps).toContain("extract-component");
+    expect(COMPONENT_EXTRACT_OPS.has("extract-component")).toBe(true);
+    expect(COMPONENT_OPS.has("extract-component")).toBe(true);
+    // Sibling component-op families are still in the union too.
+    expect(COMPONENT_OPS.has("insert-node")).toBe(true);
+    expect(COMPONENT_OPS.has("set-style-property")).toBe(true);
+    expect(COMPONENT_OPS.has("set-props-interface")).toBe(true);
+  });
+
+  it("accepts an extract-component payload (nodeId + newName)", () => {
+    const schema = z.object(applyEditInputShape);
+    const result = schema.safeParse({
+      id: "1",
+      path: "src/components/Hero.astro",
+      op: "extract-component",
+      component: {
+        path: "src/components/Hero.astro",
+        baseVersion: "sha256:abc123456789",
+        nodeId: "n2",
+        newName: "CardTitle",
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a component payload missing baseVersion, same as every other component op", () => {
+    const result = componentEditSchema.safeParse({ path: "src/components/Hero.astro", nodeId: "n2", newName: "CardTitle" });
+    expect(result.success).toBe(false);
+  });
+
+  it("still parses without newName (the field is optional at the schema layer; the resolver enforces it's required for this op)", () => {
+    const result = componentEditSchema.safeParse({
+      path: "src/components/Hero.astro",
+      baseVersion: "sha256:abc123456789",
+      nodeId: "n2",
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("createEditAppliedContent — additive newFile field", () => {
+  it("omits newFile when not passed (every existing single-file op's reply shape is unchanged)", () => {
+    const content = createEditAppliedContent("1", "src/pages/index.astro", { start: 0, end: 5 }, "deadbeef");
+    const body = JSON.parse(content.text);
+    expect(body).not.toHaveProperty("newFile");
+    expect(body.file).toBe("src/pages/index.astro");
+  });
+
+  it("includes newFile when passed (extract-component's reply)", () => {
+    const content = createEditAppliedContent(
+      "1",
+      "src/components/Hero.astro",
+      { start: 0, end: 40 },
+      "deadbeef",
+      undefined,
+      undefined,
+      "src/components/CardTitle.astro",
+    );
+    const body = JSON.parse(content.text);
+    expect(body.newFile).toBe("src/components/CardTitle.astro");
+    expect(body.file).toBe("src/components/Hero.astro");
+  });
+});

--- a/tests/component-extract-edit.test.ts
+++ b/tests/component-extract-edit.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parse } from "@astrojs/compiler";
+import { resolveComponentExtract } from "../server/component-extract-edit.mjs";
+import { buildTemplateNodeIndex } from "../server/component-node-index.mjs";
+import { fileVersion } from "../server/file-version.mjs";
+
+const HERO = `---
+---
+<section class="hero">
+  <h2 class="title">Welcome</h2>
+  <img src="/hero.jpg" alt="Nice photo" />
+  <p>Same text</p>
+  <p>Same text</p>
+</section>
+`;
+
+async function nodeIndex(source) {
+  const { ast } = await parse(source, { position: true });
+  return buildTemplateNodeIndex(ast, source);
+}
+
+async function findTag(source, tag) {
+  const { byId, rootId } = await nodeIndex(source);
+  const section = byId.get(byId.get(rootId).childIds[0]);
+  const node = section.childIds.map((id) => byId.get(id)).find((n) => n.tag === tag);
+  return { byId, rootId, section, node };
+}
+
+describe("resolveComponentExtract", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-cee-"));
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+    writeFileSync(join(tmpDir, "src", "components", "Hero.astro"), HERO);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("refuses invalid-input with no component payload", async () => {
+    const result = await resolveComponentExtract(tmpDir, { op: "extract-component" });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+
+  it("refuses invalid-input when newName isn't PascalCase", async () => {
+    const baseVersion = fileVersion(HERO);
+    const { node: h2 } = await findTag(HERO, "h2");
+    const result = await resolveComponentExtract(tmpDir, {
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: h2.id, newName: "cardTitle" },
+    });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+
+  it("refuses stale when baseVersion doesn't match", async () => {
+    const result = await resolveComponentExtract(tmpDir, {
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion: "sha256:000000000000", nodeId: "n1", newName: "CardTitle" },
+    });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("stale");
+  });
+
+  it("refuses no-match when nodeId doesn't exist", async () => {
+    const baseVersion = fileVersion(HERO);
+    const result = await resolveComponentExtract(tmpDir, {
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: "n999", newName: "CardTitle" },
+    });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("no-match");
+  });
+
+  it("refuses invalid-input when the node is the component's own (synthetic fragment) root", async () => {
+    const baseVersion = fileVersion(HERO);
+    const { rootId } = await nodeIndex(HERO);
+    const result = await resolveComponentExtract(tmpDir, {
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: rootId, newName: "CardTitle" },
+    });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+
+  it("allows extracting a top-level element (its parent is the synthetic root, not the root itself)", async () => {
+    const baseVersion = fileVersion(HERO);
+    const { byId, rootId } = await nodeIndex(HERO);
+    const section = byId.get(byId.get(rootId).childIds[0]);
+    const result = await resolveComponentExtract(tmpDir, {
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: section.id, newName: "HeroBlock" },
+    });
+    expect(result.refused).toBeFalsy();
+    expect(result.newFile.path).toBe("src/components/HeroBlock.astro");
+  });
+
+  it("refuses already-exists when the target file is already on disk", async () => {
+    writeFileSync(join(tmpDir, "src", "components", "CardTitle.astro"), "---\n---\n<h2>x</h2>\n");
+    const baseVersion = fileVersion(HERO);
+    const { node: h2 } = await findTag(HERO, "h2");
+    const result = await resolveComponentExtract(tmpDir, {
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: h2.id, newName: "CardTitle" },
+    });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("already-exists");
+  });
+
+  it("refuses invalid-input when newName collides with an existing, unrelated import's local name", async () => {
+    const WITH_IMPORT = `---
+import CardTitle from "../shared/CardTitle.astro";
+---
+<section class="hero">
+  <h2 class="title">Welcome</h2>
+</section>
+`;
+    writeFileSync(join(tmpDir, "src", "components", "Hero.astro"), WITH_IMPORT);
+    const baseVersion = fileVersion(WITH_IMPORT);
+    const { ast } = await parse(WITH_IMPORT, { position: true });
+    const { byId, rootId } = buildTemplateNodeIndex(ast, WITH_IMPORT);
+    const section = byId.get(byId.get(rootId).childIds[0]);
+    const h2 = byId.get(section.childIds[0]);
+
+    // Would otherwise append a SECOND `import CardTitle from "./CardTitle.astro";` alongside the
+    // existing, unrelated one — a duplicate-declaration syntax error at build time.
+    const result = await resolveComponentExtract(tmpDir, {
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: h2.id, newName: "CardTitle" },
+    });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+
+  it("extracts the h2 subtree, hoisting its class attr (renamed classValue — reserved word) and its text into string props", async () => {
+    const baseVersion = fileVersion(HERO);
+    const { node: h2 } = await findTag(HERO, "h2");
+
+    const result = await resolveComponentExtract(tmpDir, {
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: h2.id, newName: "CardTitle" },
+    });
+
+    expect(result.refused).toBeFalsy();
+    expect(result.extract).toBe(true);
+    expect(result.newFile.path).toBe("src/components/CardTitle.astro");
+    expect(result.newFile.content).toContain("interface Props");
+    // "class" is a reserved word as a destructured shorthand binding — renamed classValue.
+    expect(result.newFile.content).toContain("classValue: string");
+    expect(result.newFile.content).toContain("text1: string");
+    expect(result.newFile.content).toContain("const { classValue, text1 } = Astro.props;");
+    expect(result.newFile.content).toContain("<h2 class={classValue}>{text1}</h2>");
+    expect(result.newFile.content).not.toContain("Welcome");
+  });
+
+  it("does not hoist a value duplicated within the same extracted subtree", async () => {
+    const DUPLICATE = `---\n---\n<section><div><p>Same</p><p>Same</p></div></section>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Hero.astro"), DUPLICATE);
+    const baseVersion = fileVersion(DUPLICATE);
+    const { ast } = await parse(DUPLICATE, { position: true });
+    const { byId, rootId } = buildTemplateNodeIndex(ast, DUPLICATE);
+    const section = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(section.childIds[0]);
+
+    const result = await resolveComponentExtract(tmpDir, {
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: div.id, newName: "SamePair" },
+    });
+
+    expect(result.refused).toBeFalsy();
+    // Neither <p>'s "Same" text got hoisted — both occurrences remain literal.
+    expect(result.newFile.content).not.toContain("interface Props");
+    expect(result.newFile.content).toContain("<p>Same</p><p>Same</p>");
+  });
+
+  it("hoists an element's own attrs when it IS the extracted node (src/alt on <img>)", async () => {
+    const baseVersion = fileVersion(HERO);
+    const { node: img } = await findTag(HERO, "img");
+
+    const result = await resolveComponentExtract(tmpDir, {
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: img.id, newName: "HeroImage" },
+    });
+
+    expect(result.refused).toBeFalsy();
+    expect(result.newFile.content).toContain("src: string");
+    expect(result.newFile.content).toContain("alt: string");
+    expect(result.newFile.content).toContain("<img src={src} alt={alt} />");
+  });
+
+  it("replaces the original selection with an instance tag carrying the original literal values as attrs, plus a matching import", async () => {
+    const baseVersion = fileVersion(HERO);
+    const { node: h2 } = await findTag(HERO, "h2");
+
+    const result = await resolveComponentExtract(tmpDir, {
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: h2.id, newName: "CardTitle" },
+    });
+
+    expect(result.original.file).toBe("src/components/Hero.astro");
+    expect(result.original.range).toEqual({ start: 0, end: HERO.length });
+    expect(result.original.replacement).toContain('import CardTitle from "./CardTitle.astro";');
+    expect(result.original.replacement).toContain('<CardTitle classValue="title" text1="Welcome" />');
+    expect(result.original.replacement).not.toContain("<h2");
+    // Untouched siblings still present.
+    expect(result.original.replacement).toContain('<img src="/hero.jpg" alt="Nice photo" />');
+  });
+
+  it("synthesizes a frontmatter fence with the import when the source file has none yet", async () => {
+    const NO_FM = `<section><h2 class="title">Welcome</h2></section>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Hero.astro"), NO_FM);
+    const baseVersion = fileVersion(NO_FM);
+    const { ast } = await parse(NO_FM, { position: true });
+    const { byId, rootId } = buildTemplateNodeIndex(ast, NO_FM);
+    const section = byId.get(byId.get(rootId).childIds[0]);
+    const h2 = byId.get(section.childIds[0]);
+
+    const result = await resolveComponentExtract(tmpDir, {
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: h2.id, newName: "CardTitle" },
+    });
+
+    expect(result.refused).toBeFalsy();
+    expect(result.original.replacement.startsWith("---\nimport CardTitle from")).toBe(true);
+  });
+
+  it("extracts a component-kind node (an existing component instance), hoisting its own props too", async () => {
+    const WRAPPED = `---
+import Badge from "./Badge.astro";
+---
+<section>
+  <div class="wrap">
+    <Badge label="New" />
+  </div>
+</section>
+`;
+    writeFileSync(join(tmpDir, "src", "components", "Hero.astro"), WRAPPED);
+    writeFileSync(join(tmpDir, "src", "components", "Badge.astro"), "---\ninterface Props { label: string; }\nconst { label } = Astro.props;\n---\n<span>{label}</span>\n");
+    const baseVersion = fileVersion(WRAPPED);
+    const { ast } = await parse(WRAPPED, { position: true });
+    const { byId, rootId } = buildTemplateNodeIndex(ast, WRAPPED);
+    const section = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(section.childIds[0]);
+    const badge = byId.get(div.childIds[0]);
+    expect(badge.kind).toBe("component");
+
+    const result = await resolveComponentExtract(tmpDir, {
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: badge.id, newName: "BadgeWrap" },
+    });
+
+    expect(result.refused).toBeFalsy();
+    // The new file gets its OWN import of Badge — without this it would reference an undefined
+    // component. Both files live directly in src/components/, so the specifier is unchanged.
+    expect(result.newFile.content).toContain('import Badge from "./Badge.astro";');
+    expect(result.newFile.content).toContain("label: string");
+    expect(result.newFile.content).toContain("<Badge label={label} />");
+    expect(result.original.replacement).toContain('<BadgeWrap label="New" />');
+  });
+
+  it("carries a bare/aliased import specifier through UNCHANGED rather than mis-rewriting it as a relative path", async () => {
+    const WRAPPED = `---
+import Icon from "some-astro-lib/Icon.astro";
+import Button from "@components/Button.astro";
+---
+<section>
+  <div class="wrap">
+    <Icon />
+    <Button label="Go" />
+  </div>
+</section>
+`;
+    writeFileSync(join(tmpDir, "src", "components", "Hero.astro"), WRAPPED);
+    const baseVersion = fileVersion(WRAPPED);
+    const { ast } = await parse(WRAPPED, { position: true });
+    const { byId, rootId } = buildTemplateNodeIndex(ast, WRAPPED);
+    const section = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(section.childIds[0]);
+
+    const result = await resolveComponentExtract(tmpDir, {
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: div.id, newName: "IconButtonWrap" },
+    });
+
+    expect(result.refused).toBeFalsy();
+    // Bare package specifier and tsconfig path alias both pass through verbatim — rewriting them
+    // through dirname(relPath) as if they were relative paths would point nowhere.
+    expect(result.newFile.content).toContain('import Icon from "some-astro-lib/Icon.astro";');
+    expect(result.newFile.content).toContain('import Button from "@components/Button.astro";');
+  });
+});

--- a/tests/component-extract-edit.test.ts
+++ b/tests/component-extract-edit.test.ts
@@ -294,4 +294,69 @@ import Button from "@components/Button.astro";
     expect(result.newFile.content).toContain('import Icon from "some-astro-lib/Icon.astro";');
     expect(result.newFile.content).toContain('import Button from "@components/Button.astro";');
   });
+
+  it("refuses dynamic-expression rather than copying a {variable} text interpolation into the new file verbatim", async () => {
+    // `title` is a frontmatter const in the SOURCE file — it would not exist in the new file's
+    // scope (which only gets the hoisted-prop destructure), so silently copying `{title}` across
+    // would produce a component that fails to build.
+    const WITH_EXPRESSION = `---
+const title = "Hello";
+---
+<section>
+  <div class="card">
+    <h2>{title}</h2>
+  </div>
+</section>
+`;
+    writeFileSync(join(tmpDir, "src", "components", "Hero.astro"), WITH_EXPRESSION);
+    const baseVersion = fileVersion(WITH_EXPRESSION);
+    const { ast } = await parse(WITH_EXPRESSION, { position: true });
+    const { byId, rootId } = buildTemplateNodeIndex(ast, WITH_EXPRESSION);
+    const section = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(section.childIds[0]);
+
+    const result = await resolveComponentExtract(tmpDir, {
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: div.id, newName: "Card" },
+    });
+
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("dynamic-expression");
+  });
+
+  it("refuses dynamic-expression rather than copying a dynamic attribute binding (src={imageUrl}) into the new file verbatim", async () => {
+    const WITH_DYNAMIC_ATTR = `---
+const imageUrl = "/photo.jpg";
+---
+<section>
+  <div class="card">
+    <img src={imageUrl} alt="Static alt" />
+  </div>
+</section>
+`;
+    writeFileSync(join(tmpDir, "src", "components", "Hero.astro"), WITH_DYNAMIC_ATTR);
+    const baseVersion = fileVersion(WITH_DYNAMIC_ATTR);
+    const { ast } = await parse(WITH_DYNAMIC_ATTR, { position: true });
+    const { byId, rootId } = buildTemplateNodeIndex(ast, WITH_DYNAMIC_ATTR);
+    const section = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(section.childIds[0]);
+
+    const result = await resolveComponentExtract(tmpDir, {
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: div.id, newName: "Card" },
+    });
+
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("dynamic-expression");
+  });
+
+  it("still extracts a subtree that has no dynamic content at all (sanity: the new refusal doesn't over-trigger)", async () => {
+    const baseVersion = fileVersion(HERO);
+    const { node: h2 } = await findTag(HERO, "h2");
+    const result = await resolveComponentExtract(tmpDir, {
+      op: "extract-component",
+      component: { path: "src/components/Hero.astro", baseVersion, nodeId: h2.id, newName: "CardTitle" },
+    });
+    expect(result.refused).toBeFalsy();
+  });
 });


### PR DESCRIPTION
## Summary

Adds `extract-component` to the `apply_edit` MCP tool: lifts a selected outline subtree out of an existing `.astro` component into a brand-new `src/components/<newName>.astro` file, hoists "obvious" literal props, and replaces the selection in the source file with an instance of the new component plus a matching import. This is plugin-side prep for `Anglesite/Anglesite-app#495` (Component Editor slice 5's "Extract into Component…" affordance) — the design spec's op table already routes it through the existing `apply_edit` tool rather than a new dedicated tool.

This is architecturally novel versus the existing structure/style/frontmatter ops because it's a **two-file write** (every prior op patches exactly one file), which required two explicit design decisions:

### 1. Two-file write ordering + response shape

- **Write order:** the brand-new component file is written **first**, then the source file is patched **second**. If the second write fails, the new file is rolled back with a best-effort `unlink` — cheap and safe because the new file never existed before this op. The reverse order would risk leaving the source file referencing a component that doesn't exist on disk if the second write then failed. There's still no cross-file transaction (this repo's `atomicWrite` only gives single-file atomicity, same accepted limitation as `create-content.mjs`), but this ordering closes the realistic failure window.
- **Git history:** `edit-history.mjs`'s `recordEdit` gains a `files: string[]` mode that stages N files onto **one** `anglesite/edits` commit (via the existing temp-index/`write-tree`/`commit-tree` plumbing, just looped over multiple paths before the single `write-tree` call), so "one semantic op → one commit" holds here too — a single `undo_edit` call reverts the whole extraction. Single-file callers (`{file, range}`) are 100% unchanged.
- **Latent bug fixed as a prerequisite:** `undo-edit.mjs` previously assumed every file in the commit being undone already existed in the parent commit (`git show ${parent}:${file}` unconditionally) — undoing an extract would have crashed on that call for the brand-new file. Fixed to detect (`git cat-file -e`) and delete such files instead of trying to restore content that never existed.
- **Response shape:** `createEditAppliedContent` grows an additive `newFile: string` field (the new file's project-relative path) alongside the existing `file`/`range` (which still describe the SOURCE file's edit). Every other op's reply is unchanged — `newFile` is simply `undefined` and omitted from the JSON for them.
  ```jsonc
  // edit-applied body for extract-component
  {
    "type": "anglesite:edit-applied",
    "id": "...",
    "file": "src/components/Hero.astro",     // the SOURCE file (unchanged field)
    "range": { "start": 0, "end": 123 },      // whole-file replacement, same as remove/insert/move-node
    "commit": "abc123...",                    // ONE commit covering both files
    "model": { /* fresh get_component_model for the SOURCE file */ },
    "newFile": "src/components/CardTitle.astro"  // NEW field, additive only
  }
  ```

### 2. Prop-hoisting heuristic

A literal is "obvious" enough to hoist only when its exact string value occurs **exactly once** among all quoted-attribute-values and text-node contents within the extracted subtree (`kind: "quoted"` per `@astrojs/compiler`'s own attribute-kind enum — `expression`/`shorthand`/`spread`/`template-literal` attrs are never touched; text nodes modeled by `buildTemplateNodeIndex` are by construction always static).

- **Naming:** attribute props are named after the (camelCased) attribute name — `data-size` → `dataSize` — with a reserved-word guard (`class`/`for`/etc. → `classValue`/`forValue`) since a bare destructured binding named `class` is a syntax error. Text props get a generic `text1`, `text2`, … sequence in document order. Collisions (e.g. two different attrs that both camelCase to the same name) get a numeric suffix.
- **Type:** every hoisted prop is `type: "string"` — no number/boolean inference. No prior art for it anywhere in this codebase, and it's not worth the complexity for a first cut.
- **Span discipline:** the extracted subtree's own root boundary is re-derived via `component-structure-edit.mjs`'s `resolveAllSpans` lexical walk — never trusts `node.span` directly, same discipline as `remove-node`/`insert-node`/`move-node`. Individual literal candidates *within* that already-verified boundary use their own `attr.span`/`node.span` directly (matching the already-shipped `set-attr` resolver's precedent), each sanity-checked against its expected text before being trusted — a mismatch just drops that one candidate rather than risking a bad splice.
- **Import hygiene:** reuses `ensureImport`/`parseImports` (`frontmatter-imports.mjs`) for the source file's new import, and separately carries over imports for any component-kind descendants used *inside* the extracted subtree (e.g. extracting a wrapper that itself renders `<Badge ... />`) so the new file doesn't reference an undefined component. Refuses (`invalid-input`) when `newName` would collide with an existing, differently-targeted import in the source file, since `ensureImport` dedups by specifier, not local name. Bare/aliased import specifiers (`"some-lib/Icon.astro"`, `"@components/Button.astro"`) are passed through unchanged rather than mis-rewritten as relative paths.
- **Dynamic content is refused, not copied.** `collectCandidates` already skipped expression-kind nodes and non-`"quoted"` attributes when deciding what to *hoist* — but that alone didn't stop such content from being copied byte-for-byte into the new file whenever it wasn't specifically hoisted. A `{title}` text interpolation, a dynamic attribute binding (`src={imageUrl}`), a spread, or a template literal all reference identifiers that would not be in scope in the new file (which only gets the hoisted-prop destructure), so the new file would silently fail to build. Fixed in a follow-up commit: `findDynamicContent` walks the subtree up front and refuses with `dynamic-expression` (the same reason `patcher.mjs`'s `resolveAstro` already uses for "can't safely act on dynamic content") if it finds any expression-kind node or attribute — matching every sibling structural op's fail-closed convention, rather than attempting to hoist expressions as pass-through props in this same change.

## Other changes

- `component-node-index.mjs`: `attrsOf` now also carries the compiler's own attribute `kind` internally, so the resolver can tell literals from dynamic values. **Not** exposed by `component-model.mjs`'s public `get_component_model` JSON — verified `toPublicNode` whitelists `{name, value}` only, so the wire contract is unchanged.
- `component-structure-edit.mjs`: exports `resolveAllSpans`, `SpanResolutionError`, `escapeAttr`, `importSpecifier`, `VOID_ELEMENTS`, `collectComponentTags` for reuse (export-only diff — no behavior change) rather than a second, drift-prone copy of this tricky lexical-span logic.
- `apply-edit-schema.mjs`: new `extract-component` op string, `COMPONENT_EXTRACT_OPS` Set (added to the `COMPONENT_OPS` union), `newName` field on `componentEditSchema` (reuses the existing `nodeId` field).
- No version bump — per this repo's own process, that happens after review as a separate step.

## Test plan

- [x] `npm test` — full suite passes (150 files / 3082 tests, up from 147/3047 on `main`)
- [x] `tests/component-extract-edit.test.ts` — resolver unit tests: refusals (invalid-input, stale, no-match, already-exists, root-extraction, newName collision, dynamic-expression via text interpolation, dynamic-expression via a dynamic attribute binding), successful extraction with attr+text hoisting, reserved-word renaming, duplicate-value non-hoisting, component-kind extraction with prop hoisting, carried imports (relative, bare/aliased), frontmatter synthesis when the source has none, a sanity check that the dynamic-content refusal doesn't over-trigger on static content
- [x] `tests/apply-edit-dispatcher-component-extract.test.ts` — end-to-end: both files' on-disk content after a successful extract, `newFile` in the reply, stale refusal touches neither file, already-exists refusal, dry-run refusal, dynamic-expression refusal touches neither file, second-write-failure rollback (isolated via separate directories + chmod), and a real-git-repo test proving one commit covers both files and a single `undo_edit` reverts the whole extraction
- [x] `tests/apply-edit-schema-extract.test.ts` — schema validation for the new op/field, additive `newFile` on `createEditAppliedContent`
- [x] `test/edit-history.test.js` / `test/undo-edit.test.js` — new cases for `recordEdit`'s multi-file mode and `undoEdit`'s new-file-deletion path

**Update (follow-up commit `d0ae91a`):** an independent review caught that dynamic content (`{expression}` interpolation, dynamic attrs, spreads, template literals) inside the extracted subtree was silently copied into the new file instead of being refused — see "Dynamic content is refused, not copied" above. Fixed with `findDynamicContent` + 4 new tests; full suite re-verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
