### PR TITLE
feat(mcp): add extract-component apply_edit op (Component Editor Slice 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- `apply_edit` gains `extract-component` — the first two-file component op —
+  for the Component Editor's "Extract into Component…" gesture (Slice 5).
+  Carves a `get_component_model` outline subtree (element/component/slot
+  only) into a new `.astro` file under `src/components/`, hoists the
+  original component's own declared Props that the subtree bare-referenced,
+  migrates simple-selector scoped-style rules that exclusively target the
+  extracted markup (reporting non-blocking `warnings` for anything shared or
+  too complex to analyze automatically), and replaces the extracted markup
+  with a self-closing instance + import. Lands both files in one hidden
+  `anglesite/edits` branch commit, so `undo_edit` reverts both together.
+
 ## [1.6.0] — 2026-07-16
 
 ### Added

--- a/docs/superpowers/plans/2026-07-16-extract-component.md
+++ b/docs/superpowers/plans/2026-07-16-extract-component.md
@@ -1,0 +1,1847 @@
+# extract-component Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the `extract-component` `apply_edit` op — carve a `get_component_model` outline subtree into a brand-new `.astro` file under `src/components/`, hoist the original component's own declared Props that the subtree references, migrate simple scoped-style rules, and replace the extracted markup with a self-closing instance + import, as one atomic two-file edit.
+
+**Architecture:** A new `component-extract-edit.mjs` resolver (same read-fresh/check-`baseVersion`/parse shape as the existing component resolvers) returns a widened result `{file, range, replacement, newFile, hoistedProps, warnings}`. `apply-edit-dispatcher.mjs` writes `newFile` (OS-atomic create-if-absent) before splicing/writing the primary file — mirroring the precedent `replace-image-src` already set for extra file-writing outside the generic single-splice path. `edit-history.mjs`'s `recordEdit` gains an optional second blob so both files land in one hidden-branch commit; `undo-edit.mjs` needs no changes (already file-count-agnostic).
+
+**Tech Stack:** Node.js ESM, `@astrojs/compiler`, `css-tree` (via existing `css-rule-index.mjs`), Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-16-extract-component-design.md`
+
+## Global Constraints
+
+- `newComponentPath` must be a project-relative `.astro` path under `src/components/` (spec §1, §2 step 3).
+- Only `element`/`component`/`slot`-kind nodes are extractable; refuse the component root and text/expression/fragment kinds (spec §3).
+- Prop hoisting: only bare-identifier expressions (`/^[A-Za-z_$][\w$]*$/`) whose name is already one of the *original* component's own declared Props (via `parseProps`) are hoisted; everything else is left in place, never guessed at (spec §4).
+- Style migration: only simple selectors (tag/class/id, no combinators/pseudo-classes) are matched against the outline tree; anything else, or a simple selector also used outside the extracted subtree, stays in the original with a `warnings` entry (spec §5).
+- No general CSS-selector-vs-DOM engine, no TS/JS parser for scope analysis — deliberately regex/heuristic, fail-safe rather than guess, matching `props-interface.mjs`/`frontmatter-imports.mjs`'s existing discipline.
+- `baseVersion` content-hash staleness check at resolve time AND a fresh re-check at dispatcher write time (existing generic `COMPONENT_OPS` behavior — extract-component joins that union).
+- `newComponentPath` collision → refuse `exists`, both at resolve time (`existsSync`) and write time (`wx` flag), never auto-suffixed.
+- ES Modules, no new runtime dependencies. Node >=22. Vitest for all new tests.
+- One atomic edit = one hidden-branch commit = one undo step, even though two files are written.
+
+---
+
+### Task 1: `style-selector-match.mjs` — simple-selector classification and node matching
+
+**Files:**
+- Create: `server/style-selector-match.mjs`
+- Test: `tests/style-selector-match.test.ts`
+
+**Interfaces:**
+- Produces: `isSimpleSelector(selector: string): boolean`, `selectorMatchesNode(selector: string, node: {tag: string|null, attrs: {name:string, value:string|null}[]}): boolean` — consumed by Task 6.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// tests/style-selector-match.test.ts
+import { describe, it, expect } from "vitest";
+import { isSimpleSelector, selectorMatchesNode } from "../server/style-selector-match.mjs";
+
+describe("isSimpleSelector", () => {
+  it("accepts a bare tag, a bare class, a compound tag.class, an id, and multiple classes", () => {
+    expect(isSimpleSelector("div")).toBe(true);
+    expect(isSimpleSelector(".card")).toBe(true);
+    expect(isSimpleSelector("div.card")).toBe(true);
+    expect(isSimpleSelector("#hero")).toBe(true);
+    expect(isSimpleSelector("div.card.featured")).toBe(true);
+  });
+
+  it("rejects combinators, pseudo-classes, :global(), and attribute selectors", () => {
+    expect(isSimpleSelector(".card > h2")).toBe(false);
+    expect(isSimpleSelector(".card:hover")).toBe(false);
+    expect(isSimpleSelector(".parent .child")).toBe(false);
+    expect(isSimpleSelector(":global(.card)")).toBe(false);
+    expect(isSimpleSelector('[data-foo="bar"]')).toBe(false);
+    expect(isSimpleSelector("")).toBe(false);
+  });
+});
+
+describe("selectorMatchesNode", () => {
+  const div = { tag: "div", attrs: [{ name: "class", value: "card featured" }] };
+  const bareDiv = { tag: "div", attrs: [] };
+  const withId = { tag: "section", attrs: [{ name: "id", value: "hero" }] };
+
+  it("matches a bare tag selector against the node's own tag", () => {
+    expect(selectorMatchesNode("div", div)).toBe(true);
+    expect(selectorMatchesNode("section", div)).toBe(false);
+  });
+
+  it("matches a class selector when the node carries that class", () => {
+    expect(selectorMatchesNode(".card", div)).toBe(true);
+    expect(selectorMatchesNode(".missing", div)).toBe(false);
+    expect(selectorMatchesNode(".card", bareDiv)).toBe(false);
+  });
+
+  it("requires every class in a compound selector to be present", () => {
+    expect(selectorMatchesNode("div.card.featured", div)).toBe(true);
+    expect(selectorMatchesNode("div.card.other", div)).toBe(false);
+  });
+
+  it("matches an id selector against the node's id attribute", () => {
+    expect(selectorMatchesNode("#hero", withId)).toBe(true);
+    expect(selectorMatchesNode("#other", withId)).toBe(false);
+    expect(selectorMatchesNode("#hero", div)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/style-selector-match.test.ts`
+Expected: FAIL — `server/style-selector-match.mjs` does not exist.
+
+- [ ] **Step 3: Implement**
+
+```js
+// server/style-selector-match.mjs
+// Purpose-built pattern matching against the outline tree's own tag/class/id
+// data — NOT a general CSS-selector-vs-DOM engine. Bounded to the "obvious"
+// case (a class or tag styling a node directly), consistent with this
+// codebase's "deliberately regex/heuristic, refuse rather than guess"
+// discipline (props-interface.mjs, frontmatter-imports.mjs). Anything with a
+// combinator, pseudo-class, :global(), or attribute selector is "complex"
+// and never matched here — callers treat that as "leave behind, warn."
+
+const TAG_CLASS_RE = /^[a-zA-Z][\w-]*(\.[\w-]+)*$/;
+const CLASS_ONLY_RE = /^(\.[\w-]+)+$/;
+const ID_RE = /^#[\w-]+$/;
+
+export function isSimpleSelector(selector) {
+  const s = selector.trim();
+  if (!s) return false;
+  return TAG_CLASS_RE.test(s) || CLASS_ONLY_RE.test(s) || ID_RE.test(s);
+}
+
+export function selectorMatchesNode(selector, node) {
+  const s = selector.trim();
+  if (ID_RE.test(s)) {
+    const id = node.attrs?.find((a) => a.name === "id")?.value;
+    return id === s.slice(1);
+  }
+  if (!isSimpleSelector(s)) return false;
+  const parts = s.split(".");
+  const tag = parts[0]; // "" when the selector starts with "."
+  const classes = parts.slice(1);
+  if (tag && node.tag !== tag) return false;
+  if (classes.length > 0) {
+    const nodeClasses = (node.attrs?.find((a) => a.name === "class")?.value ?? "").split(/\s+/).filter(Boolean);
+    if (!classes.every((c) => nodeClasses.includes(c))) return false;
+  }
+  return true;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/style-selector-match.test.ts`
+Expected: PASS (all 8 assertions across 4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/style-selector-match.mjs tests/style-selector-match.test.ts
+git commit -m "feat(mcp): add style-selector-match for extract-component's rule migration"
+```
+
+---
+
+### Task 2: Shared primitive exports (`resolveAllSpans`, `astById`, `collectElements`)
+
+Extract-component needs four things that already exist as private/internal pieces of other modules: `resolveAllSpans`/`SpanResolutionError`/`importSpecifier`/`collectComponentTags` from `component-structure-edit.mjs`, `collectElements` from `component-model.mjs`, and a new `astById` map from `buildTemplateNodeIndex` (needed to tell attribute-*expression* values apart from literal string values — the existing public `attrs` shape only carries `{name, value, span}`, no `kind`, and adding `kind` to that shared, wire-adjacent shape is out of scope here; `astById` is an internal-only return value, never serialized into `get_component_model`'s JSON).
+
+**Files:**
+- Modify: `server/component-structure-edit.mjs` (add `export` to 4 existing declarations — no behavior change)
+- Modify: `server/component-model.mjs` (add `export` to `collectElements` — no behavior change)
+- Modify: `server/component-node-index.mjs` (`buildTemplateNodeIndex` additionally returns `astById`)
+- Test: `tests/component-node-index.test.ts` (add one case)
+
+**Interfaces:**
+- Produces: `resolveAllSpans`, `SpanResolutionError`, `importSpecifier`, `collectComponentTags` exported from `component-structure-edit.mjs`; `collectElements` exported from `component-model.mjs`; `buildTemplateNodeIndex(ast, source)` now returns `{byId, rootId, astById}` where `astById: Map<string, AstroCompilerAstNode>` maps each `byId` entry's `id` to the raw `@astrojs/compiler` AST node it was built from (element/component/fragment/expression/text nodes only — same set `byId` covers). Consumed by Task 3 onward.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/component-node-index.test.ts — add this case to the existing file
+it("also returns astById, mapping each node id to its raw compiler AST node", async () => {
+  const source = `---\n---\n<div title={foo}><h2>Hi</h2></div>\n`;
+  const { ast } = await parse(source, { position: true });
+  const { byId, rootId, astById } = buildTemplateNodeIndex(ast, source);
+  const div = byId.get(byId.get(rootId).childIds[0]);
+  const astNode = astById.get(div.id);
+  expect(astNode.type).toBe("element");
+  expect(astNode.name).toBe("div");
+  expect(astNode.attributes.find((a) => a.name === "title").kind).toBe("expression");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/component-node-index.test.ts -t "astById"`
+Expected: FAIL — `astById` is `undefined`.
+
+- [ ] **Step 3: Implement all four changes**
+
+In `server/component-structure-edit.mjs`, change these four declarations to add `export` (no other change — every internal call site within the file keeps working since exported names are still in scope locally):
+
+```js
+export class SpanResolutionError extends Error {
+```
+```js
+export function resolveAllSpans(byId, rootId, source) {
+```
+```js
+export function importSpecifier(targetRelPath, componentRelPath) {
+```
+```js
+export function collectComponentTags(byId, nodeId) {
+```
+
+In `server/component-model.mjs`, change:
+
+```js
+export function collectElements(node, name, out) {
+```
+
+In `server/component-node-index.mjs`, modify `buildTemplateNodeIndex` to build and return `astById`:
+
+```js
+export function buildTemplateNodeIndex(ast, source) {
+  const byId = new Map();
+  const astById = new Map();
+  let next = 0;
+  const nextId = () => `n${next++}`;
+  const lineStarts = buildLineStarts(source);
+
+  const rootId = nextId();
+  const rootChildIds = [];
+  byId.set(rootId, {
+    id: rootId,
+    kind: "fragment",
+    tag: null,
+    attrs: [],
+    span: [0, source.length],
+    loc: null,
+    parentId: null,
+    childIds: rootChildIds,
+  });
+
+  function visit(n, parentId) {
+    let record;
+    switch (n.type) {
+      case "element":
+        record = {
+          id: nextId(),
+          kind: n.name === "slot" ? "slot" : "element",
+          tag: n.name,
+          attrs: attrsOf(n, lineStarts),
+          ...baseSpanLoc(n, lineStarts),
+          parentId,
+          childIds: [],
+        };
+        break;
+      case "component":
+      case "custom-element":
+        record = {
+          id: nextId(),
+          kind: "component",
+          tag: n.name,
+          attrs: attrsOf(n, lineStarts),
+          ...baseSpanLoc(n, lineStarts),
+          parentId,
+          childIds: [],
+        };
+        break;
+      case "fragment":
+        record = {
+          id: nextId(),
+          kind: "fragment",
+          tag: null,
+          attrs: attrsOf(n, lineStarts),
+          ...baseSpanLoc(n, lineStarts),
+          parentId,
+          childIds: [],
+        };
+        break;
+      case "expression": {
+        record = { id: nextId(), kind: "expression", tag: null, attrs: [], ...baseSpanLoc(n, lineStarts), parentId, childIds: [] };
+        byId.set(record.id, record);
+        astById.set(record.id, n);
+        for (const c of n.children ?? []) {
+          if (!JSX_CHILD_TYPES.has(c.type)) continue;
+          const child = visit(c, record.id);
+          if (child) record.childIds.push(child.id);
+        }
+        return record;
+      }
+      case "text": {
+        const value = (n.value ?? "").trim();
+        if (!value) return null;
+        record = {
+          id: nextId(),
+          kind: "text",
+          tag: null,
+          attrs: [],
+          text: value.slice(0, 80),
+          ...baseSpanLoc(n, lineStarts),
+          parentId,
+          childIds: [],
+        };
+        byId.set(record.id, record);
+        astById.set(record.id, n);
+        return record;
+      }
+      default:
+        return null; // comment, doctype
+    }
+    byId.set(record.id, record);
+    astById.set(record.id, n);
+    for (const c of n.children ?? []) {
+      if (isZoneNode(c)) continue;
+      const child = visit(c, record.id);
+      if (child) record.childIds.push(child.id);
+    }
+    return record;
+  }
+
+  const topLevel = (ast.children ?? []).filter((n) => !isZoneNode(n));
+  for (const n of topLevel) {
+    const child = visit(n, rootId);
+    if (child) rootChildIds.push(child.id);
+  }
+
+  return { byId, rootId, astById };
+}
+```
+
+- [ ] **Step 4: Run the full existing test suite to confirm no regressions**
+
+Run: `npx vitest run`
+Expected: PASS — every existing test still passes (all four exports are additive; `astById` is an additive third return value that existing `const {byId, rootId} = buildTemplateNodeIndex(...)` call sites simply don't destructure).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/component-structure-edit.mjs server/component-model.mjs server/component-node-index.mjs tests/component-node-index.test.ts
+git commit -m "refactor(mcp): export shared span/import primitives and astById for extract-component"
+```
+
+---
+
+### Task 3: `component-extract-edit.mjs` core — validation, span resolution, plain subtree move
+
+No prop hoisting, no nested-import copying, no style migration yet — those are Tasks 4–6. This task's deliverable: extracting a subtree with **no** outer-scope references and **no** nested components and **no** matching styles produces a correct two-file result on its own.
+
+**Files:**
+- Create: `server/component-extract-edit.mjs`
+- Test: `tests/component-extract-edit.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveAllSpans`, `SpanResolutionError`, `importSpecifier` (Task 2, `component-structure-edit.mjs`); `buildTemplateNodeIndex` (Task 2, returns `astById` too); `ensureImport` (`frontmatter-imports.mjs`); `fileVersion` (`file-version.mjs`).
+- Produces: `resolveComponentExtract(projectRoot, edit): Promise<{refused: true, reason, detail} | {file, range, replacement, newFile: {path, content}, hoistedProps: string[], warnings: string[]}>` — consumed by Tasks 4–6 (same function, extended in place) and Task 9 (`patcher.mjs`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// tests/component-extract-edit.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parse } from "@astrojs/compiler";
+import { resolveComponentExtract } from "../server/component-extract-edit.mjs";
+import { buildTemplateNodeIndex } from "../server/component-node-index.mjs";
+import { fileVersion } from "../server/file-version.mjs";
+
+const PAGE = `---\n---\n<main>\n  <div class="hero">\n    <h1>Welcome</h1>\n  </div>\n</main>\n`;
+
+async function nodeIndex(source) {
+  const { ast } = await parse(source, { position: true });
+  return buildTemplateNodeIndex(ast, source);
+}
+
+describe("resolveComponentExtract — core", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-cee-"));
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), PAGE);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("refuses invalid-input with no component payload", async () => {
+    const result = await resolveComponentExtract(tmpDir, { op: "extract-component" });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+
+  it("refuses stale when baseVersion does not match", async () => {
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion: "sha256:000000000000", nodeId: "n1", newComponentPath: "src/components/Hero.astro" } };
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("stale");
+  });
+
+  it("refuses invalid-input for newComponentPath outside src/components/", async () => {
+    const baseVersion = fileVersion(PAGE);
+    const { byId, rootId } = await nodeIndex(PAGE);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[0]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/pages/Hero.astro" } };
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+
+  it("refuses invalid-input when extracting the component's root", async () => {
+    const baseVersion = fileVersion(PAGE);
+    const { rootId } = await nodeIndex(PAGE);
+    // rootId IS a real byId entry (the synthetic fragment root, parentId: null) — resolveComponentExtract's
+    // parentId === null check refuses it as invalid-input, same as remove-node's "cannot remove the
+    // component's root" rule. Extracting a real top-level node like <main> is unaffected by this check
+    // (its own parentId is rootId, not null) — already exercised by the "extracts a subtree..." test below,
+    // which extracts the doubly-nested <div>.
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: rootId, newComponentPath: "src/components/Hero.astro" } };
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+
+  it("refuses no-match when the nodeId no longer exists", async () => {
+    const baseVersion = fileVersion(PAGE);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: "n999", newComponentPath: "src/components/Hero.astro" } };
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("no-match");
+  });
+
+  it("refuses exists when newComponentPath already has a file on disk", async () => {
+    writeFileSync(join(tmpDir, "src", "components", "Hero.astro"), "<p>taken</p>\n");
+    const baseVersion = fileVersion(PAGE);
+    const { byId, rootId } = await nodeIndex(PAGE);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[0]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("exists");
+  });
+
+  it("extracts a subtree with no outer references into a new file and leaves a self-closing instance behind", async () => {
+    const baseVersion = fileVersion(PAGE);
+    const { byId, rootId } = await nodeIndex(PAGE);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[0]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    expect(result.newFile.path).toBe("src/components/Hero.astro");
+    expect(result.newFile.content).toContain('<div class="hero">');
+    expect(result.newFile.content).toContain("<h1>Welcome</h1>");
+    expect(result.hoistedProps).toEqual([]);
+    expect(result.warnings).toEqual([]);
+
+    const next = result.replacement; // whole-file rewrite: range covers [0, source.length]
+    expect(result.range).toEqual({ start: 0, end: PAGE.length });
+    expect(next).toContain("<Hero />");
+    expect(next).not.toContain('<div class="hero">');
+    expect(next).toMatch(/import Hero from "\.\/Hero\.astro";/);
+  });
+
+  it("refuses invalid-input for a text-kind node", async () => {
+    const source = `---\n---\n<p>plain text</p>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+    const baseVersion = fileVersion(source);
+    const { byId, rootId } = await nodeIndex(source);
+    const p = byId.get(byId.get(rootId).childIds[0]);
+    const textNode = byId.get(p.childIds[0]);
+    expect(textNode.kind).toBe("text");
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: textNode.id, newComponentPath: "src/components/Hero.astro" } };
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/component-extract-edit.test.ts`
+Expected: FAIL — `server/component-extract-edit.mjs` does not exist.
+
+- [ ] **Step 3: Implement**
+
+```js
+// server/component-extract-edit.mjs
+import { readFileSync, existsSync } from "node:fs";
+import { join, normalize, basename, sep } from "node:path";
+import { parse } from "@astrojs/compiler";
+import { fileVersion } from "./file-version.mjs";
+import { buildTemplateNodeIndex } from "./component-node-index.mjs";
+import { resolveAllSpans, SpanResolutionError, importSpecifier } from "./component-structure-edit.mjs";
+import { ensureImport } from "./frontmatter-imports.mjs";
+
+/**
+ * Write-side resolver for extract-component (Component Editor Slice 5). Unlike every other
+ * component op, this one touches TWO files: it carves `nodeId`'s subtree out of the target
+ * component into a brand-new file at `newComponentPath`, and replaces the subtree in the
+ * original with a self-closing instance + import. Returns the widened
+ * `{file, range, replacement, newFile, hoistedProps, warnings}` shape apply-edit-dispatcher.mjs
+ * knows how to write as one atomic two-file edit (see docs/superpowers/specs/
+ * 2026-07-16-extract-component-design.md).
+ */
+
+function refuse(reason, detail) {
+  return { refused: true, reason, detail };
+}
+
+function validComponentPath(relPath) {
+  return typeof relPath === "string" && relPath.endsWith(".astro") && !normalize(relPath).startsWith("..") && !relPath.startsWith("/");
+}
+
+function validNewComponentPath(relPath) {
+  if (!validComponentPath(relPath)) return false;
+  const normalized = normalize(relPath).split(sep).join("/");
+  return normalized.startsWith("src/components/");
+}
+
+async function loadFresh(projectRoot, relPath, baseVersion) {
+  const absPath = join(projectRoot, relPath);
+  let source;
+  try {
+    source = readFileSync(absPath, "utf-8");
+  } catch (err) {
+    return { error: refuse("read-failed", `read ${relPath}: ${err.message}`) };
+  }
+  if (fileVersion(source) !== baseVersion) {
+    return { error: refuse("stale", `${relPath} changed since the model was fetched`) };
+  }
+  let ast;
+  try {
+    ({ ast } = await parse(source, { position: true }));
+  } catch (err) {
+    return { error: refuse("parse-failed", `parse ${relPath}: ${err.message}`) };
+  }
+  const { byId, rootId, astById } = buildTemplateNodeIndex(ast, source);
+  return { source, ast, byId, rootId, astById };
+}
+
+function rewriteOriginalFrontmatter(afterNode, relPath, componentName, newComponentPath) {
+  const fmMatch = afterNode.match(/^(---\r?\n)([\s\S]*?)(\r?\n---)/);
+  const specifier = importSpecifier(relPath, newComponentPath);
+  if (fmMatch) {
+    const [, open, fmBody] = fmMatch;
+    const fmBodyStart = fmMatch.index + open.length;
+    const { source: newFmBody } = ensureImport(fmBody, { localName: componentName, specifier });
+    return afterNode.slice(0, fmBodyStart) + newFmBody + afterNode.slice(fmBodyStart + fmBody.length);
+  }
+  const importLine = `import ${componentName} from "${specifier}";\n`;
+  return `---\n${importLine}---\n${afterNode}`;
+}
+
+export async function resolveComponentExtract(projectRoot, edit) {
+  const { component } = edit;
+  if (!component || typeof component !== "object") {
+    return refuse("invalid-input", "component payload is required for this op");
+  }
+  const { path: relPath, baseVersion, nodeId, newComponentPath } = component;
+  if (!validComponentPath(relPath)) {
+    return refuse("invalid-input", `not a project-relative .astro path: ${relPath}`);
+  }
+  if (typeof nodeId !== "string") {
+    return refuse("invalid-input", "extract-component requires component.nodeId");
+  }
+  if (!validNewComponentPath(newComponentPath)) {
+    return refuse("invalid-input", `newComponentPath must be a project-relative .astro path under src/components/: ${newComponentPath}`);
+  }
+
+  const loaded = await loadFresh(projectRoot, relPath, baseVersion);
+  if (loaded.error) return loaded.error;
+  const { source, byId, rootId } = loaded;
+
+  const node = byId.get(nodeId);
+  if (!node) return refuse("no-match", "no node found at the given id — the file may have changed");
+  if (node.parentId === null) return refuse("invalid-input", "cannot extract the component's root");
+  if (node.kind !== "element" && node.kind !== "component" && node.kind !== "slot") {
+    return refuse("invalid-input", `extract-component requires a tag-shaped node (element/component/slot), got kind=${node.kind}`);
+  }
+
+  if (existsSync(join(projectRoot, newComponentPath))) {
+    return refuse("exists", `${newComponentPath} already exists`);
+  }
+
+  let spans;
+  try {
+    spans = resolveAllSpans(byId, rootId, source);
+  } catch (err) {
+    if (!(err instanceof SpanResolutionError)) throw err;
+    return refuse(
+      "no-match",
+      "could not lexically re-locate the node's true source span without trusting compiler offsets — refusing rather than risking corruption",
+    );
+  }
+  const nodeSpan = spans.get(nodeId);
+  if (!nodeSpan) {
+    return refuse(
+      "no-match",
+      "could not lexically re-locate the node's true source span without trusting compiler offsets — refusing rather than risking corruption",
+    );
+  }
+
+  const subtreeText = source.slice(nodeSpan[0], nodeSpan[1]);
+  const componentName = basename(newComponentPath, ".astro");
+
+  const instanceTag = `<${componentName} />`;
+  const afterNode = source.slice(0, nodeSpan[0]) + instanceTag + source.slice(nodeSpan[1]);
+  const afterImport = rewriteOriginalFrontmatter(afterNode, relPath, componentName, newComponentPath);
+
+  return {
+    file: relPath,
+    range: { start: 0, end: source.length },
+    replacement: afterImport,
+    newFile: { path: newComponentPath, content: `${subtreeText}\n` },
+    hoistedProps: [],
+    warnings: [],
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/component-extract-edit.test.ts`
+Expected: PASS (all 8 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/component-extract-edit.mjs tests/component-extract-edit.test.ts
+git commit -m "feat(mcp): add component-extract-edit core resolver (plain subtree move)"
+```
+
+---
+
+### Task 4: Prop hoisting
+
+Extends `resolveComponentExtract` to hoist bare-identifier expressions that are the *original* component's own declared Props (spec §4).
+
+**Files:**
+- Modify: `server/component-extract-edit.mjs`
+- Test: `tests/component-extract-edit.test.ts` (add cases)
+
+**Interfaces:**
+- Consumes: `parseProps`, `generatePropsInterface`, `generatePropsDestructure` (`props-interface.mjs`); `astById` (Task 2).
+- Produces: `resolveComponentExtract`'s `hoistedProps` is now populated; the instance tag carries hoisted-prop attributes; the new file gets a Props interface/destructure.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// tests/component-extract-edit.test.ts — add to the same describe block
+it("hoists a bare-identifier attribute expression that is one of the original's own Props", async () => {
+  const source = `---\ninterface Props { title: string; }\nconst { title } = Astro.props;\n---\n<main>\n  <div class="hero" data-label={title}>\n    <h1>Static</h1>\n  </div>\n</main>\n`;
+  writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+  const baseVersion = fileVersion(source);
+  const { byId, rootId } = await nodeIndex(source);
+  const main = byId.get(byId.get(rootId).childIds[0]);
+  const div = byId.get(main.childIds[0]);
+  const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+  const result = await resolveComponentExtract(tmpDir, edit);
+  expect(result.refused).toBeFalsy();
+  expect(result.hoistedProps).toEqual(["title"]);
+  expect(result.newFile.content).toContain("interface Props {\n  title: string;\n}");
+  expect(result.newFile.content).toContain("const { title } = Astro.props;");
+  expect(result.replacement).toContain("<Hero title={title} />");
+});
+
+it("hoists a bare-identifier text-content expression that is one of the original's own Props", async () => {
+  const source = `---\ninterface Props { title: string; }\nconst { title } = Astro.props;\n---\n<main>\n  <div class="hero">\n    <h1>{title}</h1>\n  </div>\n</main>\n`;
+  writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+  const baseVersion = fileVersion(source);
+  const { byId, rootId } = await nodeIndex(source);
+  const main = byId.get(byId.get(rootId).childIds[0]);
+  const div = byId.get(main.childIds[0]);
+  const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+  const result = await resolveComponentExtract(tmpDir, edit);
+  expect(result.hoistedProps).toEqual(["title"]);
+  expect(result.newFile.content).toContain("<h1>{title}</h1>");
+});
+
+it("does not hoist a bare identifier that is not one of the original's own Props", async () => {
+  const source = `---\nconst label = "computed";\n---\n<main>\n  <div class="hero">\n    <h1>{label}</h1>\n  </div>\n</main>\n`;
+  writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+  const baseVersion = fileVersion(source);
+  const { byId, rootId } = await nodeIndex(source);
+  const main = byId.get(byId.get(rootId).childIds[0]);
+  const div = byId.get(main.childIds[0]);
+  const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+  const result = await resolveComponentExtract(tmpDir, edit);
+  expect(result.hoistedProps).toEqual([]);
+  expect(result.newFile.content).toContain("<h1>{label}</h1>"); // left in place, unhoisted
+  expect(result.newFile.content).not.toContain("interface Props");
+});
+
+it("does not hoist a non-bare-identifier expression even when it references an original Prop", async () => {
+  const source = `---\ninterface Props { title: string; }\nconst { title } = Astro.props;\n---\n<main>\n  <div class="hero">\n    <h1>{title.toUpperCase()}</h1>\n  </div>\n</main>\n`;
+  writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+  const baseVersion = fileVersion(source);
+  const { byId, rootId } = await nodeIndex(source);
+  const main = byId.get(byId.get(rootId).childIds[0]);
+  const div = byId.get(main.childIds[0]);
+  const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+  const result = await resolveComponentExtract(tmpDir, edit);
+  expect(result.hoistedProps).toEqual([]);
+  expect(result.newFile.content).toContain("<h1>{title.toUpperCase()}</h1>");
+});
+
+it("dedups the same identifier referenced twice into one hoisted prop", async () => {
+  const source = `---\ninterface Props { title: string; }\nconst { title } = Astro.props;\n---\n<main>\n  <div class="hero" data-label={title}>\n    <h1>{title}</h1>\n  </div>\n</main>\n`;
+  writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+  const baseVersion = fileVersion(source);
+  const { byId, rootId } = await nodeIndex(source);
+  const main = byId.get(byId.get(rootId).childIds[0]);
+  const div = byId.get(main.childIds[0]);
+  const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+  const result = await resolveComponentExtract(tmpDir, edit);
+  expect(result.hoistedProps).toEqual(["title"]);
+  expect(result.replacement.match(/title=\{title\}/g)).toHaveLength(1); // one instance attr, not two
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/component-extract-edit.test.ts`
+Expected: FAIL — `hoistedProps` stays `[]`, instance tag has no attrs, new file has no Props interface.
+
+- [ ] **Step 3: Implement**
+
+Add these imports and helpers to `server/component-extract-edit.mjs`, and rewire `resolveComponentExtract`'s body between `spans`/`nodeSpan` resolution and the `instanceTag`/`afterNode` construction:
+
+```js
+// add to the top-of-file imports
+import { parseProps, generatePropsInterface, generatePropsDestructure } from "./props-interface.mjs";
+```
+
+```js
+const BARE_IDENTIFIER_RE = /^[A-Za-z_$][\w$]*$/;
+const FRONTMATTER_RE = /^(---\r?\n)([\s\S]*?)(\r?\n---)/;
+
+function collectSubtreeIds(byId, nodeId) {
+  const ids = [];
+  (function walk(id) {
+    ids.push(id);
+    for (const c of byId.get(id).childIds) walk(c);
+  })(nodeId);
+  return ids;
+}
+
+/**
+ * Bare-identifier expressions (attribute values AND text-content expression children)
+ * inside the subtree whose name is one of the original component's own declared Props.
+ * Anything else — a non-identifier expression, or an identifier that isn't an original
+ * Prop — is left alone; see the Global Constraints note on hoisting scope. Returns prop
+ * records sorted by name (the module's `props` shape: {name, type, optional, default}).
+ */
+function findHoistCandidates(byId, astById, subtreeIds, spans, source, originalProps) {
+  const ownProps = new Map(originalProps.map((p) => [p.name, p]));
+  const hoisted = new Map();
+
+  function consider(text) {
+    const trimmed = text.trim();
+    if (!BARE_IDENTIFIER_RE.test(trimmed)) return;
+    const prop = ownProps.get(trimmed);
+    if (prop) hoisted.set(trimmed, { name: prop.name, type: prop.type, optional: prop.optional, default: null });
+  }
+
+  for (const id of subtreeIds) {
+    const node = byId.get(id);
+    const astNode = astById.get(id);
+    if (astNode && Array.isArray(astNode.attributes)) {
+      for (const a of astNode.attributes) {
+        if (a.kind === "expression") consider(a.value ?? "");
+      }
+    }
+    if (node.kind === "expression") {
+      const span = spans.get(id);
+      if (span) consider(source.slice(span[0], span[1]).replace(/^\{/, "").replace(/\}$/, ""));
+    }
+  }
+  return [...hoisted.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+```
+
+In `resolveComponentExtract`, right after `nodeSpan`/`subtreeText` are resolved and before building `instanceTag`, insert:
+
+```js
+  const origFmMatch = source.match(FRONTMATTER_RE);
+  const originalProps = origFmMatch ? parseProps(origFmMatch[2]) : [];
+  const subtreeIds = collectSubtreeIds(byId, nodeId);
+  const hoistedPropRecords = findHoistCandidates(byId, loaded.astById, subtreeIds, spans, source, originalProps);
+```
+
+Replace the `instanceTag`/`newFile.content` construction with:
+
+```js
+  const instanceAttrs = hoistedPropRecords.map((p) => ` ${p.name}={${p.name}}`).join("");
+  const instanceTag = `<${componentName}${instanceAttrs} />`;
+  const afterNode = source.slice(0, nodeSpan[0]) + instanceTag + source.slice(nodeSpan[1]);
+  const afterImport = rewriteOriginalFrontmatter(afterNode, relPath, componentName, newComponentPath);
+
+  const propsInterface = generatePropsInterface(hoistedPropRecords);
+  const propsDestructure = generatePropsDestructure(hoistedPropRecords);
+  const fmParts = [propsInterface, propsDestructure].filter(Boolean);
+  const newFm = fmParts.length ? `---\n${fmParts.join("\n")}\n---\n` : "";
+
+  return {
+    file: relPath,
+    range: { start: 0, end: source.length },
+    replacement: afterImport,
+    newFile: { path: newComponentPath, content: `${newFm}${subtreeText}\n` },
+    hoistedProps: hoistedPropRecords.map((p) => p.name),
+    warnings: [],
+  };
+```
+
+(`loaded.astById` requires `loadFresh`'s destructure at the top of the function to keep `astById` — change `const { source, byId, rootId } = loaded;` to `const { source, byId, rootId, astById } = loaded;` and use `astById` directly in place of `loaded.astById` above for consistency with the rest of the function's naming.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/component-extract-edit.test.ts`
+Expected: PASS (13 tests total)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/component-extract-edit.mjs tests/component-extract-edit.test.ts
+git commit -m "feat(mcp): hoist bare-identifier own-Props references in extract-component"
+```
+
+---
+
+### Task 5: Nested-component import copying + prune-if-unused
+
+When the extracted subtree contains a component-kind descendant (e.g. `<Badge />` inside the extracted `<Hero>` markup), that import must move: copied into the new file's frontmatter (re-based to the new file's directory), and pruned from the original's frontmatter if it's no longer used anywhere in what remains.
+
+**Files:**
+- Modify: `server/component-extract-edit.mjs`
+- Test: `tests/component-extract-edit.test.ts` (add cases)
+
+**Interfaces:**
+- Consumes: `collectComponentTags` (Task 2, `component-structure-edit.mjs`); `parseImports`, `pruneImportIfUnused` (`frontmatter-imports.mjs`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// tests/component-extract-edit.test.ts — add to the same describe block
+it("copies a nested component's import into the new file, re-based to its directory, and prunes it from the original when unused elsewhere", async () => {
+  const source = `---\nimport Badge from "./Badge.astro";\n---\n<main>\n  <div class="hero">\n    <Badge />\n  </div>\n</main>\n`;
+  writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+  writeFileSync(join(tmpDir, "src", "components", "Badge.astro"), "<span>Badge</span>\n");
+  const baseVersion = fileVersion(source);
+  const { byId, rootId } = await nodeIndex(source);
+  const main = byId.get(byId.get(rootId).childIds[0]);
+  const div = byId.get(main.childIds[0]);
+  const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+  const result = await resolveComponentExtract(tmpDir, edit);
+  expect(result.refused).toBeFalsy();
+  expect(result.newFile.content).toMatch(/import Badge from "\.\/Badge\.astro";/);
+  expect(result.newFile.content).toContain("<Badge />");
+  expect(result.replacement).not.toContain("import Badge"); // pruned — no longer used in the original
+  expect(result.replacement).toMatch(/import Hero from "\.\/Hero\.astro";/);
+});
+
+it("keeps a nested component's import in the original when it's also used outside the extracted subtree", async () => {
+  const source = `---\nimport Badge from "./Badge.astro";\n---\n<main>\n  <Badge />\n  <div class="hero">\n    <Badge />\n  </div>\n</main>\n`;
+  writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+  writeFileSync(join(tmpDir, "src", "components", "Badge.astro"), "<span>Badge</span>\n");
+  const baseVersion = fileVersion(source);
+  const { byId, rootId } = await nodeIndex(source);
+  const main = byId.get(byId.get(rootId).childIds[0]);
+  const div = byId.get(main.childIds[1]);
+  const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+  const result = await resolveComponentExtract(tmpDir, edit);
+  expect(result.replacement).toMatch(/import Badge from "\.\/Badge\.astro";/); // still needed for the sibling <Badge />
+  expect(result.newFile.content).toMatch(/import Badge from "\.\/Badge\.astro";/); // also copied — extracted one still needs it
+});
+
+it("re-bases a nested component's relative import specifier for a new file in a different directory", async () => {
+  mkdirSync(join(tmpDir, "src", "components", "sections"), { recursive: true });
+  const source = `---\nimport Badge from "../Badge.astro";\n---\n<main>\n  <div class="hero">\n    <Badge />\n  </div>\n</main>\n`;
+  writeFileSync(join(tmpDir, "src", "components", "sections", "Page.astro"), source);
+  writeFileSync(join(tmpDir, "src", "components", "Badge.astro"), "<span>Badge</span>\n");
+  const baseVersion = fileVersion(source);
+  const { byId, rootId } = await nodeIndex(source);
+  const main = byId.get(byId.get(rootId).childIds[0]);
+  const div = byId.get(main.childIds[0]);
+  const edit = { op: "extract-component", component: { path: "src/components/sections/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+  const result = await resolveComponentExtract(tmpDir, edit);
+  // Hero.astro lives directly under src/components/, so its import of Badge.astro (a sibling) is "./Badge.astro",
+  // not the "../Badge.astro" that was correct from sections/Page.astro's own directory.
+  expect(result.newFile.content).toMatch(/import Badge from "\.\/Badge\.astro";/);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/component-extract-edit.test.ts`
+Expected: FAIL — new file has no `Badge` import; original still has it unconditionally.
+
+- [ ] **Step 3: Implement**
+
+Add to the imports:
+
+```js
+import { collectComponentTags } from "./component-structure-edit.mjs";
+import { parseImports, pruneImportIfUnused } from "./frontmatter-imports.mjs";
+```
+
+Add a helper that re-bases a relative import specifier from one file's directory to another's:
+
+```js
+import { dirname, relative } from "node:path";
+
+function resolveImportTargetPath(originalRelPath, specifier) {
+  const abs = normalize(join(dirname(originalRelPath), specifier));
+  return abs.split(sep).join("/");
+}
+
+function importLinesForNewFile(originalFmBody, movedComponentNames, relPath, newComponentPath) {
+  const origImports = parseImports(originalFmBody ?? "");
+  return movedComponentNames
+    .map((name) => origImports.find((i) => i.localName === name))
+    .filter(Boolean)
+    .map((imp) => {
+      const targetRelPath = resolveImportTargetPath(relPath, imp.specifier);
+      return `import ${imp.localName} from "${importSpecifier(newComponentPath, targetRelPath)}";\n`;
+    })
+    .join("");
+}
+```
+
+Change `rewriteOriginalFrontmatter` to also prune now-unused moved-component imports:
+
+```js
+function rewriteOriginalFrontmatter(afterNode, relPath, componentName, newComponentPath, movedComponentNames) {
+  const fmMatch = afterNode.match(FRONTMATTER_RE);
+  const specifier = importSpecifier(relPath, newComponentPath);
+  const ensureAndPrune = (fmBody) => {
+    let body = ensureImport(fmBody, { localName: componentName, specifier }).source;
+    for (const name of movedComponentNames) {
+      body = pruneImportIfUnused(body, afterNode, name).source;
+    }
+    return body;
+  };
+  if (fmMatch) {
+    const [, open, fmBody] = fmMatch;
+    const fmBodyStart = fmMatch.index + open.length;
+    const newFmBody = ensureAndPrune(fmBody);
+    return afterNode.slice(0, fmBodyStart) + newFmBody + afterNode.slice(fmBodyStart + fmBody.length);
+  }
+  const importLine = `import ${componentName} from "${specifier}";\n`;
+  return `---\n${importLine}---\n${afterNode}`;
+}
+```
+
+In `resolveComponentExtract`, compute `movedComponentNames` alongside `hoistedPropRecords` and thread it through:
+
+```js
+  const movedComponentNames = collectComponentTags(byId, nodeId);
+```
+
+Update the call site: `rewriteOriginalFrontmatter(afterNode, relPath, componentName, newComponentPath, movedComponentNames)`.
+
+Update the new file's frontmatter assembly to include the copied import lines:
+
+```js
+  const importLines = importLinesForNewFile(origFmMatch ? origFmMatch[2] : "", movedComponentNames, relPath, newComponentPath);
+  const propsInterface = generatePropsInterface(hoistedPropRecords);
+  const propsDestructure = generatePropsDestructure(hoistedPropRecords);
+  const fmParts = [importLines ? importLines.trimEnd() : null, propsInterface, propsDestructure].filter(Boolean);
+  const newFm = fmParts.length ? `---\n${fmParts.join("\n")}\n---\n` : "";
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/component-extract-edit.test.ts`
+Expected: PASS (16 tests total)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/component-extract-edit.mjs tests/component-extract-edit.test.ts
+git commit -m "feat(mcp): copy/prune nested-component imports in extract-component"
+```
+
+---
+
+### Task 6: Style-rule migration
+
+Migrates simple-selector rules that exclusively target the extracted subtree; leaves shared or complex-selector rules behind with a `warnings` entry (spec §5).
+
+**Files:**
+- Modify: `server/component-extract-edit.mjs`
+- Test: `tests/component-extract-edit.test.ts` (add cases)
+
+**Interfaces:**
+- Consumes: `isSimpleSelector`, `selectorMatchesNode` (Task 1); `collectElements` (Task 2, `component-model.mjs`); `indexCssRules` (`css-rule-index.mjs`); `buildLineStarts` (`component-node-index.mjs`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// tests/component-extract-edit.test.ts — add to the same describe block
+it("moves a simple-selector rule that only targets nodes inside the extracted subtree", async () => {
+  const source = `---\n---\n<main>\n  <div class="hero">\n    <h1>Hi</h1>\n  </div>\n</main>\n<style>\n  .hero {\n    color: blue;\n  }\n</style>\n`;
+  writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+  const baseVersion = fileVersion(source);
+  const { byId, rootId } = await nodeIndex(source);
+  const main = byId.get(byId.get(rootId).childIds[0]);
+  const div = byId.get(main.childIds[0]);
+  const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+  const result = await resolveComponentExtract(tmpDir, edit);
+  expect(result.warnings).toEqual([]);
+  expect(result.newFile.content).toContain(".hero {\n    color: blue;\n  }");
+  expect(result.replacement).not.toContain("color: blue");
+  // The rule's own text is gone, but removeMovedRules only strips the {...} block it matched —
+  // it does not clean up a now-empty surrounding <style></style> shell (documented limitation,
+  // see the note under Step 3 below). Assert the shell is empty rather than asserting it's gone.
+  expect(result.replacement).toMatch(/<style>\s*<\/style>/);
+});
+
+it("keeps a simple-selector rule in the original and reports a warning when it's also used outside the extracted subtree", async () => {
+  const source = `---\n---\n<main>\n  <p class="hero">Outside</p>\n  <div class="hero">\n    <h1>Hi</h1>\n  </div>\n</main>\n<style>\n  .hero {\n    color: blue;\n  }\n</style>\n`;
+  writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+  const baseVersion = fileVersion(source);
+  const { byId, rootId } = await nodeIndex(source);
+  const main = byId.get(byId.get(rootId).childIds[0]);
+  const div = byId.get(main.childIds[1]);
+  const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+  const result = await resolveComponentExtract(tmpDir, edit);
+  expect(result.warnings).toEqual([".hero not moved: also used outside the extracted markup"]);
+  expect(result.replacement).toContain("color: blue"); // stays in the original
+  expect(result.newFile.content).not.toContain("<style>");
+});
+
+it("keeps a complex-selector rule in the original and reports a warning", async () => {
+  const source = `---\n---\n<main>\n  <div class="hero">\n    <h1>Hi</h1>\n  </div>\n</main>\n<style>\n  .hero > h1 {\n    color: blue;\n  }\n</style>\n`;
+  writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+  const baseVersion = fileVersion(source);
+  const { byId, rootId } = await nodeIndex(source);
+  const main = byId.get(byId.get(rootId).childIds[0]);
+  const div = byId.get(main.childIds[0]);
+  const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+  const result = await resolveComponentExtract(tmpDir, edit);
+  expect(result.warnings).toEqual([".hero > h1 not moved: selector too complex to analyze automatically"]);
+  expect(result.replacement).toContain("color: blue");
+});
+
+it("splits a media-query block when only some of its rules move", async () => {
+  const source = `---\n---\n<main>\n  <p class="kept">Kept</p>\n  <div class="hero">\n    <h1>Hi</h1>\n  </div>\n</main>\n<style>\n  @media (min-width: 40em) {\n    .hero {\n      color: blue;\n    }\n    .kept {\n      color: red;\n    }\n  }\n</style>\n`;
+  writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+  const baseVersion = fileVersion(source);
+  const { byId, rootId } = await nodeIndex(source);
+  const main = byId.get(byId.get(rootId).childIds[0]);
+  const div = byId.get(main.childIds[1]);
+  const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+  const result = await resolveComponentExtract(tmpDir, edit);
+  expect(result.warnings).toEqual([]);
+  expect(result.newFile.content).toMatch(/@media \(min-width: 40em\)[\s\S]*\.hero[\s\S]*color: blue/);
+  expect(result.replacement).toMatch(/@media \(min-width: 40em\)[\s\S]*\.kept[\s\S]*color: red/);
+  expect(result.replacement).not.toContain(".hero");
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/component-extract-edit.test.ts`
+Expected: FAIL — `warnings` stays `[]` even for complex/shared selectors, and no rules ever move.
+
+- [ ] **Step 3: Implement**
+
+Add to the imports:
+
+```js
+import { collectElements } from "./component-model.mjs";
+import { indexCssRules } from "./css-rule-index.mjs";
+import { buildLineStarts } from "./component-node-index.mjs";
+import { isSimpleSelector, selectorMatchesNode } from "./style-selector-match.mjs";
+```
+
+Add the classification and rule-text helpers:
+
+```js
+function anyNodeMatches(byId, nodeIds, selector) {
+  return nodeIds.some((id) => selectorMatchesNode(selector, byId.get(id)));
+}
+
+/**
+ * `selectorMatchesNode` (Task 1) returns false outright for any non-simple selector — it
+ * doesn't understand combinators, so it can't itself tell whether a complex selector like
+ * ".hero > h1" "touches" the subtree. For the complex-selector warning we don't need real
+ * combinator matching, just a signal of "plausibly related to this subtree" — so split on
+ * whitespace/combinators, strip pseudo-classes/attribute-selector brackets, and check whether
+ * any resulting SIMPLE token matches a subtree node. ".hero > h1" tokenizes to [".hero", "h1"];
+ * either one matching the extracted <div class="hero"> is enough to warn.
+ */
+function selectorTouchesNodes(selector, byId, nodeIds) {
+  const tokens = selector
+    .split(/[\s>+~]+/)
+    .map((tok) => tok.replace(/:[\w-]+(\([^)]*\))?/g, "").replace(/\[[^\]]*\]/g, ""))
+    .filter(Boolean);
+  return tokens.some((tok) => isSimpleSelector(tok) && anyNodeMatches(byId, nodeIds, tok));
+}
+
+/** Splits `rules` into ones to move (simple selector, exclusively inside the subtree) and
+ *  warnings for everything else that touches the subtree but can't safely move. */
+function classifyStyleRules(byId, subtreeIds, outsideIds, rules) {
+  const toMove = [];
+  const warnings = [];
+  for (const rule of rules) {
+    if (!isSimpleSelector(rule.selector)) {
+      if (selectorTouchesNodes(rule.selector, byId, subtreeIds)) {
+        warnings.push(`${rule.selector} not moved: selector too complex to analyze automatically`);
+      }
+      continue;
+    }
+    const insideMatch = anyNodeMatches(byId, subtreeIds, rule.selector);
+    if (!insideMatch) continue;
+    if (anyNodeMatches(byId, outsideIds, rule.selector)) {
+      warnings.push(`${rule.selector} not moved: also used outside the extracted markup`);
+      continue;
+    }
+    toMove.push(rule);
+  }
+  return { toMove, warnings };
+}
+
+function sameRule(a, b) {
+  return a.selector === b.selector && a.media === b.media && JSON.stringify(a.declarations) === JSON.stringify(b.declarations);
+}
+
+function removeRuleSpan(text, span) {
+  let start = span[0];
+  while (start > 0 && (text[start - 1] === " " || text[start - 1] === "\t")) start--;
+  if (start > 0 && text[start - 1] === "\n") start--;
+  return text.slice(0, start) + text.slice(span[1]);
+}
+
+/** Removes each `toMove` rule from `text` one at a time, re-parsing/re-indexing fresh before
+ *  each removal (rather than composing stale offsets) — the same "never trust a stale offset,
+ *  always re-derive against the current string" discipline the rest of this codebase uses. */
+async function removeMovedRules(text, toMove) {
+  let current = text;
+  for (const target of toMove) {
+    const { ast } = await parse(current, { position: true });
+    const lineStarts = buildLineStarts(current);
+    const styleEls = [];
+    collectElements(ast, "style", styleEls);
+    const rules = styleEls.flatMap((el) => indexCssRules(el, lineStarts));
+    const match = rules.find((r) => sameRule(r, target));
+    if (!match) continue; // defensive: rule text/media/declarations are stable across re-parses
+    current = removeRuleSpan(current, match.span);
+  }
+  return current;
+}
+
+function indent(text) {
+  return text.split("\n").map((l) => (l ? "  " + l : l)).join("\n");
+}
+
+function buildMovedStyleBlock(source, toMove) {
+  if (toMove.length === 0) return "";
+  const byMedia = new Map();
+  for (const rule of toMove) {
+    const key = rule.media ?? "";
+    if (!byMedia.has(key)) byMedia.set(key, []);
+    byMedia.get(key).push(rule);
+  }
+  const blocks = [];
+  for (const [media, rules] of byMedia) {
+    const ruleTexts = rules.map((r) => source.slice(r.span[0], r.span[1])).join("\n\n");
+    blocks.push(media ? `@media ${media} {\n${indent(ruleTexts)}\n}` : ruleTexts);
+  }
+  return `\n<style>\n${blocks.join("\n\n")}\n</style>\n`;
+}
+```
+
+Note: `removeMovedRules` only removes each rule's own `{...}` block. It never cleans up a now-possibly-empty surrounding `@media (...) {}` wrapper, nor a now-possibly-empty `<style></style>` shell when the moved rule was the only one in that `<style>` block — that's a documented, harmless known limitation (valid, inert CSS/markup left behind), not a correctness bug; cleaning it up is out of scope (see spec §5's non-goals on not building a general CSS engine).
+
+In `resolveComponentExtract`, after `subtreeIds` is computed, add the outside-id set and rule classification:
+
+```js
+  const outsideIds = [...byId.keys()].filter((id) => id !== rootId && !subtreeIds.includes(id));
+  const styleElements = [];
+  collectElements(loaded.ast, "style", styleElements);
+  const lineStarts = buildLineStarts(source);
+  const allRules = styleElements.flatMap((el) => indexCssRules(el, lineStarts));
+  const { toMove, warnings } = classifyStyleRules(byId, subtreeIds, outsideIds, allRules);
+```
+
+(`loaded.ast` requires keeping `ast` in `loadFresh`'s returned/destructured object — change `const { source, byId, rootId, astById } = loaded;` to also keep `loaded.ast`, or destructure `ast` too: `const { source, ast, byId, rootId, astById } = loaded;`.)
+
+Change the function's final return to route the primary replacement through `removeMovedRules` and append the moved style block to the new file, and thread real `warnings` through instead of `[]`:
+
+```js
+  const finalReplacement = await removeMovedRules(afterImport, toMove);
+  const styleBlock = buildMovedStyleBlock(source, toMove);
+
+  return {
+    file: relPath,
+    range: { start: 0, end: source.length },
+    replacement: finalReplacement,
+    newFile: { path: newComponentPath, content: `${newFm}${subtreeText}\n${styleBlock}` },
+    hoistedProps: hoistedPropRecords.map((p) => p.name),
+    warnings,
+  };
+```
+
+(`resolveComponentExtract` is now `async` at its outermost call already — no change needed there — but the new `await removeMovedRules(...)` call means this must run inside the existing `async function resolveComponentExtract`, which it already is.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/component-extract-edit.test.ts`
+Expected: PASS (20 tests total)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/component-extract-edit.mjs tests/component-extract-edit.test.ts
+git commit -m "feat(mcp): migrate simple-selector style rules in extract-component"
+```
+
+---
+
+### Task 7: Wire `apply-edit-schema.mjs`
+
+**Files:**
+- Modify: `server/apply-edit-schema.mjs`
+- Test: `tests/apply-edit-schema-extract.test.ts`
+
+**Interfaces:**
+- Produces: `"extract-component"` added to `editOps`; new `COMPONENT_EXTRACT_OPS` set, folded into `COMPONENT_OPS`; `componentEditSchema.newComponentPath`; `createEditPreviewContent`'s new optional `newFile` param.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// tests/apply-edit-schema-extract.test.ts
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import {
+  editOps,
+  componentEditSchema,
+  applyEditInputShape,
+  COMPONENT_EXTRACT_OPS,
+  COMPONENT_OPS,
+  createEditPreviewContent,
+} from "../server/apply-edit-schema.mjs";
+
+describe("extract-component schema", () => {
+  it("registers extract-component in editOps, COMPONENT_EXTRACT_OPS, and COMPONENT_OPS", () => {
+    expect(editOps).toContain("extract-component");
+    expect(COMPONENT_EXTRACT_OPS.has("extract-component")).toBe(true);
+    expect(COMPONENT_OPS.has("extract-component")).toBe(true);
+  });
+
+  it("accepts an extract-component payload with nodeId and newComponentPath", () => {
+    const result = componentEditSchema.safeParse({
+      path: "src/components/Page.astro",
+      baseVersion: "sha256:abc123456789",
+      nodeId: "n3",
+      newComponentPath: "src/components/Hero.astro",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a full apply_edit input for extract-component", () => {
+    const schema = z.object(applyEditInputShape);
+    const result = schema.safeParse({
+      id: "1",
+      path: "src/components/Page.astro",
+      op: "extract-component",
+      component: { path: "src/components/Page.astro", baseVersion: "sha256:abc123456789", nodeId: "n3", newComponentPath: "src/components/Hero.astro" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("createEditPreviewContent includes newFile when provided, omits it otherwise", () => {
+    const withNewFile = JSON.parse(createEditPreviewContent("1", "a.astro", { start: 0, end: 1 }, "extract-component", "before", "after", { path: "b.astro", after: "content" }).text);
+    expect(withNewFile.newFile).toEqual({ path: "b.astro", after: "content" });
+
+    const without = JSON.parse(createEditPreviewContent("1", "a.astro", { start: 0, end: 1 }, "set-attr", "before", "after").text);
+    expect(without.newFile).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/apply-edit-schema-extract.test.ts`
+Expected: FAIL — `extract-component` not in `editOps`, `COMPONENT_EXTRACT_OPS` undefined, `newComponentPath` rejected, `createEditPreviewContent` ignores its 7th arg.
+
+- [ ] **Step 3: Implement**
+
+In `server/apply-edit-schema.mjs`:
+
+```js
+export const editOps = [
+  "replace-text",
+  "replace-attr",
+  "replace-image-src",
+  "edit-style",
+  "apply-instruction",
+  "set-style-property",
+  "remove-style-property",
+  "add-style-rule",
+  "set-rule-selector",
+  "insert-node",
+  "move-node",
+  "remove-node",
+  "set-attr",
+  "set-props-interface",
+  "set-script-zone",
+  "extract-component",
+];
+```
+
+```js
+/** Extract-component: carves a get_component_model outline subtree into a new .astro file
+ *  under src/components/, replacing it in place with a component instance + import. The only
+ *  op whose resolution touches two files — see component-extract-edit.mjs. */
+export const COMPONENT_EXTRACT_OPS = new Set(["extract-component"]);
+
+/** Union of style, structure, frontmatter, and extract component ops — used by the dispatcher's shared checks. */
+export const COMPONENT_OPS = new Set([
+  ...COMPONENT_STYLE_OPS,
+  ...COMPONENT_STRUCTURE_OPS,
+  ...COMPONENT_FRONTMATTER_OPS,
+  ...COMPONENT_EXTRACT_OPS,
+]);
+```
+
+Add to `componentEditSchema` (alongside the existing `zone`/`source` fields at the end, before the closing `});`):
+
+```js
+  newComponentPath: z
+    .string()
+    .optional()
+    .describe("Project-relative .astro path under src/components/ for the new component — required for extract-component"),
+```
+
+Update `createEditPreviewContent`:
+
+```js
+export function createEditPreviewContent(id, file, range, op, before, after, newFile) {
+  const body = { type: "anglesite:edit-preview", id, file, range, op, before, after };
+  if (newFile !== undefined) body.newFile = newFile;
+  return { type: "text", text: JSON.stringify(body) };
+}
+```
+
+Update the `op` field's description in `applyEditInputShape` to mention the new op (append to the existing description string): `"... set-props-interface/set-script-zone (component-frontmatter ops — see componentEditSchema), extract-component (carves an outline subtree into a new component under src/components/ — see componentEditSchema's nodeId/newComponentPath)"`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/apply-edit-schema-extract.test.ts && npx vitest run tests/apply-edit-schema-structure.test.ts tests/apply-edit-schema-frontmatter.test.ts`
+Expected: PASS — new tests pass, existing schema tests still pass (additive changes only).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/apply-edit-schema.mjs tests/apply-edit-schema-extract.test.ts
+git commit -m "feat(mcp): add extract-component to the apply_edit wire schema"
+```
+
+---
+
+### Task 8: Extend `edit-history.mjs`'s `recordEdit` for a second file
+
+**Files:**
+- Modify: `server/edit-history.mjs`
+- Test: `test/edit-history.test.js` (add cases — note: JS, under `test/`, matching this file's existing location per CLAUDE.md's test layout)
+
+**Interfaces:**
+- Produces: `recordEdit(projectRoot, {file, range, newFile?: {path: string}, message?})` — `newFile.path`'s on-disk content (already written by the dispatcher by the time this runs) is staged into the same commit as `file`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```js
+// test/edit-history.test.js — add to the existing describe("recordEdit", ...) block
+it("stages a second file into the same commit when newFile is provided", async () => {
+  writeFileSync(join(repo, "README.md"), "edited\n");
+  mkdirSync(join(repo, "src", "components"), { recursive: true });
+  writeFileSync(join(repo, "src", "components", "Hero.astro"), "<div>Hero</div>\n");
+
+  const sha = await recordEdit(repo, {
+    file: "README.md",
+    range: { start: 0, end: 7 },
+    newFile: { path: "src/components/Hero.astro" },
+    message: "extract Hero",
+  });
+
+  expect(sha).toMatch(/^[0-9a-f]{40}$/);
+  expect(git(["show", `${sha}:README.md`])).toBe("edited");
+  expect(git(["show", `${sha}:src/components/Hero.astro`])).toBe("<div>Hero</div>");
+  // Both files land in ONE commit, not two.
+  const parents = git(["rev-list", "--parents", "-n", "1", sha]).split(/\s+/);
+  expect(parents).toHaveLength(2); // sha itself + exactly one parent
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run test/edit-history.test.js -t "stages a second file"`
+Expected: FAIL — `recordEdit` ignores `newFile`, `src/components/Hero.astro` isn't in the commit.
+
+- [ ] **Step 3: Implement**
+
+In `server/edit-history.mjs`, change `recordEdit`'s signature and body:
+
+```js
+/**
+ * @param {string} projectRoot
+ * @param {{ file: string, range: {start:number,end:number}, newFile?: {path: string}, message?: string }} info
+ * @returns {Promise<string | undefined>} commit SHA, or undefined on any failure
+ */
+export async function recordEdit(projectRoot, { file, range, newFile, message }) {
+  if (!isGitRepo(projectRoot)) return undefined;
+
+  try {
+    const existing = tryRunGit(projectRoot, ["show-ref", "--verify", "--hash", EDITS_REF]);
+    if (!existing) {
+      const head = tryRunGit(projectRoot, ["rev-parse", "HEAD"]);
+      if (!head) return undefined;
+      runGit(projectRoot, ["update-ref", EDITS_REF, head]);
+    }
+
+    const tmpDir = mkdtempSync(join(tmpdir(), "anglesite-edit-idx-"));
+    const tmpIndex = join(tmpDir, "index");
+    const env = { GIT_INDEX_FILE: tmpIndex };
+    try {
+      runGit(projectRoot, ["read-tree", EDITS_REF], env);
+      const blob = runGit(projectRoot, ["hash-object", "-w", "--", file]);
+      runGit(projectRoot, ["update-index", "--add", "--cacheinfo", `100644,${blob},${file}`], env);
+      if (newFile) {
+        const newBlob = runGit(projectRoot, ["hash-object", "-w", "--", newFile.path]);
+        runGit(projectRoot, ["update-index", "--add", "--cacheinfo", `100644,${newBlob},${newFile.path}`], env);
+      }
+      const tree = runGit(projectRoot, ["write-tree"], env);
+      const parent = runGit(projectRoot, ["rev-parse", EDITS_REF]);
+      const commit = runGit(projectRoot, [
+        "commit-tree", tree, "-p", parent, "-m", formatMessage({ file, range, message }),
+      ]);
+      runGit(projectRoot, ["update-ref", EDITS_REF, commit, parent]);
+      return commit;
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  } catch {
+    return undefined;
+  }
+}
+```
+
+(Only the signature and the one new `if (newFile) { ... }` block change; everything else is unchanged from the existing implementation.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run test/edit-history.test.js`
+Expected: PASS — the new test plus all existing `recordEdit` tests (single-file calls still work since `newFile` is optional and `undefined` short-circuits the new branch).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/edit-history.mjs test/edit-history.test.js
+git commit -m "feat(mcp): stage an optional second file into recordEdit's commit"
+```
+
+---
+
+### Task 9: Wire `patcher.mjs` routing + `apply-edit-dispatcher.mjs` two-file write + `index-tools.mjs`
+
+Full end-to-end wiring: `patcher.mjs` routes `extract-component` to `resolveComponentExtract`; the dispatcher writes `newFile` (OS-atomic create-if-absent) before splicing/writing the primary file, threads `hoistedProps`/`warnings` into the response `result`, and supports `dry_run`'s `newFile` preview; `index-tools.mjs`'s `onApplied` passes `newFile` through to `recordEdit`.
+
+**Files:**
+- Modify: `server/patcher.mjs`
+- Modify: `server/apply-edit-dispatcher.mjs`
+- Modify: `server/index-tools.mjs`
+- Test: `tests/apply-edit-dispatcher-component-extract.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveComponentExtract` (Task 6, final form); `recordEdit` with `newFile` (Task 8); `createEditPreviewContent` with `newFile` (Task 7).
+- Produces: `applyEdit(projectRoot, edit, opts)` end-to-end support for `op: "extract-component"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// tests/apply-edit-dispatcher-component-extract.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parse } from "@astrojs/compiler";
+import { applyEdit } from "../server/apply-edit-dispatcher.mjs";
+import { buildTemplateNodeIndex } from "../server/component-node-index.mjs";
+import { fileVersion } from "../server/file-version.mjs";
+
+const PAGE = `---\ninterface Props { title: string; }\nconst { title } = Astro.props;\n---\n<main>\n  <div class="hero">\n    <h1>{title}</h1>\n  </div>\n</main>\n`;
+
+function parseContent(response) {
+  return JSON.parse(response.content[0].text);
+}
+
+async function nodeIndex(source) {
+  const { ast } = await parse(source, { position: true });
+  return buildTemplateNodeIndex(ast, source);
+}
+
+describe("applyEdit — extract-component", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-aed-ext-"));
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), PAGE);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function findDiv() {
+    const { byId, rootId } = await nodeIndex(PAGE);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    return byId.get(main.childIds[0]);
+  }
+
+  it("writes both files, commits once, and returns componentPath/hoistedProps/warnings in result", async () => {
+    const baseVersion = fileVersion(PAGE);
+    const div = await findDiv();
+
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Page.astro",
+      op: "extract-component",
+      component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" },
+    });
+
+    expect(response.isError).toBeFalsy();
+    const body = parseContent(response);
+    expect(body.type).toBe("anglesite:edit-applied");
+    expect(body.result.componentPath).toBe("src/components/Hero.astro");
+    expect(body.result.hoistedProps).toEqual(["title"]);
+    expect(body.result.warnings).toEqual([]);
+    expect(body.model).toBeDefined();
+    expect(body.model.path).toBe("src/components/Page.astro");
+
+    expect(existsSync(join(tmpDir, "src", "components", "Hero.astro"))).toBe(true);
+    const newFileOnDisk = readFileSync(join(tmpDir, "src", "components", "Hero.astro"), "utf-8");
+    expect(newFileOnDisk).toContain("<h1>{title}</h1>");
+    const originalOnDisk = readFileSync(join(tmpDir, "src", "components", "Page.astro"), "utf-8");
+    expect(originalOnDisk).toContain("<Hero title={title} />");
+  });
+
+  it("refuses exists without writing anything when newComponentPath is already taken", async () => {
+    writeFileSync(join(tmpDir, "src", "components", "Hero.astro"), "<p>taken</p>\n");
+    const baseVersion = fileVersion(PAGE);
+    const div = await findDiv();
+
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Page.astro",
+      op: "extract-component",
+      component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" },
+    });
+
+    expect(response.isError).toBe(true);
+    const body = parseContent(response);
+    expect(body.reason).toBe("exists");
+    const originalOnDisk = readFileSync(join(tmpDir, "src", "components", "Page.astro"), "utf-8");
+    expect(originalOnDisk).toBe(PAGE); // untouched
+  });
+
+  it("dry_run returns both previews and writes neither file", async () => {
+    const baseVersion = fileVersion(PAGE);
+    const div = await findDiv();
+
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Page.astro",
+      op: "extract-component",
+      component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" },
+      dry_run: true,
+    });
+
+    expect(response.isError).toBeFalsy();
+    const body = parseContent(response);
+    expect(body.type).toBe("anglesite:edit-preview");
+    expect(body.newFile.path).toBe("src/components/Hero.astro");
+    expect(body.newFile.after).toContain("<h1>{title}</h1>");
+    expect(body.after).toContain("<Hero title={title} />");
+    expect(existsSync(join(tmpDir, "src", "components", "Hero.astro"))).toBe(false);
+    expect(readFileSync(join(tmpDir, "src", "components", "Page.astro"), "utf-8")).toBe(PAGE);
+  });
+
+  it("commits both files in one hidden-branch commit and undo_edit reverts both", async () => {
+    const { execFileSync } = await import("node:child_process");
+    execFileSync("git", ["init", "--initial-branch=main", tmpDir], { stdio: "ignore" });
+    execFileSync("git", ["-C", tmpDir, "config", "user.email", "t@example.com"]);
+    execFileSync("git", ["-C", tmpDir, "config", "user.name", "T"]);
+    execFileSync("git", ["-C", tmpDir, "add", "-A"]);
+    execFileSync("git", ["-C", tmpDir, "commit", "-m", "initial"]);
+
+    const { recordEdit } = await import("../server/edit-history.mjs");
+    const { undoEdit } = await import("../server/undo-edit.mjs");
+    const baseVersion = fileVersion(PAGE);
+    const div = await findDiv();
+
+    const response = await applyEdit(
+      tmpDir,
+      {
+        id: "1",
+        path: "src/components/Page.astro",
+        op: "extract-component",
+        component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" },
+      },
+      { onApplied: ({ file, range, newFile }) => recordEdit(tmpDir, { file, range, newFile, message: `extract ${file}` }) },
+    );
+    const body = parseContent(response);
+    expect(body.commit).toMatch(/^[0-9a-f]{40}$/);
+    expect(existsSync(join(tmpDir, "src", "components", "Hero.astro"))).toBe(true);
+
+    const undone = await undoEdit(tmpDir, {});
+    expect(undone.status).toBe("undone");
+    expect(readFileSync(join(tmpDir, "src", "components", "Page.astro"), "utf-8")).toBe(PAGE);
+    expect(existsSync(join(tmpDir, "src", "components", "Hero.astro"))).toBe(false);
+  });
+
+  it("re-checks staleness after the resolver's async gap, refusing a concurrent write race", async () => {
+    const baseVersion = fileVersion(PAGE);
+    const div = await findDiv();
+
+    const editPromise = applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Page.astro",
+      op: "extract-component",
+      component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" },
+    });
+
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), PAGE.replace("Welcome", "Renamed").replace("{title}", "{title} "));
+
+    const response = await editPromise;
+    expect(response.isError).toBe(true);
+    const body = parseContent(response);
+    expect(body.reason).toBe("stale");
+    expect(existsSync(join(tmpDir, "src", "components", "Hero.astro"))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/apply-edit-dispatcher-component-extract.test.ts`
+Expected: FAIL — `resolve()` doesn't route `extract-component` yet, so every case gets a generic `no-match` refusal instead of the expected behavior.
+
+- [ ] **Step 3: Implement**
+
+In `server/patcher.mjs`, add the import and routing branch:
+
+```js
+import { resolveComponentExtract } from "./component-extract-edit.mjs";
+```
+
+```js
+import { COMPONENT_STYLE_OPS, COMPONENT_STRUCTURE_OPS, COMPONENT_FRONTMATTER_OPS, COMPONENT_EXTRACT_OPS } from "./apply-edit-schema.mjs";
+```
+
+Inside `resolve()`, add the branch right after the `COMPONENT_FRONTMATTER_OPS` check:
+
+```js
+  if (COMPONENT_FRONTMATTER_OPS.has(edit.op)) {
+    return resolveComponentFrontmatter(projectRoot, edit);
+  }
+  if (COMPONENT_EXTRACT_OPS.has(edit.op)) {
+    return resolveComponentExtract(projectRoot, edit);
+  }
+```
+
+In `server/index-tools.mjs`, update the `onApplied` wiring:
+
+```js
+  server.tool(
+    "apply_edit",
+    "Apply an edit to the underlying source for a previewed page element. The selector is the structured ElementInfo payload built by the WKWebView overlay; the server resolves it via selector.mjs and patches the matching source file. Successful edits are also committed onto the hidden anglesite/edits branch for per-edit undo.",
+    applyEditInputShape,
+    async (input) =>
+      applyEdit(projectRoot, input, {
+        onApplied: ({ file, range, newFile }) =>
+          recordEdit(projectRoot, { file, range, newFile, message: `anglesite: edit ${file}` }),
+      }),
+  );
+```
+
+In `server/apply-edit-dispatcher.mjs`, update the JSDoc `@param` for `opts.onApplied` to include `newFile`:
+
+```js
+ * @param {{ onApplied?: (info: {file:string, range:{start:number,end:number}, projectRoot:string, newFile?:{path:string}}) => Promise<string|undefined> | string | undefined }} [opts]
+```
+
+Replace the tail of `applyEdit` (from `const next = spliceSource(source, range, replacement);` through the final `return applied(...)`) with:
+
+```js
+  const next = spliceSource(source, range, replacement);
+
+  if (edit.dry_run) {
+    const { before, after } = windowAround(source, next);
+    const newFilePreview = resolution.newFile ? { path: resolution.newFile.path, after: resolution.newFile.content } : undefined;
+    return preview(edit.id, file, range, edit.op, before, after, newFilePreview);
+  }
+
+  if (resolution.newFile) {
+    const absNewPath = join(projectRoot, resolution.newFile.path);
+    try {
+      mkdirSync(dirname(absNewPath), { recursive: true });
+      writeFileSync(absNewPath, resolution.newFile.content, { encoding: "utf-8", flag: "wx" });
+    } catch (err) {
+      if (err.code === "EEXIST") return failed(edit.id, "exists", `${resolution.newFile.path} already exists`);
+      return failed(edit.id, "write-failed", `${resolution.newFile.path}: ${err.message}`);
+    }
+  }
+
+  try {
+    atomicWrite(absPath, next);
+  } catch (err) {
+    return failed(edit.id, "write-failed", `${file}: ${err.message}`);
+  }
+
+  let commit;
+  if (opts.onApplied) {
+    try {
+      commit = await opts.onApplied({
+        file,
+        range,
+        projectRoot,
+        newFile: resolution.newFile ? { path: resolution.newFile.path } : undefined,
+      });
+    } catch (err) {
+      commit = undefined;
+    }
+  }
+
+  let model;
+  if (COMPONENT_OPS.has(edit.op)) {
+    try {
+      model = await buildComponentModel(projectRoot, edit.component.path);
+    } catch {
+      model = undefined;
+    }
+  }
+
+  const extractResult = edit.op === "extract-component"
+    ? { componentPath: resolution.newFile?.path, hoistedProps: resolution.hoistedProps ?? [], warnings: resolution.warnings ?? [] }
+    : undefined;
+
+  return applied(
+    edit.id,
+    file,
+    range,
+    commit,
+    imageResult ? { src: imageResult.src, srcset: imageResult.srcset } : extractResult,
+    model,
+  );
+```
+
+Update the `preview` helper's signature to accept and forward the optional `newFile` (it already just forwards to `createEditPreviewContent`, which Task 7 updated):
+
+```js
+function preview(id, file, range, op, before, after, newFile) {
+  return { content: [createEditPreviewContent(id, file, range, op, before, after, newFile)] };
+}
+```
+
+`mkdirSync` and `dirname` are already imported in `apply-edit-dispatcher.mjs` (used by `processImageDrop`); no new imports needed there beyond the `COMPONENT_OPS`-adjacent ones already present.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/apply-edit-dispatcher-component-extract.test.ts`
+Expected: PASS (5 tests)
+
+Then run the full suite to confirm no regressions across every other op:
+
+Run: `npx vitest run`
+Expected: PASS — every existing test plus all new ones from Tasks 1–9.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/patcher.mjs server/apply-edit-dispatcher.mjs server/index-tools.mjs tests/apply-edit-dispatcher-component-extract.test.ts
+git commit -m "feat(mcp): wire extract-component end to end through apply_edit"
+```
+
+---
+
+### Task 10: CHANGELOG entry, version bump, full verification
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `package.json`, `.claude-plugin/plugin.json`, `template/package.json` (via `bin/release.ts` — do not hand-edit versions)
+
+- [ ] **Step 1: Add the CHANGELOG entry**
+
+Add a new `## [Unreleased]` (or the next version, per `bin/release.ts`'s convention — check `CHANGELOG.md`'s current top entry first) section at the top of `CHANGELOG.md`, above the existing `## [1.6.0]` entry:
+
+```markdown
+## [Unreleased]
+
+### Added
+- `apply_edit` gains `extract-component` — the first two-file component op —
+  for the Component Editor's "Extract into Component…" gesture (Slice 5).
+  Carves a `get_component_model` outline subtree (element/component/slot
+  only) into a new `.astro` file under `src/components/`, hoists the
+  original component's own declared Props that the subtree bare-referenced,
+  migrates simple-selector scoped-style rules that exclusively target the
+  extracted markup (reporting non-blocking `warnings` for anything shared or
+  too complex to analyze automatically), and replaces the extracted markup
+  with a self-closing instance + import. Lands both files in one hidden
+  `anglesite/edits` branch commit, so `undo_edit` reverts both together.
+```
+
+- [ ] **Step 2: Run the version bump**
+
+Run: `npx tsx bin/release.ts minor` (or whatever bump level the maintainer chooses — this is a new capability, not a breaking change, so `minor` per semver and this project's existing pattern of `minor` bumps for new ops in the 1.5.0/1.6.0 CHANGELOG entries read during planning)
+Expected: `package.json`, `.claude-plugin/plugin.json`, `template/package.json` versions bumped in lockstep; a new git tag created.
+
+- [ ] **Step 3: Run the full test suite one more time post-bump**
+
+Run: `npx vitest run`
+Expected: PASS — version bump touches no test-covered logic, this is a final confirmation nothing else drifted.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md package.json .claude-plugin/plugin.json template/package.json
+git commit -m "chore: release extract-component (Component Editor Slice 5, plugin side)"
+```
+
+(If `bin/release.ts` already created a commit and tag as part of Step 2, verify with `git log --oneline -3` and `git tag --points-at HEAD` instead of creating a duplicate commit — follow whatever `bin/release.ts`'s actual behavior is, per `docs/dev/` release documentation.)
+
+---
+
+## Post-plan note (not a task): Anglesite-app paired PR
+
+This plan covers the plugin side only. Per spec §7 and this project's established Slice 4 pattern (PR #418 / Anglesite-app#494), a **separate paired PR in `Anglesite/Anglesite-app`** is needed for: the "Extract into Component…" trigger, the name-prompt dialog, `dry_run` preview wiring in the app's UI, and `result.warnings`/`hoistedProps` surfacing. That work is out of scope here and should reference this plan's commit range once merged.

--- a/docs/superpowers/specs/2026-07-16-extract-component-design.md
+++ b/docs/superpowers/specs/2026-07-16-extract-component-design.md
@@ -1,0 +1,302 @@
+# `extract-component` apply_edit op
+
+**Date:** 2026-07-16 · **Issue:** Anglesite-app#495 (Component Editor Slice 5) · **Status:** draft — awaiting review
+
+Plugin-side half of Slice 5 (per Anglesite-app#496's tracking epic; design spec
+referenced there is `Anglesite-app` `docs/superpowers/specs/2026-07-05-component-editor-design.md`
+§2.3/§6, not present in this repo). The Anglesite-app side (context-menu
+trigger, name-prompt dialog, warning toasts) gets a separate paired PR, same
+split as PR #418 / Anglesite-app#494 for Slice 4 — this spec covers that
+side's touchpoints in §7 for context, but no Swift code.
+
+## Problem
+
+Slices 1–4 gave the Component Editor read (Slice 1), style writes (Slice 2),
+structure writes (Slice 3), and Props-form/code-pane writes (Slice 4) — all
+against a single `.astro` component, one at a time. Slice 5's headline
+feature, "Extract into Component…", is the first op that is inherently
+**two-file**: carve an outline subtree out of the component currently being
+edited into a brand-new `.astro` file under `src/components/`, hoist the
+subtree's obvious outer-scope references into that new component's Props,
+and replace the extracted markup in the original file with a self-closing
+instance + import.
+
+Every existing `apply_edit` op — including the 10 component ops from Slices
+2–4 — resolves to exactly one `{file, range, replacement}` splice
+(`patcher.mjs`'s `resolve()` contract), and the dispatcher
+(`apply-edit-dispatcher.mjs`) reads, splices, and atomically writes exactly
+one file, then commits exactly one file to the hidden `anglesite/edits`
+history branch (`edit-history.mjs`'s `recordEdit` hardcodes a single `file`
+param). `extract-component` needs two files touched in one atomic edit. This
+spec's central decision is how to extend that contract without disturbing it
+for the other 14 ops.
+
+## Non-goals (out of scope for this slice)
+
+- Multi-node / sibling-range extraction — only a single `get_component_model`
+  `nodeId` (element/component/slot kind) can be extracted. No fragment
+  synthesis over a selection of siblings.
+- Extracting an `expression`-kind node (e.g. a `{condition && <div>…}` block)
+  — only tag-shaped nodes (element/component/slot) are extractable; the
+  span-resolution machinery (`resolveAllSpans`) doesn't trust expression
+  spans for this kind of structural move, and expression extraction would
+  need real codegen of conditional logic in the new file, not just a markup
+  move.
+- General CSS-selector-vs-DOM matching. Style-rule migration (§5) handles
+  only simple selectors (tag/class/id, no combinators/pseudo-classes);
+  anything else is left behind with a warning, never guessed at.
+- Hoisting anything other than bare-identifier expressions that are
+  themselves one of the *original* component's own declared Props (§4).
+  Local consts, loop variables, and non-identifier expressions are left
+  verbatim in the moved markup.
+- Auto-naming the new component. The caller (app) supplies
+  `newComponentPath`; the op refuses on collision rather than guessing an
+  alternate name.
+- Media-query *editing* in the styles panel and viewport-preset polish —
+  companion bullets in Anglesite-app#495 but a separate (app-side, UI-only)
+  piece of work from this op.
+
+## 1. Wire contract
+
+`extract-component` joins `editOps` in `apply-edit-schema.mjs`, plus a new
+`COMPONENT_EXTRACT_OPS = new Set(["extract-component"])`, folded into the
+existing `COMPONENT_OPS` union so the dispatcher's generic `baseVersion`
+re-check and `component` payload guard cover it for free.
+
+New `componentEditSchema` fields (reusing `path`/`baseVersion` for the
+*original* file, same as every other component op):
+
+```js
+nodeId: string             // existing field — subtree root to extract (element/component/slot only)
+newComponentPath: string   // e.g. "src/components/Hero.astro" — must be under src/components/
+```
+
+**Response.** `edit-applied`'s `result` carries:
+
+```ts
+{
+  componentPath: string;     // == newComponentPath, echoed back
+  hoistedProps: string[];    // sorted prop names moved onto the new component
+  warnings: string[];        // non-blocking notices, see §5
+}
+```
+
+`model` is the freshly rebuilt model of the **original** file only — the app
+is looking at that file's outline/canvas; the new file's model is fetched
+on demand (existing `get_component_model`) if the user navigates to it.
+
+`dry_run` preview gains one additive field alongside the existing
+`{before, after}` windowed diff for the primary file:
+
+```ts
+{ newFile: { path: string; after: string } }  // no "before" — the file doesn't exist yet
+```
+
+**New/reused refusal reasons:**
+
+| reason | when |
+|---|---|
+| `invalid-input` | `nodeId` is the component root; `nodeId` kind is text/expression/fragment; `newComponentPath` fails validation (not under `src/components/`, wrong extension, traversal) |
+| `no-match` | subtree span can't be lexically re-located (`SpanResolutionError`, same failure mode as remove-node/move-node) |
+| `exists` (new) | `newComponentPath` already exists — checked at resolve time and re-checked atomically at write time |
+| `stale` | `baseVersion` mismatch (resolve-time and dispatcher-level re-check, same as every other component op) |
+
+## 2. Module architecture
+
+New `server/component-extract-edit.mjs`, same shape as
+`component-frontmatter-edit.mjs`: read fresh from disk → check `baseVersion`
+→ parse with `@astrojs/compiler` → resolve. `resolveComponentExtract(projectRoot, edit)`:
+
+1. Look up `nodeId` in `byId` (via `buildTemplateNodeIndex`, same as the
+   structure/frontmatter resolvers). Refuse if missing, if it's the root
+   (`parentId === null`), or if `kind` isn't `element`/`component`/`slot`.
+2. Run `resolveAllSpans` — exported from `component-structure-edit.mjs`
+   alongside its existing named exports — to get the subtree's real span.
+   Refuse `no-match` on `SpanResolutionError`.
+3. Validate `newComponentPath` (`.astro`, project-relative, no traversal,
+   starts with `src/components/`). Refuse `exists` if
+   `existsSync(join(projectRoot, newComponentPath))`.
+4. Compute hoisted props (§4) and moved style rules (§5).
+5. Build `newFile.content`: frontmatter (Props interface + destructure via
+   the existing `generatePropsInterface`/`generatePropsDestructure`, plus any
+   copied component imports, step 8) + the extracted subtree's raw source
+   text verbatim + a `<style>` block for any moved rules.
+6. Build the primary-file `replacement`: the subtree's span replaced with a
+   self-closing instance tag (`<Hero title={title} />` — hoisted props only;
+   literal attributes on the extracted root stay baked into the new file,
+   they're never hoisted since they don't reference anything external).
+7. Original-file frontmatter bookkeeping: `ensureImport` the new component's
+   default import (reusing `frontmatter-imports.mjs`); `pruneImportIfUnused`
+   for any component-kind descendant whose import is now dead (same helper
+   `remove-node` already uses for exactly this).
+8. New-file frontmatter bookkeeping: any component-kind descendants inside
+   the extracted subtree have their import lines copied from the original's
+   frontmatter (via `parseImports`, matched by tag name against
+   `collectComponentTags`) into the new file's frontmatter.
+9. Return
+   `{ file: relPath, range: subtreeSpan, replacement: instanceTag, newFile: { path: newComponentPath, content }, hoistedProps, warnings }`.
+
+`patcher.mjs`'s `resolve()` gets one more branch:
+`if (edit.op === "extract-component") return resolveComponentExtract(...)`.
+
+**Dispatcher.** After the existing fresh-read + `baseVersion` re-check
+(unchanged — already generic over `COMPONENT_OPS`), a new branch: if
+`resolution.newFile` is present, `mkdirSync(dirname(absNewPath), { recursive: true })`
+then write it with `writeFileSync(absNewPath, content, { flag: "wx" })` — an
+OS-atomic create-if-absent that refuses `exists` on `EEXIST`, closing the
+same race window the `baseVersion` re-check closes for the primary file —
+**before** splicing/writing the primary file. This ordering means the only
+possible partial-failure state is "new file exists, original untouched,"
+never a dangling reference in the original to a file that failed to write.
+
+**History.** `edit-history.mjs`'s `recordEdit` gains an optional second file:
+`recordEdit(projectRoot, { file, range, newFile, message })` where `newFile`
+is `{ path }` (content is already on disk by the time this runs) — one more
+`hash-object -w` + `update-index --add --cacheinfo` for `newFile.path` staged
+into the same temp index before `write-tree`, producing one commit covering
+both files. **`undo-edit.mjs` needs no changes** — it already does
+`git diff --name-only parent head` and restores whatever files differ, so a
+two-file commit undoes both files in one step for free.
+
+This is Approach A of three considered (special-cased dispatcher extension,
+mirroring the precedent `replace-image-src` already set by writing files
+outside the generic single-splice path). Rejected alternatives: (B) a
+generic `{writes: [...]}` array contract refactored across all resolvers —
+more general but a real refactor of 10 existing resolvers for a need nothing
+else on the roadmap has; (C) three sequential app-driven ops (create-file +
+insert-node + remove-node) — no dispatcher changes, but three history
+commits instead of one, the app re-fetching `baseVersion` between each call,
+and a crash mid-sequence leaving genuinely broken partial state. Rejected
+for breaking the "one gesture = one undo step" invariant the rest of the
+editor relies on.
+
+## 3. Extractable node kinds
+
+Only `element`, `component`, and `slot` kinds — the same tag-shaped set
+`set-attr` already restricts itself to, for the same reason: `resolveAllSpans`
+only resolves reliable spans for tag-shaped nodes (plus `expression`, which
+is excluded here per Non-goals) and `text`/`fragment` nodes have no lexical
+marker to search for or move.
+
+## 4. Prop hoisting algorithm
+
+1. Walk the extracted subtree's `expression`-kind nodes (attribute values
+   and text-content expressions), same `byId` traversal `resolveAllSpans`
+   already performs.
+2. A hoist candidate is an expression whose full text (trimmed) matches
+   `/^[A-Za-z_$][\w$]*$/` — a single bare identifier, nothing else. Member
+   access, calls, template literals, `&&`/ternaries, etc. are left verbatim
+   in the moved markup.
+3. A candidate is hoisted **only if** its name appears in
+   `parseProps(originalFrontmatterSource)` — i.e. it's one of the *original*
+   component's own declared Props (reusing `props-interface.mjs`'s
+   `parseProps`, no new scope-analysis logic). Its `type` is copied verbatim
+   from that entry, `optional` copied, `default` dropped (the new component
+   always receives a concrete value from its one caller). Any bare
+   identifier that is NOT one of the original's own Props (a local `const`,
+   a loop variable, a global) is left in place, unhoisted — no guessing at
+   scope. If it turns out to be genuinely out of scope in the new file, that
+   surfaces as an ordinary build/type error, not something the op corrupts
+   or silently blocks on.
+4. Dedup by name — an identifier referenced twice in the subtree produces
+   one hoisted prop; both usages inside the new file remain `{name}`
+   unchanged (already the correct destructured name there).
+5. `hoistedProps` in the response is the sorted list of names.
+
+## 5. Style-rule migration algorithm
+
+1. Parse each of the original component's `<style>` rules (already
+   available via `indexCssRules`, same source `component-model.mjs` uses)
+   and classify the selector as **simple** (`/^(\w+)?(\.[\w-]+)*$/` or
+   `/^#[\w-]+$/` — tag, class(es), compound tag+class, or id; zero
+   combinators) or **complex** (anything else: combinators, pseudo-classes,
+   `:global()`, attribute selectors).
+2. For each simple selector, check whether it matches (tag/class/id
+   equality) at least one node inside the extracted subtree
+   (`insideMatch`) and separately whether it matches any node in the
+   template that remains after extraction (`outsideMatch`).
+3. `insideMatch && !outsideMatch` → move the rule verbatim into the new
+   file's `<style>`, remove from the original's.
+4. `insideMatch && outsideMatch` → leave in the original;
+   `warnings` gets `"<selector> not moved: also used outside the extracted markup"`.
+5. `!insideMatch` → untouched, not mentioned in `warnings`.
+6. Any complex selector with `insideMatch` → left in the original;
+   `warnings` gets `"<selector> not moved: selector too complex to analyze automatically"`.
+7. `@media`-wrapped rules are matched by their inner selector the same way;
+   if a media block ends up with a mixed move/stay verdict across its
+   rules, it's split — a fresh `@media` wrapper is synthesized in whichever
+   file needs one, reusing `add-style-rule`'s existing "create the container
+   if absent" pattern.
+
+No general CSS-selector-vs-DOM matching engine is built — this is
+purpose-built pattern matching against the outline tree's own tag/class/id
+data, bounded to the "obvious" case (a class or tag styling the extracted
+root or its direct descendants), consistent with this codebase's existing
+"deliberately regex/heuristic, refuse rather than guess" discipline
+(`parseProps`, `pruneImportIfUnused`).
+
+## 6. Edge cases (summary)
+
+| Case | Behavior |
+|---|---|
+| `nodeId` is the component root | refuse `invalid-input` |
+| `nodeId` kind is text/expression/fragment | refuse `invalid-input` |
+| Span can't be lexically re-located | refuse `no-match` |
+| `newComponentPath` invalid (not under `src/components/`, wrong extension, traversal) | refuse `invalid-input` |
+| `newComponentPath` already exists (resolve-time or write-time race) | refuse `exists` |
+| `baseVersion` stale (resolve-time or dispatcher re-check) | refuse `stale` |
+| Extracted subtree contains a component-kind descendant | import copied to new file's frontmatter; pruned from original if now unused |
+| Non-hoistable expression referencing outer scope | left verbatim — a real build/type error if actually out of scope, never silently corrupted |
+| Style rule used both inside and outside the subtree | stays in original, reported in `warnings` |
+| Style rule with a combinator/pseudo-class/`:global()` | stays in original, reported in `warnings` |
+| Concurrent edit lands between resolve and write | `stale` or `exists`, never a partial/dangling write |
+
+## 7. App-side touchpoints (Anglesite-app, paired PR — no Swift written here)
+
+- **Trigger**: "Extract into Component…" on an outline selection, enabled
+  only when the selected node's `kind` is element/component/slot and it
+  isn't the root — computable locally from the `ComponentModel` the app
+  already holds, no round trip needed just to decide whether to grey it out.
+- **Name prompt**: a small dialog collecting `newComponentPath` under
+  `src/components/`, defaulting to a PascalCase guess derived app-side from
+  the node's tag/heading text (the op itself never guesses a name). A
+  client-side existence check is a nice-to-have; the op's `exists` refusal
+  is the authoritative check regardless.
+- **Request**: `apply_edit` with `op: "extract-component"`,
+  `component: { path, baseVersion, nodeId, newComponentPath }`. Same
+  `dry_run` support as every other component op, for live preview before
+  committing.
+- **Response handling**: on `edit-applied`, swap in the piggybacked `model`
+  for the outline/canvas; if `result.warnings` is non-empty, surface a
+  non-blocking toast/inline note per warning (e.g. "Extracted Hero.astro —
+  1 style rule was not moved: `.card` is also used outside the extracted
+  markup"). `result.hoistedProps` can drive a short confirmation summary.
+- **Navigator**: the new file should appear without a manual refresh needed
+  for the *editor* itself; any project-wide file-list cache is a separate,
+  existing app-side concern outside this op's response.
+- **Undo**: no special handling — one hidden-branch commit, one undo step,
+  both files revert together via the existing `undo_edit` flow.
+
+## 8. Testing plan
+
+Following the existing per-op layering
+(`tests/apply-edit-schema-*.test.ts`, `tests/component-*-edit.test.ts`,
+`tests/apply-edit-dispatcher-*.test.ts`):
+
+- **Schema**: `nodeId` + `newComponentPath` required and validated correctly.
+- **Resolver unit tests**: root-extraction refusal; non-tag-kind refusal;
+  collision refusal; stale refusal; prop hoisting (own-prop hit, non-prop
+  identifier left alone, complex expression left alone, dedup); style
+  migration (simple-inside-only moves, shared-stays-with-warning,
+  complex-stays-with-warning, media-query split); nested component import
+  copy + prune-if-unused on the original.
+- **Dispatcher-level**: full round trip writes both files; concurrency race
+  test mirroring the existing component-style one (two racing
+  `extract-component` calls to the same `newComponentPath`); `dry_run`
+  returns both previews and writes nothing; `onApplied`/`recordEdit`
+  receives both files and produces one commit; `undo_edit` reverts both
+  files from that one commit.
+
+## Open decisions
+
+None — all resolved during brainstorming (2026-07-16).

--- a/server/apply-edit-dispatcher.mjs
+++ b/server/apply-edit-dispatcher.mjs
@@ -6,13 +6,16 @@
  *      via `processImageDrop` — write the bytes under `public/images/`, run optimize, build the
  *      `{src, srcset}` value the patcher's resolver expects. Throws map to `image-optimize-failed`.
  *   2. `resolve(projectRoot, edit)` (patcher.mjs) returns either `{file, range, replacement}`
- *      or `{refused: true, reason, detail?}`.
+ *      (plus, for `extract-component`, a second `newFile: {path, content}`) or
+ *      `{refused: true, reason, detail?}`.
  *   3. On refusal: forward as an `edit-failed` MCP response.
- *   4. On success: read the source, splice in the replacement, atomically write back (write to
- *      a sibling temp file then `rename`), invoke an optional `onApplied` hook so #298's
- *      `edit-history.mjs` can commit to the hidden `anglesite/edits` branch and thread its SHA
- *      back as `commit`, then return `edit-applied` — with `result: {src, srcset}` for the
- *      image-drop path.
+ *   4. On success: for `extract-component`, create-write `newFile` first (fails as `exists` on
+ *      EEXIST, so the original is never touched if the new path is already taken) — then read
+ *      the source, splice in the replacement, atomically write back (write to a sibling temp
+ *      file then `rename`), invoke an optional `onApplied` hook so #298's `edit-history.mjs`
+ *      can commit both files to the hidden `anglesite/edits` branch in one commit and thread its
+ *      SHA back as `commit`, then return `edit-applied` — with `result: {src, srcset}` for the
+ *      image-drop path, or `result: {componentPath, hoistedProps, warnings}` for extract-component.
  *   5. On any filesystem error: return `edit-failed` with reason `write-failed`.
  *
  * The handler stays a pure async function so it's unit-testable independent of the MCP
@@ -69,8 +72,8 @@ function windowAround(source, next, pad = 200) {
   return { before: source.slice(from, beforeTo), after: next.slice(from, afterTo) };
 }
 
-function preview(id, file, range, op, before, after) {
-  return { content: [createEditPreviewContent(id, file, range, op, before, after)] };
+function preview(id, file, range, op, before, after, newFile) {
+  return { content: [createEditPreviewContent(id, file, range, op, before, after, newFile)] };
 }
 
 /** Atomic write via temp-sibling + rename, so a crashed mid-write can't truncate the source. */
@@ -184,7 +187,7 @@ async function processImageDrop(projectRoot, edit) {
  *
  * @param {string} projectRoot
  * @param {object} edit  payload from the `apply_edit` tool (already zod-validated)
- * @param {{ onApplied?: (info: {file:string, range:{start:number,end:number}, projectRoot:string}) => Promise<string|undefined> | string | undefined }} [opts]
+ * @param {{ onApplied?: (info: {file:string, range:{start:number,end:number}, projectRoot:string, newFile?:{path:string}}) => Promise<string|undefined> | string | undefined }} [opts]
  */
 export async function applyEdit(projectRoot, edit, opts = {}) {
   // The app's Foundation Models chat path (ApplyEditTool, #251) forwards NL instructions
@@ -251,7 +254,27 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
 
   if (edit.dry_run) {
     const { before, after } = windowAround(source, next);
-    return preview(edit.id, file, range, edit.op, before, after);
+    const newFilePreview = resolution.newFile
+      ? { path: resolution.newFile.path, after: resolution.newFile.content }
+      : undefined;
+    return preview(edit.id, file, range, edit.op, before, after, newFilePreview);
+  }
+
+  // extract-component writes a second, brand-new file. Do that FIRST with a create-if-absent
+  // flag ("wx" — fails on EEXIST) so the only possible partial-failure state is "new file
+  // exists, original untouched" — never the reverse. If this fails, the primary atomicWrite
+  // below never runs, so the original component is guaranteed unmodified.
+  if (resolution.newFile) {
+    const absNewPath = join(projectRoot, resolution.newFile.path);
+    try {
+      mkdirSync(dirname(absNewPath), { recursive: true });
+      writeFileSync(absNewPath, resolution.newFile.content, { encoding: "utf-8", flag: "wx" });
+    } catch (err) {
+      if (err.code === "EEXIST") {
+        return failed(edit.id, "exists", `${resolution.newFile.path} already exists`);
+      }
+      return failed(edit.id, "write-failed", `${resolution.newFile.path}: ${err.message}`);
+    }
   }
 
   try {
@@ -263,7 +286,12 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
   let commit;
   if (opts.onApplied) {
     try {
-      commit = await opts.onApplied({ file, range, projectRoot });
+      commit = await opts.onApplied({
+        file,
+        range,
+        projectRoot,
+        newFile: resolution.newFile ? { path: resolution.newFile.path } : undefined,
+      });
     } catch (err) {
       // Patch landed on disk but history-keeping failed. Surface as a successful apply with no
       // commit SHA — the user-visible source change is real; #298 can decide its own policy.
@@ -280,12 +308,16 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
     }
   }
 
+  const extractResult = edit.op === "extract-component"
+    ? { componentPath: resolution.newFile?.path, hoistedProps: resolution.hoistedProps ?? [], warnings: resolution.warnings ?? [] }
+    : undefined;
+
   return applied(
     edit.id,
     file,
     range,
     commit,
-    imageResult ? { src: imageResult.src, srcset: imageResult.srcset } : undefined,
+    imageResult ? { src: imageResult.src, srcset: imageResult.srcset } : extractResult,
     model,
   );
 }

--- a/server/apply-edit-schema.mjs
+++ b/server/apply-edit-schema.mjs
@@ -58,6 +58,7 @@ export const editOps = [
   "set-attr",
   "set-props-interface",
   "set-script-zone",
+  "extract-component",
 ];
 
 /** The subset of `editOps` that operate on a component's scoped `<style>` via `component`
@@ -78,8 +79,18 @@ export const COMPONENT_STRUCTURE_OPS = new Set(["insert-node", "move-node", "rem
  *  zone via `component` — the Props form and STTextView code-pane saves. */
 export const COMPONENT_FRONTMATTER_OPS = new Set(["set-props-interface", "set-script-zone"]);
 
-/** Union of style, structure, and frontmatter component ops — used by the dispatcher's shared checks. */
-export const COMPONENT_OPS = new Set([...COMPONENT_STYLE_OPS, ...COMPONENT_STRUCTURE_OPS, ...COMPONENT_FRONTMATTER_OPS]);
+/** Extract-component: carves a get_component_model outline subtree into a new .astro file
+ *  under src/components/, replacing it in place with a component instance + import. The only
+ *  op whose resolution touches two files — see component-extract-edit.mjs. */
+export const COMPONENT_EXTRACT_OPS = new Set(["extract-component"]);
+
+/** Union of style, structure, frontmatter, and extract component ops — used by the dispatcher's shared checks. */
+export const COMPONENT_OPS = new Set([
+  ...COMPONENT_STYLE_OPS,
+  ...COMPONENT_STRUCTURE_OPS,
+  ...COMPONENT_FRONTMATTER_OPS,
+  ...COMPONENT_EXTRACT_OPS,
+]);
 
 /** Structured payload for the four component-style ops. Identifies the target rule by its exact
  *  byte span (from `get_component_model`'s `styles[].span`) plus a `baseVersion` content-hash
@@ -129,6 +140,10 @@ export const componentEditSchema = z.object({
     ),
   zone: z.enum(["frontmatter", "client"]).optional().describe("Script zone for set-script-zone: the frontmatter TS or the client <script>"),
   source: z.string().optional().describe("Replacement source text for set-script-zone's target zone"),
+  newComponentPath: z
+    .string()
+    .optional()
+    .describe("Project-relative .astro path under src/components/ for the new component — required for extract-component"),
 });
 
 /** The MCP tool's input shape, as passed to `server.tool(name, description, shape, handler)`. */
@@ -158,7 +173,7 @@ export const applyEditInputShape = {
   op: z
     .enum(editOps)
     .describe(
-      "Edit operation: replace-text (innerText), replace-attr (value is {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>), apply-instruction (reserved: sent only by the Anglesite-app Foundation Models chat path; always returns edit-failed/needs-agent — do not use from external callers), set-style-property/remove-style-property/add-style-rule/set-rule-selector (component-style ops), insert-node/move-node/remove-node/set-attr (component-structure ops), set-props-interface/set-script-zone (component-frontmatter ops — see componentEditSchema)",
+      "Edit operation: replace-text (innerText), replace-attr (value is {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>), apply-instruction (reserved: sent only by the Anglesite-app Foundation Models chat path; always returns edit-failed/needs-agent — do not use from external callers), set-style-property/remove-style-property/add-style-rule/set-rule-selector (component-style ops), insert-node/move-node/remove-node/set-attr (component-structure ops), set-props-interface/set-script-zone (component-frontmatter ops — see componentEditSchema), extract-component (carves an outline subtree into a new component under src/components/ — see componentEditSchema's nodeId/newComponentPath)",
     ),
   value: z
     .unknown()
@@ -199,7 +214,8 @@ export function createEditAppliedContent(id, file, range, commit, result, model)
 
 /** Build the MCP `content` entry for an edit-preview (dry-run) response. `before`/`after` are the
  *  windowed source fragments around the change — see dispatcher `windowAround`. */
-export function createEditPreviewContent(id, file, range, op, before, after) {
+export function createEditPreviewContent(id, file, range, op, before, after, newFile) {
   const body = { type: "anglesite:edit-preview", id, file, range, op, before, after };
+  if (newFile !== undefined) body.newFile = newFile;
   return { type: "text", text: JSON.stringify(body) };
 }

--- a/server/component-extract-edit.mjs
+++ b/server/component-extract-edit.mjs
@@ -5,6 +5,7 @@ import { fileVersion } from "./file-version.mjs";
 import { buildTemplateNodeIndex } from "./component-node-index.mjs";
 import { resolveAllSpans, SpanResolutionError, importSpecifier } from "./component-structure-edit.mjs";
 import { ensureImport } from "./frontmatter-imports.mjs";
+import { parseProps, generatePropsInterface, generatePropsDestructure } from "./props-interface.mjs";
 
 /**
  * Write-side resolver for extract-component (Component Editor Slice 5). Unlike every other
@@ -66,6 +67,52 @@ function findFrontmatterBody(source) {
   return { bodyStart, bodyEnd: closeIdx };
 }
 
+const BARE_IDENTIFIER_RE = /^[A-Za-z_$][\w$]*$/;
+const FRONTMATTER_RE = /^(---\r?\n)([\s\S]*?)(\r?\n---)/;
+
+function collectSubtreeIds(byId, nodeId) {
+  const ids = [];
+  (function walk(id) {
+    ids.push(id);
+    for (const c of byId.get(id).childIds) walk(c);
+  })(nodeId);
+  return ids;
+}
+
+/**
+ * Bare-identifier expressions (attribute values AND text-content expression children)
+ * inside the subtree whose name is one of the original component's own declared Props.
+ * Anything else — a non-identifier expression, or an identifier that isn't an original
+ * Prop — is left alone; see the Global Constraints note on hoisting scope. Returns prop
+ * records sorted by name (the module's `props` shape: {name, type, optional, default}).
+ */
+function findHoistCandidates(byId, astById, subtreeIds, spans, source, originalProps) {
+  const ownProps = new Map(originalProps.map((p) => [p.name, p]));
+  const hoisted = new Map();
+
+  function consider(text) {
+    const trimmed = text.trim();
+    if (!BARE_IDENTIFIER_RE.test(trimmed)) return;
+    const prop = ownProps.get(trimmed);
+    if (prop) hoisted.set(trimmed, { name: prop.name, type: prop.type, optional: prop.optional, default: null });
+  }
+
+  for (const id of subtreeIds) {
+    const node = byId.get(id);
+    const astNode = astById.get(id);
+    if (astNode && Array.isArray(astNode.attributes)) {
+      for (const a of astNode.attributes) {
+        if (a.kind === "expression") consider(a.value ?? "");
+      }
+    }
+    if (node.kind === "expression") {
+      const span = spans.get(id);
+      if (span) consider(source.slice(span[0], span[1]).replace(/^\{/, "").replace(/\}$/, ""));
+    }
+  }
+  return [...hoisted.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
 function rewriteOriginalFrontmatter(afterNode, relPath, componentName, newComponentPath) {
   const specifier = importSpecifier(relPath, newComponentPath);
   const fm = findFrontmatterBody(afterNode);
@@ -100,7 +147,7 @@ export async function resolveComponentExtract(projectRoot, edit) {
 
   const loaded = await loadFresh(projectRoot, relPath, baseVersion);
   if (loaded.error) return loaded.error;
-  const { source, byId, rootId } = loaded;
+  const { source, byId, rootId, astById } = loaded;
 
   const node = byId.get(nodeId);
   if (!node) return refuse("no-match", "no node found at the given id — the file may have changed");
@@ -133,16 +180,27 @@ export async function resolveComponentExtract(projectRoot, edit) {
 
   const subtreeText = source.slice(nodeSpan[0], nodeSpan[1]);
 
-  const instanceTag = `<${componentName} />`;
+  const origFmMatch = source.match(FRONTMATTER_RE);
+  const originalProps = origFmMatch ? parseProps(origFmMatch[2]) : [];
+  const subtreeIds = collectSubtreeIds(byId, nodeId);
+  const hoistedPropRecords = findHoistCandidates(byId, astById, subtreeIds, spans, source, originalProps);
+
+  const instanceAttrs = hoistedPropRecords.map((p) => ` ${p.name}={${p.name}}`).join("");
+  const instanceTag = `<${componentName}${instanceAttrs} />`;
   const afterNode = source.slice(0, nodeSpan[0]) + instanceTag + source.slice(nodeSpan[1]);
   const afterImport = rewriteOriginalFrontmatter(afterNode, relPath, componentName, newComponentPath);
+
+  const propsInterface = generatePropsInterface(hoistedPropRecords);
+  const propsDestructure = generatePropsDestructure(hoistedPropRecords);
+  const fmParts = [propsInterface, propsDestructure].filter(Boolean);
+  const newFm = fmParts.length ? `---\n${fmParts.join("\n")}\n---\n` : "";
 
   return {
     file: relPath,
     range: { start: 0, end: source.length },
     replacement: afterImport,
-    newFile: { path: newComponentPath, content: `${subtreeText}\n` },
-    hoistedProps: [],
+    newFile: { path: newComponentPath, content: `${newFm}${subtreeText}\n` },
+    hoistedProps: hoistedPropRecords.map((p) => p.name),
     warnings: [],
   };
 }

--- a/server/component-extract-edit.mjs
+++ b/server/component-extract-edit.mjs
@@ -71,7 +71,6 @@ function findFrontmatterBody(source) {
 }
 
 const BARE_IDENTIFIER_RE = /^[A-Za-z_$][\w$]*$/;
-const FRONTMATTER_RE = /^(---\r?\n)([\s\S]*?)(\r?\n---)/;
 
 function collectSubtreeIds(byId, nodeId) {
   const ids = [];
@@ -141,10 +140,11 @@ function importLinesForNewFile(originalFmBody, movedComponentNames, relPath, new
     .join("");
 }
 
-// `findFrontmatterBody` (not the FRONTMATTER_RE regex) is used here deliberately — see its
-// file-level comment above: the regex fails to match the minimal empty-body frontmatter
-// shape "---\n---\n", which would otherwise cause a second frontmatter block to be
-// prepended via the no-frontmatter fallback below, corrupting the file.
+// `findFrontmatterBody` is the sole frontmatter detector in this module (see its file-level
+// comment above) — it correctly matches the minimal empty-body frontmatter shape
+// "---\n---\n", which a regex requiring two independently-matched newlines would miss,
+// causing a second frontmatter block to be prepended via the no-frontmatter fallback below
+// and corrupting the file.
 function rewriteOriginalFrontmatter(afterNode, relPath, componentName, newComponentPath, movedComponentNames) {
   const specifier = importSpecifier(relPath, newComponentPath);
   const fm = findFrontmatterBody(afterNode);
@@ -320,8 +320,9 @@ export async function resolveComponentExtract(projectRoot, edit) {
 
   const subtreeText = source.slice(nodeSpan[0], nodeSpan[1]);
 
-  const origFmMatch = source.match(FRONTMATTER_RE);
-  const originalProps = origFmMatch ? parseProps(origFmMatch[2]) : [];
+  const origFm = findFrontmatterBody(source);
+  const origFmBody = origFm ? source.slice(origFm.bodyStart, origFm.bodyEnd) : "";
+  const originalProps = parseProps(origFmBody);
   const subtreeIds = collectSubtreeIds(byId, nodeId);
   const hoistedPropRecords = findHoistCandidates(byId, astById, subtreeIds, spans, source, originalProps);
   const movedComponentNames = collectComponentTags(byId, nodeId);
@@ -338,7 +339,7 @@ export async function resolveComponentExtract(projectRoot, edit) {
   const afterNode = source.slice(0, nodeSpan[0]) + instanceTag + source.slice(nodeSpan[1]);
   const afterImport = rewriteOriginalFrontmatter(afterNode, relPath, componentName, newComponentPath, movedComponentNames);
 
-  const importLines = importLinesForNewFile(origFmMatch ? origFmMatch[2] : "", movedComponentNames, relPath, newComponentPath);
+  const importLines = importLinesForNewFile(origFmBody, movedComponentNames, relPath, newComponentPath);
   const propsInterface = generatePropsInterface(hoistedPropRecords);
   const propsDestructure = generatePropsDestructure(hoistedPropRecords);
   const fmParts = [importLines ? importLines.trimEnd() : null, propsInterface, propsDestructure].filter(Boolean);

--- a/server/component-extract-edit.mjs
+++ b/server/component-extract-edit.mjs
@@ -1,10 +1,10 @@
 import { readFileSync, existsSync } from "node:fs";
-import { join, normalize, basename, sep } from "node:path";
+import { join, normalize, basename, dirname, sep } from "node:path";
 import { parse } from "@astrojs/compiler";
 import { fileVersion } from "./file-version.mjs";
 import { buildTemplateNodeIndex } from "./component-node-index.mjs";
-import { resolveAllSpans, SpanResolutionError, importSpecifier } from "./component-structure-edit.mjs";
-import { ensureImport } from "./frontmatter-imports.mjs";
+import { resolveAllSpans, SpanResolutionError, importSpecifier, collectComponentTags } from "./component-structure-edit.mjs";
+import { ensureImport, parseImports, pruneImportIfUnused } from "./frontmatter-imports.mjs";
 import { parseProps, generatePropsInterface, generatePropsDestructure } from "./props-interface.mjs";
 
 /**
@@ -113,12 +113,48 @@ function findHoistCandidates(byId, astById, subtreeIds, spans, source, originalP
   return [...hoisted.values()].sort((a, b) => a.name.localeCompare(b.name));
 }
 
-function rewriteOriginalFrontmatter(afterNode, relPath, componentName, newComponentPath) {
+// Re-bases a relative import specifier from the ORIGINAL file's directory to a
+// project-relative path, so it can be re-expressed relative to the NEW file's own
+// directory below (via importSpecifier). E.g. from "src/components/sections/Page.astro"
+// resolving specifier "../Badge.astro" yields "src/components/Badge.astro".
+function resolveImportTargetPath(originalRelPath, specifier) {
+  const abs = normalize(join(dirname(originalRelPath), specifier));
+  return abs.split(sep).join("/");
+}
+
+// Import lines for any nested component(s) carried into the extracted subtree — copied
+// from the original file's frontmatter and re-based to the new file's own directory. A
+// moved name with no matching import in the original frontmatter (e.g. never actually
+// declared) is silently skipped rather than fabricated.
+function importLinesForNewFile(originalFmBody, movedComponentNames, relPath, newComponentPath) {
+  const origImports = parseImports(originalFmBody ?? "");
+  return movedComponentNames
+    .map((name) => origImports.find((i) => i.localName === name))
+    .filter(Boolean)
+    .map((imp) => {
+      const targetRelPath = resolveImportTargetPath(relPath, imp.specifier);
+      return `import ${imp.localName} from "${importSpecifier(newComponentPath, targetRelPath)}";\n`;
+    })
+    .join("");
+}
+
+// `findFrontmatterBody` (not the FRONTMATTER_RE regex) is used here deliberately — see its
+// file-level comment above: the regex fails to match the minimal empty-body frontmatter
+// shape "---\n---\n", which would otherwise cause a second frontmatter block to be
+// prepended via the no-frontmatter fallback below, corrupting the file.
+function rewriteOriginalFrontmatter(afterNode, relPath, componentName, newComponentPath, movedComponentNames) {
   const specifier = importSpecifier(relPath, newComponentPath);
   const fm = findFrontmatterBody(afterNode);
+  const ensureAndPrune = (fmBody) => {
+    let body = ensureImport(fmBody, { localName: componentName, specifier }).source;
+    for (const name of movedComponentNames) {
+      body = pruneImportIfUnused(body, afterNode, name).source;
+    }
+    return body;
+  };
   if (fm) {
     const fmBody = afterNode.slice(fm.bodyStart, fm.bodyEnd);
-    const { source: newFmBody } = ensureImport(fmBody, { localName: componentName, specifier });
+    const newFmBody = ensureAndPrune(fmBody);
     return afterNode.slice(0, fm.bodyStart) + newFmBody + afterNode.slice(fm.bodyStart + fmBody.length);
   }
   const importLine = `import ${componentName} from "${specifier}";\n`;
@@ -184,15 +220,17 @@ export async function resolveComponentExtract(projectRoot, edit) {
   const originalProps = origFmMatch ? parseProps(origFmMatch[2]) : [];
   const subtreeIds = collectSubtreeIds(byId, nodeId);
   const hoistedPropRecords = findHoistCandidates(byId, astById, subtreeIds, spans, source, originalProps);
+  const movedComponentNames = collectComponentTags(byId, nodeId);
 
   const instanceAttrs = hoistedPropRecords.map((p) => ` ${p.name}={${p.name}}`).join("");
   const instanceTag = `<${componentName}${instanceAttrs} />`;
   const afterNode = source.slice(0, nodeSpan[0]) + instanceTag + source.slice(nodeSpan[1]);
-  const afterImport = rewriteOriginalFrontmatter(afterNode, relPath, componentName, newComponentPath);
+  const afterImport = rewriteOriginalFrontmatter(afterNode, relPath, componentName, newComponentPath, movedComponentNames);
 
+  const importLines = importLinesForNewFile(origFmMatch ? origFmMatch[2] : "", movedComponentNames, relPath, newComponentPath);
   const propsInterface = generatePropsInterface(hoistedPropRecords);
   const propsDestructure = generatePropsDestructure(hoistedPropRecords);
-  const fmParts = [propsInterface, propsDestructure].filter(Boolean);
+  const fmParts = [importLines ? importLines.trimEnd() : null, propsInterface, propsDestructure].filter(Boolean);
   const newFm = fmParts.length ? `---\n${fmParts.join("\n")}\n---\n` : "";
 
   return {

--- a/server/component-extract-edit.mjs
+++ b/server/component-extract-edit.mjs
@@ -2,10 +2,13 @@ import { readFileSync, existsSync } from "node:fs";
 import { join, normalize, basename, dirname, sep } from "node:path";
 import { parse } from "@astrojs/compiler";
 import { fileVersion } from "./file-version.mjs";
-import { buildTemplateNodeIndex } from "./component-node-index.mjs";
+import { buildTemplateNodeIndex, buildLineStarts } from "./component-node-index.mjs";
 import { resolveAllSpans, SpanResolutionError, importSpecifier, collectComponentTags } from "./component-structure-edit.mjs";
 import { ensureImport, parseImports, pruneImportIfUnused } from "./frontmatter-imports.mjs";
 import { parseProps, generatePropsInterface, generatePropsDestructure } from "./props-interface.mjs";
+import { collectElements } from "./component-model.mjs";
+import { indexCssRules } from "./css-rule-index.mjs";
+import { isSimpleSelector, selectorMatchesNode } from "./style-selector-match.mjs";
 
 /**
  * Write-side resolver for extract-component (Component Editor Slice 5). Unlike every other
@@ -161,6 +164,107 @@ function rewriteOriginalFrontmatter(afterNode, relPath, componentName, newCompon
   return `---\n${importLine}---\n${afterNode}`;
 }
 
+function anyNodeMatches(byId, nodeIds, selector) {
+  return nodeIds.some((id) => selectorMatchesNode(selector, byId.get(id)));
+}
+
+/**
+ * `selectorMatchesNode` (Task 1) returns false outright for any non-simple selector — it
+ * doesn't understand combinators, so it can't itself tell whether a complex selector like
+ * ".hero > h1" "touches" the subtree. For the complex-selector warning we don't need real
+ * combinator matching, just a signal of "plausibly related to this subtree" — so split on
+ * whitespace/combinators, strip pseudo-classes/attribute-selector brackets, and check whether
+ * any resulting SIMPLE token matches a subtree node. ".hero > h1" tokenizes to [".hero", "h1"];
+ * either one matching the extracted <div class="hero"> is enough to warn.
+ */
+function selectorTouchesNodes(selector, byId, nodeIds) {
+  const tokens = selector
+    .split(/[\s>+~]+/)
+    .map((tok) => tok.replace(/:[\w-]+(\([^)]*\))?/g, "").replace(/\[[^\]]*\]/g, ""))
+    .filter(Boolean);
+  return tokens.some((tok) => isSimpleSelector(tok) && anyNodeMatches(byId, nodeIds, tok));
+}
+
+/** Splits `rules` into ones to move (simple selector, exclusively inside the subtree) and
+ *  warnings for everything else that touches the subtree but can't safely move. */
+function classifyStyleRules(byId, subtreeIds, outsideIds, rules) {
+  const toMove = [];
+  const warnings = [];
+  for (const rule of rules) {
+    if (!isSimpleSelector(rule.selector)) {
+      if (selectorTouchesNodes(rule.selector, byId, subtreeIds)) {
+        warnings.push(`${rule.selector} not moved: selector too complex to analyze automatically`);
+      }
+      continue;
+    }
+    const insideMatch = anyNodeMatches(byId, subtreeIds, rule.selector);
+    if (!insideMatch) continue;
+    if (anyNodeMatches(byId, outsideIds, rule.selector)) {
+      warnings.push(`${rule.selector} not moved: also used outside the extracted markup`);
+      continue;
+    }
+    toMove.push(rule);
+  }
+  return { toMove, warnings };
+}
+
+// Compares by CONTENT only (selector/media/declaration property+value pairs), never by
+// span. `removeMovedRules` re-parses `current` fresh before every removal, and each prior
+// removal shifts every subsequent byte offset in the file — so a `target` rule's span
+// (captured once, from the original `source`) can never be expected to equal the span of
+// the same rule re-derived from a `current` string of a different length. Declaration
+// `span`s (nested inside `declarations`) would leak into a naive `JSON.stringify` diff,
+// so they're stripped before comparing.
+function sameRule(a, b) {
+  const strip = (decls) => decls.map(({ property, value }) => ({ property, value }));
+  return a.selector === b.selector && a.media === b.media && JSON.stringify(strip(a.declarations)) === JSON.stringify(strip(b.declarations));
+}
+
+function removeRuleSpan(text, span) {
+  let start = span[0];
+  while (start > 0 && (text[start - 1] === " " || text[start - 1] === "\t")) start--;
+  if (start > 0 && text[start - 1] === "\n") start--;
+  return text.slice(0, start) + text.slice(span[1]);
+}
+
+/** Removes each `toMove` rule from `text` one at a time, re-parsing/re-indexing fresh before
+ *  each removal (rather than composing stale offsets) — the same "never trust a stale offset,
+ *  always re-derive against the current string" discipline the rest of this codebase uses. */
+async function removeMovedRules(text, toMove) {
+  let current = text;
+  for (const target of toMove) {
+    const { ast } = await parse(current, { position: true });
+    const lineStarts = buildLineStarts(current);
+    const styleEls = [];
+    collectElements(ast, "style", styleEls);
+    const rules = styleEls.flatMap((el) => indexCssRules(el, lineStarts));
+    const match = rules.find((r) => sameRule(r, target));
+    if (!match) continue; // defensive: rule text/media/declarations are stable across re-parses
+    current = removeRuleSpan(current, match.span);
+  }
+  return current;
+}
+
+function indent(text) {
+  return text.split("\n").map((l) => (l ? "  " + l : l)).join("\n");
+}
+
+function buildMovedStyleBlock(source, toMove) {
+  if (toMove.length === 0) return "";
+  const byMedia = new Map();
+  for (const rule of toMove) {
+    const key = rule.media ?? "";
+    if (!byMedia.has(key)) byMedia.set(key, []);
+    byMedia.get(key).push(rule);
+  }
+  const blocks = [];
+  for (const [media, rules] of byMedia) {
+    const ruleTexts = rules.map((r) => source.slice(r.span[0], r.span[1])).join("\n\n");
+    blocks.push(media ? `@media ${media} {\n${indent(ruleTexts)}\n}` : ruleTexts);
+  }
+  return `\n<style>\n${blocks.join("\n\n")}\n</style>\n`;
+}
+
 export async function resolveComponentExtract(projectRoot, edit) {
   const { component } = edit;
   if (!component || typeof component !== "object") {
@@ -183,7 +287,7 @@ export async function resolveComponentExtract(projectRoot, edit) {
 
   const loaded = await loadFresh(projectRoot, relPath, baseVersion);
   if (loaded.error) return loaded.error;
-  const { source, byId, rootId, astById } = loaded;
+  const { source, ast, byId, rootId, astById } = loaded;
 
   const node = byId.get(nodeId);
   if (!node) return refuse("no-match", "no node found at the given id — the file may have changed");
@@ -222,6 +326,13 @@ export async function resolveComponentExtract(projectRoot, edit) {
   const hoistedPropRecords = findHoistCandidates(byId, astById, subtreeIds, spans, source, originalProps);
   const movedComponentNames = collectComponentTags(byId, nodeId);
 
+  const outsideIds = [...byId.keys()].filter((id) => id !== rootId && !subtreeIds.includes(id));
+  const styleElements = [];
+  collectElements(ast, "style", styleElements);
+  const lineStarts = buildLineStarts(source);
+  const allRules = styleElements.flatMap((el) => indexCssRules(el, lineStarts));
+  const { toMove, warnings } = classifyStyleRules(byId, subtreeIds, outsideIds, allRules);
+
   const instanceAttrs = hoistedPropRecords.map((p) => ` ${p.name}={${p.name}}`).join("");
   const instanceTag = `<${componentName}${instanceAttrs} />`;
   const afterNode = source.slice(0, nodeSpan[0]) + instanceTag + source.slice(nodeSpan[1]);
@@ -233,12 +344,15 @@ export async function resolveComponentExtract(projectRoot, edit) {
   const fmParts = [importLines ? importLines.trimEnd() : null, propsInterface, propsDestructure].filter(Boolean);
   const newFm = fmParts.length ? `---\n${fmParts.join("\n")}\n---\n` : "";
 
+  const finalReplacement = await removeMovedRules(afterImport, toMove);
+  const styleBlock = buildMovedStyleBlock(source, toMove);
+
   return {
     file: relPath,
     range: { start: 0, end: source.length },
-    replacement: afterImport,
-    newFile: { path: newComponentPath, content: `${newFm}${subtreeText}\n` },
+    replacement: finalReplacement,
+    newFile: { path: newComponentPath, content: `${newFm}${subtreeText}\n${styleBlock}` },
     hoistedProps: hoistedPropRecords.map((p) => p.name),
-    warnings: [],
+    warnings,
   };
 }

--- a/server/component-extract-edit.mjs
+++ b/server/component-extract-edit.mjs
@@ -51,14 +51,28 @@ async function loadFresh(projectRoot, relPath, baseVersion) {
   return { source, ast, byId, rootId, astById };
 }
 
+// Detects an existing frontmatter block via indexOf rather than a regex requiring two
+// independently-matched newlines — the regex approach fails to match the minimal
+// empty-body shape `"---\n---\n"` (no blank body line between fences), which caused a
+// second frontmatter block to be prepended in front of the existing one, corrupting the
+// file. Mirrors the already-correct `findFrontmatterEnd` pattern in server/patcher.mjs.
+function findFrontmatterBody(source) {
+  if (!source.startsWith("---")) return null;
+  const afterOpen = source.indexOf("\n", 3);
+  if (afterOpen === -1) return null;
+  const bodyStart = afterOpen + 1;
+  const closeIdx = source.indexOf("\n---", 3);
+  if (closeIdx === -1) return null;
+  return { bodyStart, bodyEnd: closeIdx };
+}
+
 function rewriteOriginalFrontmatter(afterNode, relPath, componentName, newComponentPath) {
-  const fmMatch = afterNode.match(/^(---\r?\n)([\s\S]*?)(\r?\n---)/);
   const specifier = importSpecifier(relPath, newComponentPath);
-  if (fmMatch) {
-    const [, open, fmBody] = fmMatch;
-    const fmBodyStart = fmMatch.index + open.length;
+  const fm = findFrontmatterBody(afterNode);
+  if (fm) {
+    const fmBody = afterNode.slice(fm.bodyStart, fm.bodyEnd);
     const { source: newFmBody } = ensureImport(fmBody, { localName: componentName, specifier });
-    return afterNode.slice(0, fmBodyStart) + newFmBody + afterNode.slice(fmBodyStart + fmBody.length);
+    return afterNode.slice(0, fm.bodyStart) + newFmBody + afterNode.slice(fm.bodyStart + fmBody.length);
   }
   const importLine = `import ${componentName} from "${specifier}";\n`;
   return `---\n${importLine}---\n${afterNode}`;
@@ -78,6 +92,10 @@ export async function resolveComponentExtract(projectRoot, edit) {
   }
   if (!validNewComponentPath(newComponentPath)) {
     return refuse("invalid-input", `newComponentPath must be a project-relative .astro path under src/components/: ${newComponentPath}`);
+  }
+  const componentName = basename(newComponentPath, ".astro");
+  if (!/^[A-Z][A-Za-z0-9_]*$/.test(componentName)) {
+    return refuse("invalid-input", `newComponentPath's basename must be a capitalized component identifier: ${componentName}`);
   }
 
   const loaded = await loadFresh(projectRoot, relPath, baseVersion);
@@ -114,7 +132,6 @@ export async function resolveComponentExtract(projectRoot, edit) {
   }
 
   const subtreeText = source.slice(nodeSpan[0], nodeSpan[1]);
-  const componentName = basename(newComponentPath, ".astro");
 
   const instanceTag = `<${componentName} />`;
   const afterNode = source.slice(0, nodeSpan[0]) + instanceTag + source.slice(nodeSpan[1]);

--- a/server/component-extract-edit.mjs
+++ b/server/component-extract-edit.mjs
@@ -128,7 +128,7 @@ function resolveImportTargetPath(originalRelPath, specifier) {
 // declared) is silently skipped rather than fabricated.
 function importLinesForNewFile(originalFmBody, movedComponentNames, relPath, newComponentPath) {
   const origImports = parseImports(originalFmBody ?? "");
-  return movedComponentNames
+  return [...new Set(movedComponentNames)]
     .map((name) => origImports.find((i) => i.localName === name))
     .filter(Boolean)
     .map((imp) => {

--- a/server/component-extract-edit.mjs
+++ b/server/component-extract-edit.mjs
@@ -1,0 +1,131 @@
+import { readFileSync, existsSync } from "node:fs";
+import { join, normalize, basename, sep } from "node:path";
+import { parse } from "@astrojs/compiler";
+import { fileVersion } from "./file-version.mjs";
+import { buildTemplateNodeIndex } from "./component-node-index.mjs";
+import { resolveAllSpans, SpanResolutionError, importSpecifier } from "./component-structure-edit.mjs";
+import { ensureImport } from "./frontmatter-imports.mjs";
+
+/**
+ * Write-side resolver for extract-component (Component Editor Slice 5). Unlike every other
+ * component op, this one touches TWO files: it carves `nodeId`'s subtree out of the target
+ * component into a brand-new file at `newComponentPath`, and replaces the subtree in the
+ * original with a self-closing instance + import. Returns the widened
+ * `{file, range, replacement, newFile, hoistedProps, warnings}` shape apply-edit-dispatcher.mjs
+ * knows how to write as one atomic two-file edit (see docs/superpowers/specs/
+ * 2026-07-16-extract-component-design.md).
+ */
+
+function refuse(reason, detail) {
+  return { refused: true, reason, detail };
+}
+
+function validComponentPath(relPath) {
+  return typeof relPath === "string" && relPath.endsWith(".astro") && !normalize(relPath).startsWith("..") && !relPath.startsWith("/");
+}
+
+function validNewComponentPath(relPath) {
+  if (!validComponentPath(relPath)) return false;
+  const normalized = normalize(relPath).split(sep).join("/");
+  return normalized.startsWith("src/components/");
+}
+
+async function loadFresh(projectRoot, relPath, baseVersion) {
+  const absPath = join(projectRoot, relPath);
+  let source;
+  try {
+    source = readFileSync(absPath, "utf-8");
+  } catch (err) {
+    return { error: refuse("read-failed", `read ${relPath}: ${err.message}`) };
+  }
+  if (fileVersion(source) !== baseVersion) {
+    return { error: refuse("stale", `${relPath} changed since the model was fetched`) };
+  }
+  let ast;
+  try {
+    ({ ast } = await parse(source, { position: true }));
+  } catch (err) {
+    return { error: refuse("parse-failed", `parse ${relPath}: ${err.message}`) };
+  }
+  const { byId, rootId, astById } = buildTemplateNodeIndex(ast, source);
+  return { source, ast, byId, rootId, astById };
+}
+
+function rewriteOriginalFrontmatter(afterNode, relPath, componentName, newComponentPath) {
+  const fmMatch = afterNode.match(/^(---\r?\n)([\s\S]*?)(\r?\n---)/);
+  const specifier = importSpecifier(relPath, newComponentPath);
+  if (fmMatch) {
+    const [, open, fmBody] = fmMatch;
+    const fmBodyStart = fmMatch.index + open.length;
+    const { source: newFmBody } = ensureImport(fmBody, { localName: componentName, specifier });
+    return afterNode.slice(0, fmBodyStart) + newFmBody + afterNode.slice(fmBodyStart + fmBody.length);
+  }
+  const importLine = `import ${componentName} from "${specifier}";\n`;
+  return `---\n${importLine}---\n${afterNode}`;
+}
+
+export async function resolveComponentExtract(projectRoot, edit) {
+  const { component } = edit;
+  if (!component || typeof component !== "object") {
+    return refuse("invalid-input", "component payload is required for this op");
+  }
+  const { path: relPath, baseVersion, nodeId, newComponentPath } = component;
+  if (!validComponentPath(relPath)) {
+    return refuse("invalid-input", `not a project-relative .astro path: ${relPath}`);
+  }
+  if (typeof nodeId !== "string") {
+    return refuse("invalid-input", "extract-component requires component.nodeId");
+  }
+  if (!validNewComponentPath(newComponentPath)) {
+    return refuse("invalid-input", `newComponentPath must be a project-relative .astro path under src/components/: ${newComponentPath}`);
+  }
+
+  const loaded = await loadFresh(projectRoot, relPath, baseVersion);
+  if (loaded.error) return loaded.error;
+  const { source, byId, rootId } = loaded;
+
+  const node = byId.get(nodeId);
+  if (!node) return refuse("no-match", "no node found at the given id — the file may have changed");
+  if (node.parentId === null) return refuse("invalid-input", "cannot extract the component's root");
+  if (node.kind !== "element" && node.kind !== "component" && node.kind !== "slot") {
+    return refuse("invalid-input", `extract-component requires a tag-shaped node (element/component/slot), got kind=${node.kind}`);
+  }
+
+  if (existsSync(join(projectRoot, newComponentPath))) {
+    return refuse("exists", `${newComponentPath} already exists`);
+  }
+
+  let spans;
+  try {
+    spans = resolveAllSpans(byId, rootId, source);
+  } catch (err) {
+    if (!(err instanceof SpanResolutionError)) throw err;
+    return refuse(
+      "no-match",
+      "could not lexically re-locate the node's true source span without trusting compiler offsets — refusing rather than risking corruption",
+    );
+  }
+  const nodeSpan = spans.get(nodeId);
+  if (!nodeSpan) {
+    return refuse(
+      "no-match",
+      "could not lexically re-locate the node's true source span without trusting compiler offsets — refusing rather than risking corruption",
+    );
+  }
+
+  const subtreeText = source.slice(nodeSpan[0], nodeSpan[1]);
+  const componentName = basename(newComponentPath, ".astro");
+
+  const instanceTag = `<${componentName} />`;
+  const afterNode = source.slice(0, nodeSpan[0]) + instanceTag + source.slice(nodeSpan[1]);
+  const afterImport = rewriteOriginalFrontmatter(afterNode, relPath, componentName, newComponentPath);
+
+  return {
+    file: relPath,
+    range: { start: 0, end: source.length },
+    replacement: afterImport,
+    newFile: { path: newComponentPath, content: `${subtreeText}\n` },
+    hoistedProps: [],
+    warnings: [],
+  };
+}

--- a/server/component-model.mjs
+++ b/server/component-model.mjs
@@ -86,7 +86,7 @@ export async function buildComponentModel(projectRoot, relPath) {
   };
 }
 
-function collectElements(node, name, out) {
+export function collectElements(node, name, out) {
   if (node.type === "element" && node.name === name) out.push(node);
   for (const child of node.children ?? []) collectElements(child, name, out);
 }

--- a/server/component-node-index.mjs
+++ b/server/component-node-index.mjs
@@ -79,6 +79,7 @@ function baseSpanLoc(n, lineStarts) {
 
 export function buildTemplateNodeIndex(ast, source) {
   const byId = new Map();
+  const astById = new Map();
   let next = 0;
   const nextId = () => `n${next++}`;
   const lineStarts = buildLineStarts(source);
@@ -136,6 +137,7 @@ export function buildTemplateNodeIndex(ast, source) {
       case "expression": {
         record = { id: nextId(), kind: "expression", tag: null, attrs: [], ...baseSpanLoc(n, lineStarts), parentId, childIds: [] };
         byId.set(record.id, record);
+        astById.set(record.id, n);
         for (const c of n.children ?? []) {
           if (!JSX_CHILD_TYPES.has(c.type)) continue;
           const child = visit(c, record.id);
@@ -157,12 +159,14 @@ export function buildTemplateNodeIndex(ast, source) {
           childIds: [],
         };
         byId.set(record.id, record);
+        astById.set(record.id, n);
         return record;
       }
       default:
         return null; // comment, doctype
     }
     byId.set(record.id, record);
+    astById.set(record.id, n);
     for (const c of n.children ?? []) {
       if (isZoneNode(c)) continue;
       const child = visit(c, record.id);
@@ -177,5 +181,5 @@ export function buildTemplateNodeIndex(ast, source) {
     if (child) rootChildIds.push(child.id);
   }
 
-  return { byId, rootId };
+  return { byId, rootId, astById };
 }

--- a/server/component-structure-edit.mjs
+++ b/server/component-structure-edit.mjs
@@ -316,7 +316,7 @@ function findTagOpenFrom(masked, tagName, from) {
 // Thrown by `resolveAllSpans` when a node's lexical marker can't be found from the
 // current cursor position. Callers must catch this and refuse the op (fail closed)
 // rather than guess — see the file-level comment above for why offsets can't be trusted.
-class SpanResolutionError extends Error {
+export class SpanResolutionError extends Error {
   constructor(nodeId) {
     super(`could not lexically locate node ${nodeId}`);
     this.nodeId = nodeId;
@@ -336,7 +336,7 @@ const VOID_ELEMENTS = new Set([
 // replaces the old per-node k-th-occurrence search). Returns a Map<nodeId, [start, end]>
 // (only for kinds this function can resolve — text nodes and tagless fragments are
 // never spanned); throws `SpanResolutionError` if a node's marker can't be located.
-function resolveAllSpans(byId, rootId, source) {
+export function resolveAllSpans(byId, rootId, source) {
   const masked = maskOpaqueZones(source);
   const spans = new Map();
   let cursor = 0;
@@ -464,7 +464,7 @@ function applyRemoveNode(file, source, byId, rootId, component) {
   return { file, range: { start: 0, end: source.length }, replacement: rewritten };
 }
 
-function collectComponentTags(byId, nodeId) {
+export function collectComponentTags(byId, nodeId) {
   const names = [];
   function walk(id) {
     const n = byId.get(id);
@@ -489,7 +489,7 @@ function buildMarkup(nodeSpec) {
 /** Relative import specifier from the target component's own directory to the component
  *  being inserted, Astro-style (keeps the .astro extension, always POSIX-separated, always
  *  prefixed with ./ or ../ so it never gets mistaken for a bare-specifier package import). */
-function importSpecifier(targetRelPath, componentRelPath) {
+export function importSpecifier(targetRelPath, componentRelPath) {
   const rel = relative(dirname(targetRelPath), componentRelPath).split(sep).join("/");
   return rel.startsWith(".") ? rel : `./${rel}`;
 }

--- a/server/edit-history.mjs
+++ b/server/edit-history.mjs
@@ -47,10 +47,10 @@ function formatMessage({ file, range, message }) {
 
 /**
  * @param {string} projectRoot
- * @param {{ file: string, range: {start:number,end:number}, message?: string }} info
+ * @param {{ file: string, range: {start:number,end:number}, newFile?: {path: string}, message?: string }} info
  * @returns {Promise<string | undefined>} commit SHA, or undefined on any failure
  */
-export async function recordEdit(projectRoot, { file, range, message }) {
+export async function recordEdit(projectRoot, { file, range, newFile, message }) {
   if (!isGitRepo(projectRoot)) return undefined;
 
   try {
@@ -78,6 +78,10 @@ export async function recordEdit(projectRoot, { file, range, message }) {
         ["update-index", "--add", "--cacheinfo", `100644,${blob},${file}`],
         env,
       );
+      if (newFile) {
+        const newBlob = runGit(projectRoot, ["hash-object", "-w", "--", newFile.path]);
+        runGit(projectRoot, ["update-index", "--add", "--cacheinfo", `100644,${newBlob},${newFile.path}`], env);
+      }
       const tree = runGit(projectRoot, ["write-tree"], env);
       const parent = runGit(projectRoot, ["rev-parse", EDITS_REF]);
       const commit = runGit(projectRoot, [

--- a/server/index-tools.mjs
+++ b/server/index-tools.mjs
@@ -120,8 +120,8 @@ export function buildServer(projectRoot) {
     applyEditInputShape,
     async (input) =>
       applyEdit(projectRoot, input, {
-        onApplied: ({ file, range }) =>
-          recordEdit(projectRoot, { file, range, message: `anglesite: edit ${file}` }),
+        onApplied: ({ file, range, newFile }) =>
+          recordEdit(projectRoot, { file, range, newFile, message: `anglesite: edit ${file}` }),
       }),
   );
 

--- a/server/patcher.mjs
+++ b/server/patcher.mjs
@@ -4,7 +4,8 @@ import { rewriteAstroStyle } from "./style-edit.mjs";
 import { resolveComponentStyle } from "./component-style-edit.mjs";
 import { resolveComponentStructure } from "./component-structure-edit.mjs";
 import { resolveComponentFrontmatter } from "./component-frontmatter-edit.mjs";
-import { COMPONENT_STYLE_OPS, COMPONENT_STRUCTURE_OPS, COMPONENT_FRONTMATTER_OPS } from "./apply-edit-schema.mjs";
+import { resolveComponentExtract } from "./component-extract-edit.mjs";
+import { COMPONENT_STYLE_OPS, COMPONENT_STRUCTURE_OPS, COMPONENT_FRONTMATTER_OPS, COMPONENT_EXTRACT_OPS } from "./apply-edit-schema.mjs";
 
 /**
  * @typedef {import('./apply-edit-schema.mjs').default} _unused
@@ -16,17 +17,18 @@ import { COMPONENT_STYLE_OPS, COMPONENT_STRUCTURE_OPS, COMPONENT_FRONTMATTER_OPS
  * Resolve an edit payload to a source-file patch.
  *
  * Tries resolvers in priority order: edit-style → component-style ops →
- * component-structure ops → component-frontmatter ops → .mdoc → Keystatic
- * YAML/JSON → .astro. Returns the first non-refusal. If all refuse, returns
- * the most informative refusal (from the highest-priority resolver that had
- * an opinion).
+ * component-structure ops → component-frontmatter ops → component-extract ops
+ * → .mdoc → Keystatic YAML/JSON → .astro. Returns the first non-refusal. If
+ * all refuse, returns the most informative refusal (from the highest-priority
+ * resolver that had an opinion).
  *
  * Async because `resolveComponentStyle` (component-style-edit.mjs),
- * `resolveComponentStructure` (component-structure-edit.mjs), and
- * `resolveComponentFrontmatter` (component-frontmatter-edit.mjs) parse the
- * target .astro file with `@astrojs/compiler`, which is itself async. Every
- * other resolver here is synchronous; awaiting their (non-Promise) return
- * values is a no-op, so this doesn't change their behavior.
+ * `resolveComponentStructure` (component-structure-edit.mjs),
+ * `resolveComponentFrontmatter` (component-frontmatter-edit.mjs), and
+ * `resolveComponentExtract` (component-extract-edit.mjs) parse the target
+ * .astro file with `@astrojs/compiler`, which is itself async. Every other
+ * resolver here is synchronous; awaiting their (non-Promise) return values is
+ * a no-op, so this doesn't change their behavior.
  *
  * @param {string} projectRoot
  * @param {{ path: string, selector: object, op: string, value?: unknown, component?: object }} edit
@@ -44,6 +46,9 @@ export async function resolve(projectRoot, edit) {
   }
   if (COMPONENT_FRONTMATTER_OPS.has(edit.op)) {
     return resolveComponentFrontmatter(projectRoot, edit);
+  }
+  if (COMPONENT_EXTRACT_OPS.has(edit.op)) {
+    return resolveComponentExtract(projectRoot, edit);
   }
   const resolvers = [resolveMdoc, resolveKeystatic, resolveAstro];
   let bestRefusal = /** @type {ResolveRefusal | null} */ (null);

--- a/server/style-selector-match.mjs
+++ b/server/style-selector-match.mjs
@@ -1,0 +1,35 @@
+// Purpose-built pattern matching against the outline tree's own tag/class/id
+// data — NOT a general CSS-selector-vs-DOM engine. Bounded to the "obvious"
+// case (a class or tag styling a node directly), consistent with this
+// codebase's "deliberately regex/heuristic, refuse rather than guess"
+// discipline (props-interface.mjs, frontmatter-imports.mjs). Anything with a
+// combinator, pseudo-class, :global(), or attribute selector is "complex"
+// and never matched here — callers treat that as "leave behind, warn."
+
+const TAG_CLASS_RE = /^[a-zA-Z][\w-]*(\.[\w-]+)*$/;
+const CLASS_ONLY_RE = /^(\.[\w-]+)+$/;
+const ID_RE = /^#[\w-]+$/;
+
+export function isSimpleSelector(selector) {
+  const s = selector.trim();
+  if (!s) return false;
+  return TAG_CLASS_RE.test(s) || CLASS_ONLY_RE.test(s) || ID_RE.test(s);
+}
+
+export function selectorMatchesNode(selector, node) {
+  const s = selector.trim();
+  if (ID_RE.test(s)) {
+    const id = node.attrs?.find((a) => a.name === "id")?.value;
+    return id === s.slice(1);
+  }
+  if (!isSimpleSelector(s)) return false;
+  const parts = s.split(".");
+  const tag = parts[0]; // "" when the selector starts with "."
+  const classes = parts.slice(1);
+  if (tag && node.tag !== tag) return false;
+  if (classes.length > 0) {
+    const nodeClasses = (node.attrs?.find((a) => a.name === "class")?.value ?? "").split(/\s+/).filter(Boolean);
+    if (!classes.every((c) => nodeClasses.includes(c))) return false;
+  }
+  return true;
+}

--- a/server/undo-edit.mjs
+++ b/server/undo-edit.mjs
@@ -14,7 +14,7 @@
  *   - working-tree-modified: at least one touched file differs on disk vs. HEAD's blob
  */
 import { execFileSync } from "node:child_process";
-import { writeFileSync } from "node:fs";
+import { writeFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 
 const EDITS_REF = "refs/heads/anglesite/edits";
@@ -76,10 +76,22 @@ export async function undoEdit(projectRoot, { commit, force = false } = {}) {
     }
   }
 
-  // 6. Write parent's blob content for each file back to disk.
+  // 6. Restore each touched file: files that existed at `parent` get their old blob content
+  // written back; files that were pure additions at `head` (didn't exist at `parent` — e.g. the
+  // new component file extract-component creates) get deleted instead, since "undo" for a newly
+  // created file means removing it.
   for (const file of files) {
-    const content = runGitBuffer(projectRoot, ["show", `${parent}:${file}`]);
-    writeFileSync(join(projectRoot, file), content);
+    const existedAtParent = tryRunGit(projectRoot, ["cat-file", "-e", `${parent}:${file}`]) !== undefined;
+    if (existedAtParent) {
+      const content = runGitBuffer(projectRoot, ["show", `${parent}:${file}`]);
+      writeFileSync(join(projectRoot, file), content);
+    } else {
+      try {
+        unlinkSync(join(projectRoot, file));
+      } catch {
+        // already gone; nothing to undo
+      }
+    }
   }
 
   // 7. Advance the hidden branch with a new commit whose tree matches parent's tree.

--- a/test/edit-history.test.js
+++ b/test/edit-history.test.js
@@ -93,4 +93,24 @@ describe("recordEdit", () => {
       rmSync(notRepo, { recursive: true, force: true });
     }
   });
+
+  it("stages a second file into the same commit when newFile is provided", async () => {
+    writeFileSync(join(repo, "README.md"), "edited\n");
+    mkdirSync(join(repo, "src", "components"), { recursive: true });
+    writeFileSync(join(repo, "src", "components", "Hero.astro"), "<div>Hero</div>\n");
+
+    const sha = await recordEdit(repo, {
+      file: "README.md",
+      range: { start: 0, end: 7 },
+      newFile: { path: "src/components/Hero.astro" },
+      message: "extract Hero",
+    });
+
+    expect(sha).toMatch(/^[0-9a-f]{40}$/);
+    expect(git(["show", `${sha}:README.md`])).toBe("edited");
+    expect(git(["show", `${sha}:src/components/Hero.astro`])).toBe("<div>Hero</div>");
+    // Both files land in ONE commit, not two.
+    const parents = git(["rev-list", "--parents", "-n", "1", sha]).split(/\s+/);
+    expect(parents).toHaveLength(2); // sha itself + exactly one parent
+  });
 });

--- a/test/undo-edit.test.js
+++ b/test/undo-edit.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
@@ -127,6 +127,25 @@ describe("undoEdit", () => {
     const result = await undoEdit(repo, {});
     expect(result.status).toBe("refused");
     expect(result.reason).toBe("initial-commit");
+  });
+
+  it("deletes a newly-added file on undo while restoring the modified primary file", async () => {
+    writeFileSync(join(repo, "about.md"), "edited\n");
+    writeFileSync(join(repo, "hero.md"), "brand new\n");
+    const editSha = await recordEdit(repo, {
+      file: "about.md",
+      range: { start: 0, end: 7 },
+      newFile: { path: "hero.md" },
+      message: "extract hero.md",
+    });
+    expect(editSha).toMatch(/^[0-9a-f]{40}$/);
+    expect(existsSync(join(repo, "hero.md"))).toBe(true);
+
+    const result = await undoEdit(repo, {});
+    expect(result.status).toBe("undone");
+
+    expect(readFileSync(join(repo, "about.md"), "utf-8")).toBe("original\n");
+    expect(existsSync(join(repo, "hero.md"))).toBe(false);
   });
 
   it("refuses with no-edits-to-undo when projectRoot is not a git repo", async () => {

--- a/tests/apply-edit-dispatcher-component-extract.test.ts
+++ b/tests/apply-edit-dispatcher-component-extract.test.ts
@@ -7,7 +7,7 @@ import { applyEdit } from "../server/apply-edit-dispatcher.mjs";
 import { buildTemplateNodeIndex } from "../server/component-node-index.mjs";
 import { fileVersion } from "../server/file-version.mjs";
 
-const PAGE = `---\ninterface Props { title: string; }\nconst { title } = Astro.props;\n---\n<main>\n  <div class="hero">\n    <h1>{title}</h1>\n  </div>\n</main>\n`;
+const PAGE = `---\ninterface Props {\n  title: string;\n}\nconst { title } = Astro.props;\n---\n<main>\n  <div class="hero">\n    <h1>{title}</h1>\n  </div>\n</main>\n`;
 
 function parseContent(response) {
   return JSON.parse(response.content[0].text);

--- a/tests/apply-edit-dispatcher-component-extract.test.ts
+++ b/tests/apply-edit-dispatcher-component-extract.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parse } from "@astrojs/compiler";
+import { applyEdit } from "../server/apply-edit-dispatcher.mjs";
+import { buildTemplateNodeIndex } from "../server/component-node-index.mjs";
+import { fileVersion } from "../server/file-version.mjs";
+
+const PAGE = `---\ninterface Props { title: string; }\nconst { title } = Astro.props;\n---\n<main>\n  <div class="hero">\n    <h1>{title}</h1>\n  </div>\n</main>\n`;
+
+function parseContent(response) {
+  return JSON.parse(response.content[0].text);
+}
+
+async function nodeIndex(source) {
+  const { ast } = await parse(source, { position: true });
+  return buildTemplateNodeIndex(ast, source);
+}
+
+describe("applyEdit — extract-component", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-aed-ext-"));
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), PAGE);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function findDiv() {
+    const { byId, rootId } = await nodeIndex(PAGE);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    return byId.get(main.childIds[0]);
+  }
+
+  it("writes both files, commits once, and returns componentPath/hoistedProps/warnings in result", async () => {
+    const baseVersion = fileVersion(PAGE);
+    const div = await findDiv();
+
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Page.astro",
+      op: "extract-component",
+      component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" },
+    });
+
+    expect(response.isError).toBeFalsy();
+    const body = parseContent(response);
+    expect(body.type).toBe("anglesite:edit-applied");
+    expect(body.result.componentPath).toBe("src/components/Hero.astro");
+    expect(body.result.hoistedProps).toEqual(["title"]);
+    expect(body.result.warnings).toEqual([]);
+    expect(body.model).toBeDefined();
+    expect(body.model.path).toBe("src/components/Page.astro");
+
+    expect(existsSync(join(tmpDir, "src", "components", "Hero.astro"))).toBe(true);
+    const newFileOnDisk = readFileSync(join(tmpDir, "src", "components", "Hero.astro"), "utf-8");
+    expect(newFileOnDisk).toContain("<h1>{title}</h1>");
+    const originalOnDisk = readFileSync(join(tmpDir, "src", "components", "Page.astro"), "utf-8");
+    expect(originalOnDisk).toContain("<Hero title={title} />");
+  });
+
+  it("refuses exists without writing anything when newComponentPath is already taken", async () => {
+    writeFileSync(join(tmpDir, "src", "components", "Hero.astro"), "<p>taken</p>\n");
+    const baseVersion = fileVersion(PAGE);
+    const div = await findDiv();
+
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Page.astro",
+      op: "extract-component",
+      component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" },
+    });
+
+    expect(response.isError).toBe(true);
+    const body = parseContent(response);
+    expect(body.reason).toBe("exists");
+    const originalOnDisk = readFileSync(join(tmpDir, "src", "components", "Page.astro"), "utf-8");
+    expect(originalOnDisk).toBe(PAGE); // untouched
+  });
+
+  it("dry_run returns both previews and writes neither file", async () => {
+    const baseVersion = fileVersion(PAGE);
+    const div = await findDiv();
+
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Page.astro",
+      op: "extract-component",
+      component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" },
+      dry_run: true,
+    });
+
+    expect(response.isError).toBeFalsy();
+    const body = parseContent(response);
+    expect(body.type).toBe("anglesite:edit-preview");
+    expect(body.newFile.path).toBe("src/components/Hero.astro");
+    expect(body.newFile.after).toContain("<h1>{title}</h1>");
+    expect(body.after).toContain("<Hero title={title} />");
+    expect(existsSync(join(tmpDir, "src", "components", "Hero.astro"))).toBe(false);
+    expect(readFileSync(join(tmpDir, "src", "components", "Page.astro"), "utf-8")).toBe(PAGE);
+  });
+
+  it("commits both files in one hidden-branch commit and undo_edit reverts both", async () => {
+    const { execFileSync } = await import("node:child_process");
+    execFileSync("git", ["init", "--initial-branch=main", tmpDir], { stdio: "ignore" });
+    execFileSync("git", ["-C", tmpDir, "config", "user.email", "t@example.com"]);
+    execFileSync("git", ["-C", tmpDir, "config", "user.name", "T"]);
+    execFileSync("git", ["-C", tmpDir, "add", "-A"]);
+    execFileSync("git", ["-C", tmpDir, "commit", "-m", "initial"]);
+
+    const { recordEdit } = await import("../server/edit-history.mjs");
+    const { undoEdit } = await import("../server/undo-edit.mjs");
+    const baseVersion = fileVersion(PAGE);
+    const div = await findDiv();
+
+    const response = await applyEdit(
+      tmpDir,
+      {
+        id: "1",
+        path: "src/components/Page.astro",
+        op: "extract-component",
+        component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" },
+      },
+      { onApplied: ({ file, range, newFile }) => recordEdit(tmpDir, { file, range, newFile, message: `extract ${file}` }) },
+    );
+    const body = parseContent(response);
+    expect(body.commit).toMatch(/^[0-9a-f]{40}$/);
+    expect(existsSync(join(tmpDir, "src", "components", "Hero.astro"))).toBe(true);
+
+    const undone = await undoEdit(tmpDir, {});
+    expect(undone.status).toBe("undone");
+    expect(readFileSync(join(tmpDir, "src", "components", "Page.astro"), "utf-8")).toBe(PAGE);
+    expect(existsSync(join(tmpDir, "src", "components", "Hero.astro"))).toBe(false);
+  });
+
+  it("re-checks staleness after the resolver's async gap, refusing a concurrent write race", async () => {
+    const baseVersion = fileVersion(PAGE);
+    const div = await findDiv();
+
+    const editPromise = applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Page.astro",
+      op: "extract-component",
+      component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" },
+    });
+
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), PAGE.replace("Welcome", "Renamed").replace("{title}", "{title} "));
+
+    const response = await editPromise;
+    expect(response.isError).toBe(true);
+    const body = parseContent(response);
+    expect(body.reason).toBe("stale");
+    expect(existsSync(join(tmpDir, "src", "components", "Hero.astro"))).toBe(false);
+  });
+});

--- a/tests/apply-edit-schema-extract.test.ts
+++ b/tests/apply-edit-schema-extract.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import {
+  editOps,
+  componentEditSchema,
+  applyEditInputShape,
+  COMPONENT_EXTRACT_OPS,
+  COMPONENT_OPS,
+  createEditPreviewContent,
+} from "../server/apply-edit-schema.mjs";
+
+describe("extract-component schema", () => {
+  it("registers extract-component in editOps, COMPONENT_EXTRACT_OPS, and COMPONENT_OPS", () => {
+    expect(editOps).toContain("extract-component");
+    expect(COMPONENT_EXTRACT_OPS.has("extract-component")).toBe(true);
+    expect(COMPONENT_OPS.has("extract-component")).toBe(true);
+  });
+
+  it("accepts an extract-component payload with nodeId and newComponentPath", () => {
+    const result = componentEditSchema.safeParse({
+      path: "src/components/Page.astro",
+      baseVersion: "sha256:abc123456789",
+      nodeId: "n3",
+      newComponentPath: "src/components/Hero.astro",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a full apply_edit input for extract-component", () => {
+    const schema = z.object(applyEditInputShape);
+    const result = schema.safeParse({
+      id: "1",
+      path: "src/components/Page.astro",
+      op: "extract-component",
+      component: { path: "src/components/Page.astro", baseVersion: "sha256:abc123456789", nodeId: "n3", newComponentPath: "src/components/Hero.astro" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("createEditPreviewContent includes newFile when provided, omits it otherwise", () => {
+    const withNewFile = JSON.parse(createEditPreviewContent("1", "a.astro", { start: 0, end: 1 }, "extract-component", "before", "after", { path: "b.astro", after: "content" }).text);
+    expect(withNewFile.newFile).toEqual({ path: "b.astro", after: "content" });
+
+    const without = JSON.parse(createEditPreviewContent("1", "a.astro", { start: 0, end: 1 }, "set-attr", "before", "after").text);
+    expect(without.newFile).toBeUndefined();
+  });
+});

--- a/tests/component-extract-edit.test.ts
+++ b/tests/component-extract-edit.test.ts
@@ -141,4 +141,78 @@ describe("resolveComponentExtract — core", () => {
     expect(result.refused).toBe(true);
     expect(result.reason).toBe("invalid-input");
   });
+
+  it("hoists a bare-identifier attribute expression that is one of the original's own Props", async () => {
+    const source = `---\ninterface Props {\n  title: string;\n}\nconst { title } = Astro.props;\n---\n<main>\n  <div class="hero" data-label={title}>\n    <h1>Static</h1>\n  </div>\n</main>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+    const baseVersion = fileVersion(source);
+    const { byId, rootId } = await nodeIndex(source);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[0]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    expect(result.hoistedProps).toEqual(["title"]);
+    expect(result.newFile.content).toContain("interface Props {\n  title: string;\n}");
+    expect(result.newFile.content).toContain("const { title } = Astro.props;");
+    expect(result.replacement).toContain("<Hero title={title} />");
+  });
+
+  it("hoists a bare-identifier text-content expression that is one of the original's own Props", async () => {
+    const source = `---\ninterface Props {\n  title: string;\n}\nconst { title } = Astro.props;\n---\n<main>\n  <div class="hero">\n    <h1>{title}</h1>\n  </div>\n</main>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+    const baseVersion = fileVersion(source);
+    const { byId, rootId } = await nodeIndex(source);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[0]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.hoistedProps).toEqual(["title"]);
+    expect(result.newFile.content).toContain("<h1>{title}</h1>");
+  });
+
+  it("does not hoist a bare identifier that is not one of the original's own Props", async () => {
+    const source = `---\nconst label = "computed";\n---\n<main>\n  <div class="hero">\n    <h1>{label}</h1>\n  </div>\n</main>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+    const baseVersion = fileVersion(source);
+    const { byId, rootId } = await nodeIndex(source);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[0]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.hoistedProps).toEqual([]);
+    expect(result.newFile.content).toContain("<h1>{label}</h1>"); // left in place, unhoisted
+    expect(result.newFile.content).not.toContain("interface Props");
+  });
+
+  it("does not hoist a non-bare-identifier expression even when it references an original Prop", async () => {
+    const source = `---\ninterface Props {\n  title: string;\n}\nconst { title } = Astro.props;\n---\n<main>\n  <div class="hero">\n    <h1>{title.toUpperCase()}</h1>\n  </div>\n</main>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+    const baseVersion = fileVersion(source);
+    const { byId, rootId } = await nodeIndex(source);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[0]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.hoistedProps).toEqual([]);
+    expect(result.newFile.content).toContain("<h1>{title.toUpperCase()}</h1>");
+  });
+
+  it("dedups the same identifier referenced twice into one hoisted prop", async () => {
+    const source = `---\ninterface Props {\n  title: string;\n}\nconst { title } = Astro.props;\n---\n<main>\n  <div class="hero" data-label={title}>\n    <h1>{title}</h1>\n  </div>\n</main>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+    const baseVersion = fileVersion(source);
+    const { byId, rootId } = await nodeIndex(source);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[0]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.hoistedProps).toEqual(["title"]);
+    expect(result.replacement.match(/title=\{title\}/g)).toHaveLength(1); // one instance attr, not two
+  });
 });

--- a/tests/component-extract-edit.test.ts
+++ b/tests/component-extract-edit.test.ts
@@ -110,9 +110,11 @@ describe("resolveComponentExtract — core", () => {
     // PAGE's frontmatter is the minimal empty-body, adjacent-fence shape ("---\n---\n"). A prior
     // regex-based frontmatter detector failed to match this shape and prepended a second
     // frontmatter block, leaving a stray "---\n---\n" text node when re-parsed. Guard against
-    // regressions by re-parsing the rewritten source and asserting exactly one frontmatter node.
+    // regressions by re-parsing the rewritten source and asserting exactly one frontmatter node
+    // AND that no stray text nodes contain "---" (which would indicate corruption).
     const { ast: nextAst } = await parse(next, { position: true });
     expect(nextAst.children.filter((n) => n.type === "frontmatter")).toHaveLength(1);
+    expect(nextAst.children.some((n) => n.type === "text" && n.value.includes("---"))).toBe(false);
   });
 
   it("refuses invalid-input when newComponentPath's basename is not capitalized", async () => {

--- a/tests/component-extract-edit.test.ts
+++ b/tests/component-extract-edit.test.ts
@@ -1,0 +1,124 @@
+// tests/component-extract-edit.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parse } from "@astrojs/compiler";
+import { resolveComponentExtract } from "../server/component-extract-edit.mjs";
+import { buildTemplateNodeIndex } from "../server/component-node-index.mjs";
+import { fileVersion } from "../server/file-version.mjs";
+
+const PAGE = `---\n---\n<main>\n  <div class="hero">\n    <h1>Welcome</h1>\n  </div>\n</main>\n`;
+
+async function nodeIndex(source) {
+  const { ast } = await parse(source, { position: true });
+  return buildTemplateNodeIndex(ast, source);
+}
+
+describe("resolveComponentExtract — core", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-cee-"));
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), PAGE);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("refuses invalid-input with no component payload", async () => {
+    const result = await resolveComponentExtract(tmpDir, { op: "extract-component" });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+
+  it("refuses stale when baseVersion does not match", async () => {
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion: "sha256:000000000000", nodeId: "n1", newComponentPath: "src/components/Hero.astro" } };
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("stale");
+  });
+
+  it("refuses invalid-input for newComponentPath outside src/components/", async () => {
+    const baseVersion = fileVersion(PAGE);
+    const { byId, rootId } = await nodeIndex(PAGE);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[0]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/pages/Hero.astro" } };
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+
+  it("refuses invalid-input when extracting the component's root", async () => {
+    const baseVersion = fileVersion(PAGE);
+    const { rootId } = await nodeIndex(PAGE);
+    // rootId IS a real byId entry (the synthetic fragment root, parentId: null) — resolveComponentExtract's
+    // parentId === null check refuses it as invalid-input, same as remove-node's "cannot remove the
+    // component's root" rule. Extracting a real top-level node like <main> is unaffected by this check
+    // (its own parentId is rootId, not null) — already exercised by the "extracts a subtree..." test below,
+    // which extracts the doubly-nested <div>.
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: rootId, newComponentPath: "src/components/Hero.astro" } };
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+
+  it("refuses no-match when the nodeId no longer exists", async () => {
+    const baseVersion = fileVersion(PAGE);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: "n999", newComponentPath: "src/components/Hero.astro" } };
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("no-match");
+  });
+
+  it("refuses exists when newComponentPath already has a file on disk", async () => {
+    writeFileSync(join(tmpDir, "src", "components", "Hero.astro"), "<p>taken</p>\n");
+    const baseVersion = fileVersion(PAGE);
+    const { byId, rootId } = await nodeIndex(PAGE);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[0]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("exists");
+  });
+
+  it("extracts a subtree with no outer references into a new file and leaves a self-closing instance behind", async () => {
+    const baseVersion = fileVersion(PAGE);
+    const { byId, rootId } = await nodeIndex(PAGE);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[0]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    expect(result.newFile.path).toBe("src/components/Hero.astro");
+    expect(result.newFile.content).toContain('<div class="hero">');
+    expect(result.newFile.content).toContain("<h1>Welcome</h1>");
+    expect(result.hoistedProps).toEqual([]);
+    expect(result.warnings).toEqual([]);
+
+    const next = result.replacement; // whole-file rewrite: range covers [0, source.length]
+    expect(result.range).toEqual({ start: 0, end: PAGE.length });
+    expect(next).toContain("<Hero />");
+    expect(next).not.toContain('<div class="hero">');
+    expect(next).toMatch(/import Hero from "\.\/Hero\.astro";/);
+  });
+
+  it("refuses invalid-input for a text-kind node", async () => {
+    const source = `---\n---\n<p>plain text</p>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+    const baseVersion = fileVersion(source);
+    const { byId, rootId } = await nodeIndex(source);
+    const p = byId.get(byId.get(rootId).childIds[0]);
+    const textNode = byId.get(p.childIds[0]);
+    expect(textNode.kind).toBe("text");
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: textNode.id, newComponentPath: "src/components/Hero.astro" } };
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+});

--- a/tests/component-extract-edit.test.ts
+++ b/tests/component-extract-edit.test.ts
@@ -215,4 +215,54 @@ describe("resolveComponentExtract — core", () => {
     expect(result.hoistedProps).toEqual(["title"]);
     expect(result.replacement.match(/title=\{title\}/g)).toHaveLength(1); // one instance attr, not two
   });
+
+  it("copies a nested component's import into the new file, re-based to its directory, and prunes it from the original when unused elsewhere", async () => {
+    const source = `---\nimport Badge from "./Badge.astro";\n---\n<main>\n  <div class="hero">\n    <Badge />\n  </div>\n</main>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+    writeFileSync(join(tmpDir, "src", "components", "Badge.astro"), "<span>Badge</span>\n");
+    const baseVersion = fileVersion(source);
+    const { byId, rootId } = await nodeIndex(source);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[0]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    expect(result.newFile.content).toMatch(/import Badge from "\.\/Badge\.astro";/);
+    expect(result.newFile.content).toContain("<Badge />");
+    expect(result.replacement).not.toContain("import Badge"); // pruned — no longer used in the original
+    expect(result.replacement).toMatch(/import Hero from "\.\/Hero\.astro";/);
+  });
+
+  it("keeps a nested component's import in the original when it's also used outside the extracted subtree", async () => {
+    const source = `---\nimport Badge from "./Badge.astro";\n---\n<main>\n  <Badge />\n  <div class="hero">\n    <Badge />\n  </div>\n</main>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+    writeFileSync(join(tmpDir, "src", "components", "Badge.astro"), "<span>Badge</span>\n");
+    const baseVersion = fileVersion(source);
+    const { byId, rootId } = await nodeIndex(source);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[1]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.replacement).toMatch(/import Badge from "\.\/Badge\.astro";/); // still needed for the sibling <Badge />
+    expect(result.newFile.content).toMatch(/import Badge from "\.\/Badge\.astro";/); // also copied — extracted one still needs it
+  });
+
+  it("re-bases a nested component's relative import specifier for a new file in a different directory", async () => {
+    mkdirSync(join(tmpDir, "src", "components", "sections"), { recursive: true });
+    const source = `---\nimport Badge from "../Badge.astro";\n---\n<main>\n  <div class="hero">\n    <Badge />\n  </div>\n</main>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "sections", "Page.astro"), source);
+    writeFileSync(join(tmpDir, "src", "components", "Badge.astro"), "<span>Badge</span>\n");
+    const baseVersion = fileVersion(source);
+    const { byId, rootId } = await nodeIndex(source);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[0]);
+    const edit = { op: "extract-component", component: { path: "src/components/sections/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+    const result = await resolveComponentExtract(tmpDir, edit);
+    // Hero.astro lives directly under src/components/, so its import of Badge.astro (a sibling) is "./Badge.astro",
+    // not the "../Badge.astro" that was correct from sections/Page.astro's own directory.
+    expect(result.newFile.content).toMatch(/import Badge from "\.\/Badge\.astro";/);
+  });
 });

--- a/tests/component-extract-edit.test.ts
+++ b/tests/component-extract-edit.test.ts
@@ -285,4 +285,72 @@ describe("resolveComponentExtract — core", () => {
     const badgeUsages = result.newFile.content.match(/<Badge \/>/g);
     expect(badgeUsages).toHaveLength(2);
   });
+
+  it("moves a simple-selector rule that only targets nodes inside the extracted subtree", async () => {
+    const source = `---\n---\n<main>\n  <div class="hero">\n    <h1>Hi</h1>\n  </div>\n</main>\n<style>\n  .hero {\n    color: blue;\n  }\n</style>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+    const baseVersion = fileVersion(source);
+    const { byId, rootId } = await nodeIndex(source);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[0]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.warnings).toEqual([]);
+    expect(result.newFile.content).toContain(".hero {\n    color: blue;\n  }");
+    expect(result.replacement).not.toContain("color: blue");
+    // The rule's own text is gone, but removeMovedRules only strips the {...} block it matched —
+    // it does not clean up a now-empty surrounding <style></style> shell (documented limitation,
+    // see the note under Step 3 below). Assert the shell is empty rather than asserting it's gone.
+    expect(result.replacement).toMatch(/<style>\s*<\/style>/);
+  });
+
+  it("keeps a simple-selector rule in the original and reports a warning when it's also used outside the extracted subtree", async () => {
+    const source = `---\n---\n<main>\n  <p class="hero">Outside</p>\n  <div class="hero">\n    <h1>Hi</h1>\n  </div>\n</main>\n<style>\n  .hero {\n    color: blue;\n  }\n</style>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+    const baseVersion = fileVersion(source);
+    const { byId, rootId } = await nodeIndex(source);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[1]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.warnings).toEqual([".hero not moved: also used outside the extracted markup"]);
+    expect(result.replacement).toContain("color: blue"); // stays in the original
+    expect(result.newFile.content).not.toContain("<style>");
+  });
+
+  it("keeps a complex-selector rule in the original and reports a warning", async () => {
+    const source = `---\n---\n<main>\n  <div class="hero">\n    <h1>Hi</h1>\n  </div>\n</main>\n<style>\n  .hero > h1 {\n    color: blue;\n  }\n</style>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+    const baseVersion = fileVersion(source);
+    const { byId, rootId } = await nodeIndex(source);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[0]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+    const result = await resolveComponentExtract(tmpDir, edit);
+    // css-tree's generate() (used by indexCssRules, out of scope for this task) normalizes
+    // combinator whitespace away — ".hero > h1" round-trips as ".hero>h1", not the
+    // source-literal spacing. The warning text is built from that already-normalized
+    // rule.selector, so it reflects the normalized form too.
+    expect(result.warnings).toEqual([".hero>h1 not moved: selector too complex to analyze automatically"]);
+    expect(result.replacement).toContain("color: blue");
+  });
+
+  it("splits a media-query block when only some of its rules move", async () => {
+    const source = `---\n---\n<main>\n  <p class="kept">Kept</p>\n  <div class="hero">\n    <h1>Hi</h1>\n  </div>\n</main>\n<style>\n  @media (min-width: 40em) {\n    .hero {\n      color: blue;\n    }\n    .kept {\n      color: red;\n    }\n  }\n</style>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+    const baseVersion = fileVersion(source);
+    const { byId, rootId } = await nodeIndex(source);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[1]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.warnings).toEqual([]);
+    expect(result.newFile.content).toMatch(/@media \(min-width: 40em\)[\s\S]*\.hero[\s\S]*color: blue/);
+    expect(result.replacement).toMatch(/@media \(min-width: 40em\)[\s\S]*\.kept[\s\S]*color: red/);
+    expect(result.replacement).not.toContain(".hero");
+  });
 });

--- a/tests/component-extract-edit.test.ts
+++ b/tests/component-extract-edit.test.ts
@@ -265,4 +265,24 @@ describe("resolveComponentExtract — core", () => {
     // not the "../Badge.astro" that was correct from sections/Page.astro's own directory.
     expect(result.newFile.content).toMatch(/import Badge from "\.\/Badge\.astro";/);
   });
+
+  it("dedups a repeated nested-component import when the same component appears multiple times in the extracted subtree", async () => {
+    const source = `---\nimport Badge from "./Badge.astro";\n---\n<main>\n  <div class="hero">\n    <Badge />\n    <Badge />\n  </div>\n</main>\n`;
+    writeFileSync(join(tmpDir, "src", "components", "Page.astro"), source);
+    writeFileSync(join(tmpDir, "src", "components", "Badge.astro"), "<span>Badge</span>\n");
+    const baseVersion = fileVersion(source);
+    const { byId, rootId } = await nodeIndex(source);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[0]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/Hero.astro" } };
+
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.refused).toBeFalsy();
+    // The import line should appear exactly once, not twice
+    const importMatches = result.newFile.content.match(/import Badge from "\.\/Badge\.astro";/g);
+    expect(importMatches).toHaveLength(1);
+    // But both <Badge /> usages should still be in the extracted markup
+    const badgeUsages = result.newFile.content.match(/<Badge \/>/g);
+    expect(badgeUsages).toHaveLength(2);
+  });
 });

--- a/tests/component-extract-edit.test.ts
+++ b/tests/component-extract-edit.test.ts
@@ -106,6 +106,24 @@ describe("resolveComponentExtract — core", () => {
     expect(next).toContain("<Hero />");
     expect(next).not.toContain('<div class="hero">');
     expect(next).toMatch(/import Hero from "\.\/Hero\.astro";/);
+
+    // PAGE's frontmatter is the minimal empty-body, adjacent-fence shape ("---\n---\n"). A prior
+    // regex-based frontmatter detector failed to match this shape and prepended a second
+    // frontmatter block, leaving a stray "---\n---\n" text node when re-parsed. Guard against
+    // regressions by re-parsing the rewritten source and asserting exactly one frontmatter node.
+    const { ast: nextAst } = await parse(next, { position: true });
+    expect(nextAst.children.filter((n) => n.type === "frontmatter")).toHaveLength(1);
+  });
+
+  it("refuses invalid-input when newComponentPath's basename is not capitalized", async () => {
+    const baseVersion = fileVersion(PAGE);
+    const { byId, rootId } = await nodeIndex(PAGE);
+    const main = byId.get(byId.get(rootId).childIds[0]);
+    const div = byId.get(main.childIds[0]);
+    const edit = { op: "extract-component", component: { path: "src/components/Page.astro", baseVersion, nodeId: div.id, newComponentPath: "src/components/hero.astro" } };
+    const result = await resolveComponentExtract(tmpDir, edit);
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
   });
 
   it("refuses invalid-input for a text-kind node", async () => {

--- a/tests/component-node-index.test.ts
+++ b/tests/component-node-index.test.ts
@@ -27,6 +27,17 @@ describe("buildTemplateNodeIndex", () => {
     expect(article.parentId).toBe("n0");
   });
 
+  it("also returns astById, mapping each node id to its raw compiler AST node", async () => {
+    const source = `---\n---\n<div title={foo}><h2>Hi</h2></div>\n`;
+    const { ast } = await parse(source, { position: true });
+    const { byId, rootId, astById } = buildTemplateNodeIndex(ast, source);
+    const div = byId.get(byId.get(rootId).childIds[0]);
+    const astNode = astById.get(div.id);
+    expect(astNode.type).toBe("element");
+    expect(astNode.name).toBe("div");
+    expect(astNode.attributes.find((a) => a.name === "title").kind).toBe("expression");
+  });
+
   it("captures attribute name/value/span", async () => {
     const { ast } = await parse(CARD, { position: true });
     const { byId, rootId } = buildTemplateNodeIndex(ast, CARD);

--- a/tests/style-selector-match.test.ts
+++ b/tests/style-selector-match.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { isSimpleSelector, selectorMatchesNode } from "../server/style-selector-match.mjs";
+
+describe("isSimpleSelector", () => {
+  it("accepts a bare tag, a bare class, a compound tag.class, an id, and multiple classes", () => {
+    expect(isSimpleSelector("div")).toBe(true);
+    expect(isSimpleSelector(".card")).toBe(true);
+    expect(isSimpleSelector("div.card")).toBe(true);
+    expect(isSimpleSelector("#hero")).toBe(true);
+    expect(isSimpleSelector("div.card.featured")).toBe(true);
+  });
+
+  it("rejects combinators, pseudo-classes, :global(), and attribute selectors", () => {
+    expect(isSimpleSelector(".card > h2")).toBe(false);
+    expect(isSimpleSelector(".card:hover")).toBe(false);
+    expect(isSimpleSelector(".parent .child")).toBe(false);
+    expect(isSimpleSelector(":global(.card)")).toBe(false);
+    expect(isSimpleSelector('[data-foo="bar"]')).toBe(false);
+    expect(isSimpleSelector("")).toBe(false);
+  });
+});
+
+describe("selectorMatchesNode", () => {
+  const div = { tag: "div", attrs: [{ name: "class", value: "card featured" }] };
+  const bareDiv = { tag: "div", attrs: [] };
+  const withId = { tag: "section", attrs: [{ name: "id", value: "hero" }] };
+
+  it("matches a bare tag selector against the node's own tag", () => {
+    expect(selectorMatchesNode("div", div)).toBe(true);
+    expect(selectorMatchesNode("section", div)).toBe(false);
+  });
+
+  it("matches a class selector when the node carries that class", () => {
+    expect(selectorMatchesNode(".card", div)).toBe(true);
+    expect(selectorMatchesNode(".missing", div)).toBe(false);
+    expect(selectorMatchesNode(".card", bareDiv)).toBe(false);
+  });
+
+  it("requires every class in a compound selector to be present", () => {
+    expect(selectorMatchesNode("div.card.featured", div)).toBe(true);
+    expect(selectorMatchesNode("div.card.other", div)).toBe(false);
+  });
+
+  it("matches an id selector against the node's id attribute", () => {
+    expect(selectorMatchesNode("#hero", withId)).toBe(true);
+    expect(selectorMatchesNode("#other", withId)).toBe(false);
+    expect(selectorMatchesNode("#hero", div)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `extract-component` to the `apply_edit` MCP tool — the first op that writes **two files** atomically in one edit: carves a `get_component_model` outline subtree (element/component/slot only) out of an existing `.astro` component into a brand-new file under `src/components/`, and replaces the extracted markup with a self-closing instance + import.
- Hoists the original component's own declared Props that the subtree bare-referenced (`props-interface.mjs`'s `parseProps`), copies/rebases/prunes nested-component imports carried into the moved markup, and migrates simple-selector (tag/class/id only) scoped-style rules that exclusively target the extracted markup — anything shared or too complex to analyze automatically stays behind with a non-blocking entry in a new `warnings` array.
- Both files land in **one** commit on the hidden `anglesite/edits` history branch, so `undo_edit` reverts both together in a single step.
- `server/undo-edit.mjs` gains a fix for its own latent gap: it previously assumed every touched file existed in the parent commit (true for every other op) and crashed reverting a brand-new file. It now deletes files that didn't exist at the parent commit instead of trying to restore them.

Design: `docs/superpowers/specs/2026-07-16-extract-component-design.md`
Plan: `docs/superpowers/plans/2026-07-16-extract-component.md`

## Paired PR check

- [ ] This change **needs a paired PR** in [`Anglesite/Anglesite-app`](https://github.com/Anglesite/Anglesite-app) — the app-side "Extract into Component…" UI, name-prompt dialog, and `result.warnings`/`hoistedProps` surfacing (Anglesite-app#495, Component Editor Slice 5). Not included in this PR; app-side work is a separate follow-up per the established Slice 4 pattern (PR #418 / Anglesite-app#494).
- [ ] Version bump (`bin/release.ts`) is intentionally **not** included here — versioning/tagging/release should happen from `main` after this branch merges, not from the feature branch.

## Test plan

- [x] `npx vitest run` — 3086 passed, 1 pre-existing unrelated failure (`test/optimize-images-packaging.test.js`, missing local `node_modules/.bin/tsx` binary — confirmed via `npm ls tsx` returning empty; last touched by an unrelated PR #402, not caused by this branch).
- [x] New tests across 6 files: `tests/style-selector-match.test.ts`, `tests/component-extract-edit.test.ts` (22 cases covering the core move, prop hoisting, nested-import copy/prune, and style migration), `tests/apply-edit-schema-extract.test.ts`, `tests/apply-edit-dispatcher-component-extract.test.ts` (full round trip, `exists` refusal, `dry_run`, one-commit-undo-reverts-both, concurrency/staleness race), plus additions to `test/edit-history.test.js` and `test/undo-edit.test.js`.
- [x] Built via 10 TDD subagent-driven tasks, each independently spec-compliance + code-quality reviewed (several real bugs — empty-frontmatter corruption, duplicate nested-component imports, a stale-span rule-matching bug, the `undo_edit` new-file gap — were caught and fixed during those reviews), plus a final whole-branch review (**Ready to merge: Yes**, no Critical/Important issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)