### PR TITLE
docs: trim derivable content from root CLAUDE.md

### DIFF
--- a/.claude/skills/serena/SKILL.md
+++ b/.claude/skills/serena/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: serena
+description: Set up Serena for semantic, symbol-level code navigation when working on the Anglesite plugin itself — indexing the project and starting its MCP server via uvx. Use when tracing cross-skill references or finding symbol usages across the skills tree.
+---
+
+# Serena (optional, plugin development)
+
+[Serena](https://github.com/oraios/serena) provides semantic, symbol-level code navigation via language servers. It's useful when working on the plugin itself (tracing cross-skill references, finding symbol usages across the skills tree). Not required — all standard tools work without it.
+
+**Setup:**
+
+```sh
+# Index the project (one-time)
+uvx -p 3.13 --from git+https://github.com/oraios/serena serena project index
+
+# Start the MCP server
+uvx -p 3.13 --from git+https://github.com/oraios/serena serena start-mcp-server --project .
+```
+
+Config lives in `.serena/project.yml`. Requires Python 3.13 and [uv](https://docs.astral.sh/uv/).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 Anglesite is a Claude plugin that scaffolds and manages websites for small businesses. It works with Claude Cowork (non-technical site owners, GUI) and Claude Code (developers, CLI). It generates Astro + Keystatic sites deployed to Cloudflare Workers (Static Assets, via the `@astrojs/cloudflare` adapter).
 
+**Version:** 1.7.0
+
+> Don't hand-edit or remove that line: `bin/release.ts` rewrites it on every bump and **throws** if it's missing, and `tests/release.test.ts` asserts it matches `package.json`.
+
 ## Agent instruction hierarchy
 
 Two levels of agent instructions exist — do not confuse them:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,150 +2,6 @@
 
 Anglesite is a Claude plugin that scaffolds and manages websites for small businesses. It works with Claude Cowork (non-technical site owners, GUI) and Claude Code (developers, CLI). It generates Astro + Keystatic sites deployed to Cloudflare Workers (Static Assets, via the `@astrojs/cloudflare` adapter).
 
-**Version:** 1.7.0 · **License:** ISC · **Node:** >=22 · **Module system:** ESM
-
-## Plugin structure
-
-```
-├── .claude-plugin/
-│   ├── plugin.json               Plugin manifest (name, version, metadata)
-│   └── marketplace.json          Marketplace catalog — this repo is also its own marketplace
-├── skills/                       Skills (56 total: 31 user-facing, 25 model-only)
-│   ├── start/SKILL.md            First-time setup + scaffolding
-│   ├── deploy/SKILL.md           Build, scan, deploy to Cloudflare Workers
-│   ├── check/SKILL.md            Health audit + troubleshooting
-│   ├── update/SKILL.md           Update dependencies + template files
-│   ├── domain/SKILL.md           DNS management (email, Bluesky, verification)
-│   ├── import/SKILL.md           Import from website URL
-│   ├── convert/SKILL.md          Convert existing SSG project to Anglesite
-│   ├── export/SKILL.md           Portable export (dist + content + MIGRATING.md)
-│   ├── contact/SKILL.md          Contact form (Workers + Turnstile)
-│   ├── forms/SKILL.md            Custom forms — RSVP, lead, survey, callback (Workers + Turnstile)
-│   ├── inbox/SKILL.md            Form submissions inbox in Keystatic (Cloudflare D1 + triage + CSV export)
-│   ├── indieweb/SKILL.md         Self-owned IndieAuth + Webmention + Micropub endpoints (user-facing)
-│   ├── backup/SKILL.md           Back up changes to GitHub
-│   ├── stats/SKILL.md            Plain-language site analytics
-│   ├── newsletter/SKILL.md       Email newsletter setup + subscribe form
-│   ├── add-store/SKILL.md        Ecommerce intake (user-facing)
-│   ├── design-interview/SKILL.md Visual identity (model-only)
-│   ├── email/SKILL.md            Business email setup, Apple-first (model-only)
-│   ├── animate/SKILL.md          CSS animations (model-only)
-│   ├── new-page/SKILL.md         Page creation (model-only)
-│   ├── repurpose/SKILL.md        Social media post generation (model-only)
-│   ├── seasonal/SKILL.md         Seasonal content suggestions (model-only)
-│   ├── optimize-images/SKILL.md  Image optimization pipeline (model-only)
-│   ├── og-images/SKILL.md       Satori-based OG image generation (model-only)
-│   ├── business-info/SKILL.md    Hours, location, LocalBusiness JSON-LD (model-only)
-│   ├── themes/SKILL.md           Visual theme picker — freedesignmd + built-ins (model-only)
-│   ├── freedesignmd/SKILL.md    Apply a design system from freedesignmd.com (model-only)
-│   ├── qr/SKILL.md              QR codes + UTM tracking (model-only)
-│   ├── reputation/SKILL.md     Review monitoring + competitive coaching (model-only)
-│   ├── testimonials/SKILL.md    Review collection + display (model-only)
-│   ├── i18n/SKILL.md            Multi-language support (model-only)
-│   ├── print/SKILL.md           Print materials generation (model-only)
-│   ├── buy-button/SKILL.md     Stripe Payment Link buy button (model-only)
-│   ├── lemon-squeezy/SKILL.md  Lemon Squeezy checkout for digital goods (model-only)
-│   ├── snipcart/SKILL.md       Snipcart ecommerce for physical goods (model-only)
-│   ├── shopify-buy-button/SKILL.md  Shopify Buy Button for full catalogs (model-only)
-│   ├── paddle/SKILL.md         Paddle checkout for SaaS/software licensing (model-only)
-│   ├── social-media/SKILL.md    Social media strategy + content calendars (model-only)
-│   ├── booking/SKILL.md        Appointment scheduling embed (user-facing)
-│   ├── seo/SKILL.md            SEO audit, Schema.org, sitemap, LLM/GEO (user-facing)
-│   ├── search/SKILL.md          On-site search via Pagefind (user-facing)
-│   ├── copy-edit/SKILL.md       Website copy audit + brand voice coaching (model-only)
-│   ├── experiment/SKILL.md      A/B testing + funnel optimization (model-only)
-│   ├── creative-canvas/SKILL.md Interactive visual effects + creative coding (model-only)
-│   ├── photography/SKILL.md    Shot list generator + phone photography tips
-│   ├── menu/SKILL.md            Restaurant menu import, creation, and management (user-facing)
-│   ├── podcast/SKILL.md         Podcast: episodes, RSS+iTunes, transcripts, audio player (user-facing)
-│   ├── donations/SKILL.md       Donation button + page (Stripe/Liberapay/GitHub Sponsors) (user-facing)
-│   ├── redirects/SKILL.md       Manage Cloudflare _redirects (user-facing)
-│   ├── design-import/SKILL.md    Import design from Canva/Figma (user-facing)
-│   ├── giscus/SKILL.md          Blog comments via Giscus + GitHub Discussions (user-facing)
-│   ├── consent/SKILL.md         Category-based GDPR/CCPA cookie consent banner (user-facing)
-│   ├── membership/SKILL.md       Paywall + content gating: free (newsletter) and paid (Stripe) tiers (user-facing)
-│   ├── tracking/SKILL.md         Meta Pixel, Google Ads, GA4, LinkedIn, TikTok, Pinterest, X via @astrojs/partytown + Microsoft Clarity (main thread) (user-facing)
-│   ├── pwa/SKILL.md              Progressive Web App: installable, offline support, service worker (user-facing)
-│   └── share/SKILL.md            Native sharing via Web Share API + clipboard fallback (user-facing)
-├── settings.json                 Plugin settings (empty — permissions via allowed-tools)
-├── hooks/hooks.json              PreToolUse hook for deploy safety scans
-├── scripts/
-│   ├── scaffold.sh               Copies template/ to user's project (zsh, rsync)
-│   ├── update.sh                 Compares template files against scaffolded site
-│   ├── pre-deploy-check.sh       Blocks deploy if security scans fail
-│   ├── pack-plugin.sh            Builds distributable plugin ZIP
-│   ├── design-import/            Canva/Figma extraction scripts
-│   │   ├── canva-playwright.mjs  Browser-based Canva content extraction (Playwright fallback)
-│   │   ├── canva-safari.mjs      Safari MCP Canva extraction (preferred on macOS; same JSON contract)
-│   │   ├── canva-colors.mjs      Canva color token extraction
-│   │   ├── canva-fonts.mjs       Canva font extraction
-│   │   ├── comparison.mjs        Design comparison utilities
-│   │   ├── infer-axes.mjs        Layout axis inference
-│   │   ├── layout-heuristics.mjs Layout detection heuristics
-│   │   └── text-hierarchy.mjs    Text hierarchy analysis
-│   └── import/                   Platform-specific extraction scripts
-│       ├── menu-extract.mjs      Menu extraction from PDF/photo
-│       ├── wix/
-│       │   ├── wix-playwright.mjs Browser-based content + CSS token extraction
-│       │   ├── wix-extract.mjs    Curl+regex fallback for Wix HTML parsing
-│       │   └── color-utils.mjs    RGB/hex conversion, luminance, color classification
-│       └── wordpress/
-│           ├── wp-xml-parse.mjs   WordPress WXR export parser
-│           └── wp-content-clean.mjs WordPress content cleanup
-├── server/                       MCP server + shared modules (Node.js, ESM) — the wire contract the Anglesite-app host builds against
-│   ├── index-tools.mjs           buildServer(projectRoot): registers all 8 MCP tools (transport-agnostic)
-│   ├── index.mjs                 stdio entry point (wires buildServer to StdioServerTransport)
-│   ├── http-server.mjs           Streamable HTTP transport (/mcp, Mcp-Session-Id) for container runtimes
-│   ├── annotations.mjs           Annotation store (CRUD + persistence)
-│   ├── selector.mjs              CSS selector generation from ElementInfo metadata
-│   ├── messages.mjs              WebSocket message schema (overlay ↔ server)
-│   ├── apply-edit-schema.mjs     Zod schema + response builders for apply_edit (ElementInfo, op enum, edit-applied/failed/preview)
-│   ├── apply-edit-dispatcher.mjs apply_edit handler: image pre-process → resolve → atomic write → onApplied hook
-│   ├── patcher.mjs               Source-file resolver (mdoc → Keystatic → .astro)
-│   ├── style-edit.mjs            edit-style op resolver (inline/scoped style patches)
-│   ├── undo-edit.mjs             undo_edit handler
-│   ├── edit-history.mjs          Commits applied edits to the hidden anglesite/edits branch
-│   ├── list-content.mjs          list_content tool (enumerate pages/posts)
-│   ├── create-content.mjs        create_page / create_post tools
-│   ├── content-frontmatter.mjs   Shared frontmatter helpers for content tools
-│   ├── content-types.mjs         Built-in typed-content catalog mirrored from the app's ContentTypeRegistry.swift (source of truth is Swift)
-│   └── optimize-images.mjs       Image optimize/srcset used by the image-drop edit path
-├── bin/
-│   ├── build-instructions.ts     Agent instruction file validator
-│   ├── build-agent-skills.ts     Generates agent-skills/ (Open Agent Skills export)
-│   ├── generate-skill-registry.ts Generates docs/dev/skill-registry.md from frontmatter
-│   └── release.ts                Semantic version bumper (updates all manifests)
-├── agent-skills/                 GENERATED — Open Agent Skills export (skills.sh); never edit by hand
-├── package.json                  Dev dependencies and test scripts
-├── vitest.config.ts              Test configuration
-├── docs/                         Reference docs (read by skills via ${CLAUDE_PLUGIN_ROOT})
-│   ├── smb/                      Business type guides (67 files, ~59 verticals)
-│   ├── import/                   Platform migration guides (29 files)
-│   ├── platforms/                Tool integration guides (23 files)
-│   ├── dev/                      Plugin development guides (7 files: architecture, releasing, testing, etc.)
-│   ├── decisions/                ADRs — architecture decision records (24 files)
-│   ├── style-guide.md           HTML, CSS, and TypeScript coding standards for generated sites
-│   └── content-conversion.md    Shared HTML-to-Markdown guidance (used by import + convert)
-├── template/                     Files scaffolded to user's project
-│   ├── src/                      Astro source (pages, layouts, styles, integrations, toolbar)
-│   │   ├── layouts/ImmersiveLayout.astro  Full-viewport layout for creative experiments
-│   │   ├── pages/lab/index.astro          Experiment gallery page
-│   │   └── styles/immersive.css           Dark/immersive styles for creative work
-│   ├── public/                   Static assets
-│   ├── scripts/                  setup.ts, check-prereqs.ts, cleanup.ts, platform.ts
-│   ├── docs/                     Site-specific docs (~17 files) + workflows/
-│   ├── CLAUDE.md                 Webmaster guide + Claude Code commands
-│   ├── package.json              Site dependencies (Astro, Keystatic)
-│   ├── astro.config.ts           Astro + Keystatic integration config
-│   ├── keystatic.config.ts       CMS schema and collection definitions
-│   ├── worker/                   Cloudflare Worker source (contact form)
-│   ├── .mcp.json                 MCP server config (annotation tools)
-│   └── .gitignore                Build artifacts exclusions
-├── test/                         JavaScript tests + fixtures
-│   └── fixtures/                 Sample HTML for Wix extraction tests
-└── tests/                        TypeScript tests
-```
-
 ## Agent instruction hierarchy
 
 Two levels of agent instructions exist — do not confuse them:
@@ -180,73 +36,16 @@ Two levels of agent instructions exist — do not confuse them:
 
 **Runtime.** The app vendors a pinned Node (`Anglesite-app/scripts/node-version.txt`) to execute `server/*.mjs`; the CI test matrix should track it so the shipped interpreter is exercised here.
 
+**Typed content.** `server/content-types.mjs` is a mirror of the app's `ContentTypeRegistry.swift` — the Swift file is the source of truth. Change it there first, then mirror the change here.
+
 ## Skills reference
 
-**User-facing** (invoked via `/anglesite:<name>`, have `disable-model-invocation: true`):
+`docs/dev/skill-registry.md` is generated from skill frontmatter (`npm run registry`) — read it for the current inventory rather than maintaining a second copy here.
 
-| Skill | Purpose |
-|---|---|
-| `start` | First-time setup: scaffolding, discovery interview, design, tool installation, preview |
-| `deploy` | Build, 4-point security scan, deploy to Cloudflare Workers |
-| `check` | Health audit, troubleshooting, diagnostics |
-| `update` | Update dependencies and template files to the latest version |
-| `domain` | DNS record management (email, Bluesky, domain verification) |
-| `import` | Import content from external website URL |
-| `convert` | Convert existing SSG project (Hugo, Jekyll, Next.js, etc.) to Anglesite |
-| `export` | Portable export of the site (`dist/`, `content/`, `public/`, `MIGRATING.md`) for self-host or migration |
-| `contact` | Contact form via Cloudflare Workers + Turnstile |
-| `forms` | Custom forms (RSVP, lead capture, survey, callback) via Cloudflare Workers + Turnstile |
-| `inbox` | Persisted form submissions inbox in Keystatic (Cloudflare D1, triage, CSV export) |
-| `indieweb` | Self-owned IndieAuth, Webmention, and Micropub endpoints on the owner's domain |
-| `backup` | Back up site changes to GitHub, or restore an earlier snapshot |
-| `stats` | Plain-language site analytics from Cloudflare |
-| `newsletter` | Email newsletter setup (Buttondown/Mailchimp) + subscribe form |
-| `add-store` | Ecommerce intake: routes to Stripe, Polar, or coming-soon paths |
-| `booking` | Embed appointment scheduling (Cal.com or Calendly) |
-| `seo` | SEO audit, metadata editing, Schema.org, sitemap, LLM/GEO optimization |
-| `search` | On-site search via Pagefind (build-time index, ~6 KB JS) |
-| `photography` | Site-type-specific shot list generator and phone photography tips |
-| `menu` | Restaurant menu import (PDF/photo), creation, and editing |
-| `podcast` | First-class podcast support — episodes, RSS+iTunes feed, transcripts, audio player, directory submission |
-| `donations` | Donation button + page (Stripe / Liberapay / GitHub Sponsors), suggested + custom amounts, recurring defaults, optional goal widget, 501(c)(3) tax-receipt template |
-| `redirects` | Manage Cloudflare `_redirects`: add, remove, list, validate, bulk-import (301/302/308) |
-| `design-import` | Import design tokens and page layouts from Canva or Figma |
-| `giscus` | Blog comments backed by GitHub Discussions (per-post opt-out via frontmatter) |
-| `consent` | Category-based GDPR/CCPA cookie consent banner; gates third-party scripts/embeds via `data-consent` |
-| `membership` | Paywall and content gating: free tier (newsletter) and paid tier (Stripe), edge-gated via signed cookie |
-| `tracking` | Meta Pixel, Google Ads, GA4, LinkedIn Insight, TikTok, Pinterest, X — wrapped in `@astrojs/partytown` so they run in a worker, not on the main thread; plus Microsoft Clarity (heatmaps + session recording), which runs on the main thread because session replay needs DOM access |
-| `pwa` | Progressive Web App: standalone display, service worker with offline caching, install prompt — no app store required |
-| `share` | Native share button via Web Share API (mobile) with copy-to-clipboard fallback (desktop) — no third-party share widgets |
+Two visibility classes, set in each skill's frontmatter:
 
-**Model-only** (called programmatically by other skills, `user-invocable: false`):
-
-| Skill | Purpose |
-|---|---|
-| `design-interview` | Visual identity and branding questionnaire |
-| `email` | Business email setup: Apple-first provider recommendation, DNS pre-fill |
-| `animate` | CSS animations (hover, scroll reveals, transitions) |
-| `creative-canvas` | Interactive visual effects and creative coding (p5.js, Three.js, GSAP, Tone.js, D3.js) |
-| `new-page` | Create new page with SEO and accessibility |
-| `repurpose` | Generate per-platform social media post variants from blog post |
-| `seasonal` | Surface seasonal content suggestions by business type |
-| `optimize-images` | Resize, convert to WebP, strip EXIF, generate srcset |
-| `og-images` | Satori-based OG image generation for social sharing previews |
-| `business-info` | Hours, address, phone, LocalBusiness JSON-LD |
-| `themes` | Pre-built visual theme picker (freedesignmd catalog + 9 built-in quick-picks) |
-| `freedesignmd` | Browse, fetch, and apply a design system from freedesignmd.com |
-| `qr` | QR codes, shortlinks, UTM campaign URLs |
-| `reputation` | Review monitoring coaching and competitive awareness |
-| `testimonials` | Customer review collection, moderation, display |
-| `i18n` | Multi-language support with hreflang and language switcher |
-| `print` | Print-ready materials (business cards, flyers, door hangers, social cards) |
-| `buy-button` | Stripe Payment Link buy button for single product/service sales |
-| `lemon-squeezy` | Lemon Squeezy checkout overlay for digital product sales (alternative to Polar) |
-| `snipcart` | Snipcart ecommerce for small physical product catalogs |
-| `shopify-buy-button` | Shopify Buy Button for full catalog physical goods |
-| `paddle` | Paddle checkout for software licensing, SaaS subscriptions, or metered billing |
-| `copy-edit` | Audit and coach website copy for clarity, tone, and brand voice |
-| `social-media` | Proactive social media strategy, content calendars, and profile optimization |
-| `experiment` | A/B testing: propose, run, analyze, and promote winning variants |
+- **User-facing** — invoked as `/anglesite:<name>`; frontmatter has `disable-model-invocation: true`.
+- **Model-only** — called programmatically by other skills; frontmatter has `user-invocable: false`.
 
 ## Editing guidelines
 
@@ -278,24 +77,7 @@ Two levels of agent instructions exist — do not confuse them:
 | Pagefind (not Algolia/Orama) | Build-time index, ~6 KB JS, no external service, first-class Astro integration |
 | On-device `fm` as optional authoring accelerator | Free/private/offline drafts — alt text (incl. imported images via `ai-alt`) and inbox triage; never in the deployed site, always falls back to Claude (ADR-0021) |
 
-Full ADRs are in `docs/decisions/` (ADR-0001 through ADR-0023, plus README).
-
-## Testing
-
-**Framework:** Vitest 3.1.1
-
-```sh
-npm test              # Run all tests
-npm run test:watch    # Watch mode
-npm run test:coverage # Coverage report
-```
-
-**Test layout:**
-- `tests/` — TypeScript tests (token calc, instruction validation, config, image gen, platform detection, pre-deploy checks)
-- `test/` — JavaScript tests (BaseLayout, convert skill, scaffold .gitignore, Wix extraction + color utils)
-- `test/fixtures/` — Sample HTML for Wix extraction tests
-
-**Config:** `vitest.config.ts` includes both directories, aliases `./config.js` and `./platform.js` to template sources for import resolution.
+Full ADRs are in `docs/decisions/`.
 
 ## Version management
 
@@ -319,17 +101,9 @@ Anglesite ships two ways from one source — they coexist:
 
 ## CI/CD
 
-**`.github/workflows/test.yml`** — Runs on PRs and pushes to `main`. Three jobs:
-1. **`test`** — Node matrix [22, 24]; runs the full test suite on both the `engines` floor and the runtime `Anglesite-app` ships
-2. **`agent-skills-export`** — verifies `agent-skills/` is current (`npm run build:agent-skills`); fails if stale
-3. **`template-lockfile`** — verifies `template/package-lock.json` is in sync (`npm ci` inside `template/`)
+`.github/workflows/test.yml` runs on PRs and pushes to `main`; `release.yml` runs on `v*` tags.
 
-When the app bumps its pinned Node version (`Anglesite-app/scripts/node-version.txt`), update the matrix to match.
-
-**`.github/workflows/release.yml`** — Triggered on `v*` tags:
-1. Verifies version consistency across all manifests
-2. Runs `scripts/pack-plugin.sh` to build plugin ZIP
-3. Creates GitHub Release with ZIP artifact
+When the app bumps its pinned Node version (`Anglesite-app/scripts/node-version.txt`), update the test matrix to match.
 
 ## Testing changes manually
 
@@ -340,22 +114,6 @@ cd /tmp/test-site
 npm install
 npm run dev
 ```
-
-## Serena (optional, plugin development)
-
-[Serena](https://github.com/oraios/serena) provides semantic, symbol-level code navigation via language servers. It's useful when working on the plugin itself (tracing cross-skill references, finding symbol usages across 56 skills). Not required — all standard tools work without it.
-
-**Setup:**
-
-```sh
-# Index the project (one-time)
-uvx -p 3.13 --from git+https://github.com/oraios/serena serena project index
-
-# Start the MCP server
-uvx -p 3.13 --from git+https://github.com/oraios/serena serena start-mcp-server --project .
-```
-
-Config lives in `.serena/project.yml`. Requires Python 3.13 and [uv](https://docs.astral.sh/uv/).
 
 ## Security hooks
 

--- a/agent-skills/README.md
+++ b/agent-skills/README.md
@@ -9,7 +9,7 @@ material lives in its `references/` directory.
 > Generated — do not edit by hand. Edit the plugin sources in `skills/` and run
 > `npm run build:agent-skills`.
 
-**Version:** 1.6.0 · **License:** ISC · 56 skills
+**Version:** 1.7.0 · **License:** ISC · 56 skills
 
 ## Install
 

--- a/agent-skills/add-store/SKILL.md
+++ b/agent-skills/add-store/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npx wrangler *), Bash(npm run build), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/animate/SKILL.md
+++ b/agent-skills/animate/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/backup/SKILL.md
+++ b/agent-skills/backup/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(git status *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git log *), Bash(git diff *), Bash(git checkout *), Bash(git branch *), Bash(git tag *), Bash(git show *), Bash(git stash *), Bash(git fetch *), Bash(git rev-parse *), Bash(npx tsx *), Read
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/booking/SKILL.md
+++ b/agent-skills/booking/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob, Bash(npm run build), Bash(npx astro check)
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/business-info/SKILL.md
+++ b/agent-skills/business-info/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/buy-button/SKILL.md
+++ b/agent-skills/buy-button/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/check/SKILL.md
+++ b/agent-skills/check/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run *), Bash(npx astro check), Bash(npx pa11y *), Bash(npx pa11y-ci *), Bash(npx tsx scripts/link-check.ts *), Bash(npx tsx scripts/a11y-audit.ts *), Bash(npx tsx scripts/a14y-audit.ts *), Bash(npx a14y *), Bash(a14y *), Bash(grep *), Bash(find dist/ *), Bash(stat *), Bash(npm audit *), Bash(lsof *), Bash(netstat *), Bash(getent *), Bash(nslookup *), Bash(gh issue *), Bash(gh label *), Write, Read, Glob, mcp__cloudflare__accounts_list, mcp__cloudflare__search_cloudflare_documentation, mcp__cloudflare__workers_list, mcp__cloudflare__workers_get_worker, mcp__cloudflare__workers_get_worker_code
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[optional: describe the problem]"

--- a/agent-skills/consent/SKILL.md
+++ b/agent-skills/consent/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(grep *), Write, Read, Glob, Edit
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/contact/SKILL.md
+++ b/agent-skills/contact/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(npx astro check), Bash(grep *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/convert/SKILL.md
+++ b/agent-skills/convert/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: ["Bash(npm run build)", "Bash(npm install)", "Bash(npm run ai-alt)", "Bash(zsh *)", "Bash(node *)", "Bash(npx sharp-cli *)", "Bash(mkdir *)", "Bash(git add *)", "Bash(git commit *)", "Bash(ls *)", "Bash(wc *)", "Bash(cp *)", "Bash(find src/content/posts *)", "Bash(find public/images *)", "Bash(find */images *)", "Bash(find */public *)", "Bash(find */static *)", "Bash(find */source *)", "Bash(find */content *)", "Bash(find */docs *)", "Bash(find */_posts *)", "Bash(find */layouts *)", "Bash(find */templates *)", "Bash(find */_includes *)", "Write", "Read", "Glob", "Edit"]
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/copy-edit/SKILL.md
+++ b/agent-skills/copy-edit/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/creative-canvas/SKILL.md
+++ b/agent-skills/creative-canvas/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm install *), Bash(npm run dev), Bash(npm run build), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
   argument-hint: "[effect description or library name]"

--- a/agent-skills/deploy/SKILL.md
+++ b/agent-skills/deploy/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npm run deploy *), Bash(npm run preview *), Bash(npm run ai-linkcheck *), Bash(npm run ai-a11y *), Bash(npm run ai-a14y *), Bash(npm run ai-perf *), Bash(npm run ai-webmention-send *), Bash(npx wrangler *), Bash(grep *), Bash(find dist/ *), Bash(gh *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git checkout *), Bash(git merge *), Bash(git branch *), Bash(kill *), Write, Read, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__search_cloudflare_documentation
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/design-import/SKILL.md
+++ b/agent-skills/design-import/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: ["Bash(node *)", "Bash(npx sharp-cli *)", "Bash(npx playwright install *)", "Bash(npm install *)", "Bash(npm run dev *)", "Bash(npm run build)", "Bash(mkdir *)", "Bash(curl *)", "Bash(git add *)", "Bash(git commit *)", "Bash(git push *)", "Bash(ls *)", "Bash(npm ls *)", "Bash(grep *)", "WebFetch", "Write", "Read", "Edit", "Glob"]
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[Canva site URL, Figma file URL, or freedesignmd.com system URL]"

--- a/agent-skills/design-interview/SKILL.md
+++ b/agent-skills/design-interview/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run *), WebFetch, Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/domain/SKILL.md
+++ b/agent-skills/domain/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(curl *), Write, Read, mcp__cloudflare__search_cloudflare_documentation
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[email, bluesky, or service name]"

--- a/agent-skills/donations/SKILL.md
+++ b/agent-skills/donations/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/email/SKILL.md
+++ b/agent-skills/email/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(curl *), Write, Read
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/experiment/SKILL.md
+++ b/agent-skills/experiment/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/export/SKILL.md
+++ b/agent-skills/export/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(mkdir *), Bash(cp *), Bash(rsync *), Bash(zip *), Bash(ls *), Bash(find *), Bash(du *), Bash(grep *), Bash(date *), Bash(git rev-parse *), Bash(npx wrangler r2 *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, Read, Write
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/forms/SKILL.md
+++ b/agent-skills/forms/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(npx astro check), Bash(grep *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/freedesignmd/SKILL.md
+++ b/agent-skills/freedesignmd/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: WebFetch, Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/giscus/SKILL.md
+++ b/agent-skills/giscus/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx astro check), Bash(grep *), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/i18n/SKILL.md
+++ b/agent-skills/i18n/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx astro check), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/import/SKILL.md
+++ b/agent-skills/import/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: ["WebFetch", "Bash(curl *)", "Bash(npx sharp-cli *)", "Bash(mkdir *)", "Bash(npm run build)", "Bash(npm install)", "Bash(npm run ai-alt)", "Bash(zsh *)", "Bash(node *)", "Bash(git add *)", "Bash(git commit *)", "Bash(git push *)", "Bash(ls *)", "Bash(wc *)", "Bash(grep *)", "Bash(find src/content/posts *)", "Bash(find public/images *)", "Bash(find */images *)", "Bash(find */public *)", "Bash(find */static *)", "Bash(find */source *)", "Bash(find */content *)", "Bash(find */docs *)", "Bash(find */_posts *)", "Bash(cp *)", "Write", "Read", "Glob", "Edit"]
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[website URL or local path]"

--- a/agent-skills/inbox/SKILL.md
+++ b/agent-skills/inbox/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run *), Bash(npx wrangler *), Bash(grep *), Write, Read, Edit, Glob, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__d1_database_create, mcp__cloudflare__d1_databases_list, mcp__cloudflare__d1_database_get, mcp__cloudflare__d1_database_query
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/indieweb/SKILL.md
+++ b/agent-skills/indieweb/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npm install *), Bash(npx wrangler *), Bash(openssl *), Bash(grep *), Bash(gh *), Bash(node *), Bash(mktemp *), Bash(printf *), Bash(rm *), Write, Read, Edit, Glob, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__d1_database_create, mcp__cloudflare__d1_databases_list, mcp__cloudflare__d1_database_get, mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_buckets_list
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/lemon-squeezy/SKILL.md
+++ b/agent-skills/lemon-squeezy/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/membership/SKILL.md
+++ b/agent-skills/membership/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(npx astro check), Bash(grep *), Bash(node *), Write, Read, Edit, Glob, mcp__cloudflare__kv_namespace_create, mcp__cloudflare__kv_namespace_get, mcp__cloudflare__kv_namespaces_list, mcp__cloudflare__accounts_list
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/menu/SKILL.md
+++ b/agent-skills/menu/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run dev), Bash(npm run build), Read, Write, Glob, Grep
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/new-page/SKILL.md
+++ b/agent-skills/new-page/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
   argument-hint: "[page name or purpose]"

--- a/agent-skills/newsletter/SKILL.md
+++ b/agent-skills/newsletter/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(curl *), Bash(grep *), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/og-images/SKILL.md
+++ b/agent-skills/og-images/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run ai-images), Bash(npm run ai-og), Bash(npx wrangler r2 *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, Read, Glob, Write
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/optimize-images/SKILL.md
+++ b/agent-skills/optimize-images/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run ai-optimize), Bash(npx wrangler r2 *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/paddle/SKILL.md
+++ b/agent-skills/paddle/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Edit, Glob, Bash(npm run build), Bash(npx astro check)
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/photography/SKILL.md
+++ b/agent-skills/photography/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Read, Glob, Write
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/podcast/SKILL.md
+++ b/agent-skills/podcast/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npm run dev), Bash(npx wrangler r2 *), Bash(wc -c *), Bash(stat *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, mcp__cloudflare__r2_bucket_delete, Read, Write, Edit, Glob, Grep
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/print/SKILL.md
+++ b/agent-skills/print/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob, Bash(npm run ai-qr)
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/pwa/SKILL.md
+++ b/agent-skills/pwa/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(node *), Write, Read, Glob, Edit
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/qr/SKILL.md
+++ b/agent-skills/qr/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run ai-qr), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/redirects/SKILL.md
+++ b/agent-skills/redirects/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Read, Write, Edit, Glob, Bash(grep *), Bash(find *), Bash(wc *), Bash(sort *), Bash(awk *), Bash(test *), Bash(ls *), Bash(cat *)
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[add | remove | list | validate | import | review]"

--- a/agent-skills/repurpose/SKILL.md
+++ b/agent-skills/repurpose/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/reputation/SKILL.md
+++ b/agent-skills/reputation/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(date *), Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/search/SKILL.md
+++ b/agent-skills/search/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm install *), Bash(npm run build), Bash(npx astro check), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/seasonal/SKILL.md
+++ b/agent-skills/seasonal/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(date *), Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/seo/SKILL.md
+++ b/agent-skills/seo/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npm run ai-seo*), Bash(npx astro check), Bash(grep *), Bash(find dist/ *), Bash(git log *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[page /about | schema | sitemap | og-images]"

--- a/agent-skills/share/SKILL.md
+++ b/agent-skills/share/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Write, Read, Glob, Edit
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/shopify-buy-button/SKILL.md
+++ b/agent-skills/shopify-buy-button/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Edit, Glob, Bash(npm run build), Bash(npx astro check)
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/snipcart/SKILL.md
+++ b/agent-skills/snipcart/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Edit, Glob, Bash(npm run build), Bash(npx astro check)
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/social-media/SKILL.md
+++ b/agent-skills/social-media/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/start/SKILL.md
+++ b/agent-skills/start/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(zsh *), Bash(npm install), Bash(npm run *), Bash(gh *), Bash(git remote *), Bash(git push *), Bash(git branch *), Bash(git add *), Bash(git commit *), WebFetch, Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/stats/SKILL.md
+++ b/agent-skills/stats/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(curl *), Bash(grep *), Bash(git log *), Bash(cat perf-trend.json), Write, Edit, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/testimonials/SKILL.md
+++ b/agent-skills/testimonials/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/themes/SKILL.md
+++ b/agent-skills/themes/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: WebFetch, Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/tracking/SKILL.md
+++ b/agent-skills/tracking/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm install *), Bash(npm run build), Bash(npx astro check), Bash(grep *), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/update/SKILL.md
+++ b/agent-skills/update/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(zsh *), Bash(npm run *), Bash(npm install *), Bash(npm update *), Bash(npm outdated *), Bash(npm audit *), Bash(npx astro check), Bash(git add *), Bash(git commit *), Bash(git diff *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.6.0"
+  version: "1.7.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/update/references/package.json
+++ b/agent-skills/update/references/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anglesite",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "module",
   "description": "AI webmaster that scaffolds, designs, and deploys Astro + Keystatic sites on Cloudflare Workers.",
   "scripts": {

--- a/agent-skills/update/references/template/package.json
+++ b/agent-skills/update/references/template/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dwk/anglesite",
   "type": "module",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "scripts": {
     "dev": "astro dev",

--- a/bin/build-agent-skills.ts
+++ b/bin/build-agent-skills.ts
@@ -428,6 +428,9 @@ const isMain =
 
 if (isMain) {
   const root = resolve(import.meta.dirname ?? ".", "..");
+  // Only skills/ is exported — deliberately NOT .claude/skills/, which holds
+  // Claude-Code-native skills for developing this plugin (never shipped to end
+  // users). Widening this glob would publish internal tooling to skills.sh.
   const skillsDir = join(root, "skills");
   const outRoot = join(root, "agent-skills");
   const version = JSON.parse(readFileSync(join(root, "package.json"), "utf-8")).version;


### PR DESCRIPTION
## Summary

- Cut ~two-thirds of the root `CLAUDE.md` — content a session can reconstruct by reading the repo. The file loads in full every session, so it went from **28,632 → ~10,300 chars (~4,600 est. tokens saved per session)**.
- Removed as derivable: the 141-line annotated directory tree (`ls` shows it), both 56-row skills reference tables (they duplicated each skill's own frontmatter `description` *and* the generated `docs/dev/skill-registry.md`), the `Testing` section (vitest version + npm scripts + dir layout all live in `package.json`/`vitest.config.ts`), and the CI/CD job-by-job walkthrough (both workflow files are readable). Also dropped a stale ADR count: it claimed 24, `docs/decisions/` holds 25.
- Moved the optional Serena setup into `.claude/skills/serena/SKILL.md` so only its one-line description stays resident.
- Regenerated the `agent-skills/` export, which was stale on `main` and blocking all PRs (see below).

Deliberately preserved, because the codebase can't teach them: the `content-types.mjs` ↔ `ContentTypeRegistry.swift` source-of-truth rule (now a **Typed content** note in the MCP section), the user-facing/model-only frontmatter convention, and the directive to track the app's pinned Node version in the test matrix. Also kept whole: the agent instruction hierarchy table, the MCP/Anglesite-app contract, every editing guideline (cross-platform bans, PII-on-demand, MCP-first provisioning), key decisions, version management, distribution channels, the non-guessable manual scaffold recipe, and the security-hooks policy.

`template/CLAUDE.md` is untouched — it's a product artifact copied into users' projects by `scripts/scaffold.sh`, not developer memory.

### Correction: the `**Version:**` line stays

The first pass cut it as a redundant fifth copy of an already-thrice-synced number. That was wrong, and CI caught it (`5cee9a6` restores it). The line is machine-maintained: `bin/release.ts:59` **throws** if it's missing, so removing it would have broken the next release outright, and `tests/release.test.ts:100` asserts it matches `package.json`. It's back, now carrying a note recording that constraint so the same heuristic isn't reapplied. The license / Node / module-system fields on that line remain dropped — those are genuinely derivable.

### Pre-existing on `main`: stale `agent-skills/` export

`agent-skills/` was stamped `1.6.0` while every manifest reads `1.7.0`, so `agent-skills-export` and 56 `build-agent-skills` assertions failed on `main` independently of this PR. Since that check gates every PR, `5675b0a` regenerates it — pure `npm run build:agent-skills` output (version stamp in 56 `SKILL.md` files, two bundled reference `package.json` copies, one README line; no content changes), in its own commit to stay reviewable separately.

This is the second occurrence: `8bbfbe2` fixed it for 1.6.0, then `082c59c` ("chore: release v1.7.0") reintroduced it. Root cause is that `bin/release.ts` bumps manifests without regenerating derived files. Two related items left **out** of this PR: the root `package-lock.json` is stamped `1.5.0` (no CI job gates it — `template-lockfile` only checks `template/`), and wiring the export regen into `bin/release.ts` would end the recurrence. Both belong in a follow-up that changes the release path.

## Paired PR check

- [x] This change is **self-contained** to the plugin (skills / hooks / template / docs / MCP server with no consumer-visible contract change).
- [ ] This change **needs a paired PR** in [`Anglesite/Anglesite-app`](https://github.com/Anglesite/Anglesite-app) (MCP message schema, template fields the app reads, hook surface, anything the native app embeds or shells out to). Link it here:

Docs plus a regenerated export. No MCP message schema, template field, or hook surface changes — the MCP section's tool table and transport contract are carried over verbatim, with one clarifying note added.

## Test plan

- [x] Plugin self-checks pass — full suite run locally: **3065 passed, 3 failed**
- [x] If touching the template: `scripts/scaffold.sh` produces a buildable site — n/a, `template/` untouched
- [x] If touching the MCP server: paired app PR exercises the new/changed messages — n/a, `server/` untouched

The 3 local failures are a sandbox artifact, not a regression: `apply-edit-dispatcher` "write should fail when the directory isn't writable" cases, which cannot fail under **uid 0** because root ignores permission bits. They are absent from CI's failure list, which runs non-root.

Suites covering the CI failures and every file touched here pass locally: `build-agent-skills` (87), `release` (11), `skill-registry` (24), `markdownlint` (5), `build-instructions` (21).

Verified by inspection as well:

- `bin/build-instructions.ts` validates `template/CLAUDE.md` only (lines 276, 358) — not the root file this PR edits.
- `tests/markdownlint.test.ts` lints `template/**/*.md`; its only root-`CLAUDE.md` mention is a code comment pointing at the "Testing changes manually" section, which this PR keeps.
- `bin/build-agent-skills.ts` globs `join(root, "skills")`, so `.claude/skills/serena/` can't leak into the export or trip the staleness check. That reasoning is now a comment at the glob itself rather than only here in the description, per review feedback.