### PR TITLE
docs(adr): record snapshotted embeds, reject Zaraz SSR

### DIFF
--- a/agent-skills/animate/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/animate/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/booking/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/booking/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/business-info/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/business-info/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/buy-button/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/buy-button/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/check/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/check/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/consent/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/consent/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/contact/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/contact/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/convert/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/convert/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/creative-canvas/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/creative-canvas/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/deploy/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/deploy/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/design-import/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/design-import/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/donations/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/donations/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/experiment/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/experiment/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/export/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/export/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/forms/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/forms/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/freedesignmd/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/freedesignmd/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/giscus/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/giscus/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/import/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/import/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/lemon-squeezy/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/lemon-squeezy/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/membership/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/membership/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/newsletter/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/newsletter/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/paddle/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/paddle/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/podcast/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/podcast/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/print/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/print/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/pwa/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/pwa/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/qr/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/qr/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/search/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/search/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/seo/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/seo/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/share/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/share/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/shopify-buy-button/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/shopify-buy-button/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/snipcart/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/snipcart/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/stats/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/stats/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/testimonials/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/testimonials/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/agent-skills/tracking/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/tracking/references/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/docs/decisions/0008-no-third-party-javascript.md
+++ b/docs/decisions/0008-no-third-party-javascript.md
@@ -99,10 +99,15 @@ Preferred privacy-respecting alternatives to common third-party scripts:
 |---|---|
 | Google Analytics | Cloudflare Web Analytics (auto-included) |
 | Google Maps embed | OpenStreetMap static image or link |
-| Social media embeds | Static screenshots with links to original posts |
+| Social media embeds | Snapshotted first-party embed cards (see ADR-0025) |
 | Google Fonts CDN | System fonts or self-hosted WOFF2 (see ADR-0005) |
 | Live chat widget | Contact form with Cloudflare Worker backend |
-| YouTube embed | Link to video with a thumbnail image |
+| YouTube embed | Snapshotted card linking to the video, with a self-hosted thumbnail (see ADR-0025) |
 | Disqus or Facebook comments | Giscus (GitHub Discussions) — see exception #8 |
 
 Each alternative eliminates a third-party dependency while preserving the functionality the owner needs.
+
+Note that the social-embed and YouTube rows do **not** add an exception to the list above.
+A snapshotted embed card is first-party HTML and first-party images served from the owner's
+own domain, so it needs no CSP allowlist entry at all — which is the test of whether an
+"alternative" genuinely preserves this ADR rather than quietly widening it. See ADR-0025.

--- a/docs/decisions/0025-snapshotted-embeds.md
+++ b/docs/decisions/0025-snapshotted-embeds.md
@@ -1,0 +1,147 @@
+---
+status: accepted
+date: 2026-07-26
+decision-makers: [Anglesite maintainers]
+---
+
+# Snapshot social embeds into the owner's repo instead of rendering them remotely
+
+## Context and Problem Statement
+
+Owners want to embed content from social platforms — a tweet quoted in a blog post, the
+post a reply is replying to. ADR-0008 blocks the normal way of doing this: every platform's
+embed is a `<script>` from the platform's own CDN that tracks every visitor who loads the
+page, whether or not they interact with it.
+
+ADR-0008's stated alternative was "static screenshots with links to original posts". That
+is honest but manual, produces no machine-readable citation, and degrades the IndieWeb
+reply-context markup (`u-in-reply-to`, `h-cite`) that receiving Webmention endpoints parse.
+Anglesite needed a real embed story that keeps ADR-0008 intact.
+
+There is a second, less obvious problem. This is *legacy* social content: the premise is
+that these platforms are decaying. Any design that fetches from the platform at render time
+— or at build time — has bet the owner's archive on that platform's continued goodwill.
+X's oEmbed endpoint, Instagram's API, and the platforms themselves may not outlive the
+sites that cite them.
+
+## Decision Drivers
+
+* ADR-0008 — no third-party JavaScript, and no new exception if it can be avoided
+* Visitor privacy — a hotlinked image is still a tracked request, not just a script
+* ADR-0011 — the owner controls everything; the artifact must live in their repo
+* Git is the source of truth — the app must never be the only way to edit a site
+* Durability — an embed must survive the platform deleting the post or retiring its API
+* Build determinism — a deploy must not fail because a remote is down
+* IndieWeb correctness — reply context must emit parseable `h-cite` microformats
+
+## Considered Options
+
+* **Snapshot at author time into the owner's git repo** (chosen)
+* **Cloudflare Zaraz server-side rendering of embeds**
+* **`astro-embed` as shipped** (fetch at build time, hotlink media)
+* **Status quo** — static screenshots with links, per ADR-0008's original table
+
+## Decision Outcome
+
+Chosen: **snapshot at author time into the owner's git repo.**
+
+A CLI fetches the post once, when the owner adds it, and writes a normalized record to
+`src/embeds/<slug>.json` plus its media to `public/embeds/<slug>/`. Both are committed. At
+build time a Markdown plugin swaps a bare URL for a first-party card rendered from that
+committed record; the same renderer serves `inReplyTo` / `bookmarkOf` / `likeOf` reply
+context as `h-cite`. **The build makes no network request at all.**
+
+Consequences that follow directly:
+
+* The rendered card is first-party HTML and first-party images, so **no CSP allowlist entry
+  and no new ADR-0008 exception are required**. A correct implementation needs neither —
+  that is the test of whether this preserves the ADR or quietly widens it.
+* Media is downloaded and self-hosted rather than hotlinked. Hotlinking would still leak
+  every visitor's IP and `Referer` to the platform, which is the exact tracking ADR-0008
+  exists to prevent, and it would force a per-platform `img-src` allowlist.
+* An embed keeps rendering after the platform deletes the post or retires its API, because
+  the content is a file in the owner's repo.
+* A URL with no snapshot degrades to an ordinary working link. A platform being down,
+  rate-limiting, or blocking automation can never fail a build.
+* Inline video stays **opt-in** (`EMBED_VIDEO_INLINE`). The default card is a link with a
+  self-hosted thumbnail. The opt-in widens `frame-src` to exactly `youtube-nocookie.com`
+  and loads the player only when it scrolls into view.
+* A pre-deploy scan rule fails the deploy if built output references platform media hosts,
+  so the privacy property is enforced mechanically rather than by convention (ADR-0007).
+
+### Rejected: Cloudflare Zaraz SSR
+
+Zaraz's server-side rendering of embeds genuinely does solve the third-party-JavaScript
+problem — Cloudflare fetches the post at the edge, strips the platform's scripts, and
+proxies images through the owner's domain. On the narrow ADR-0008 question it is a valid
+answer, and it was the specific proposal this decision was asked to evaluate.
+
+It was rejected because it solves the problem **at request time, at the edge**, so the
+rendered artifact exists nowhere the owner can see, keep, or move:
+
+| | Zaraz SSR | Snapshot |
+|---|---|---|
+| Third-party JS on page | None | None |
+| Third-party image requests | Proxied via the owner's domain | Self-hosted |
+| Platform coverage | X + Instagram only | Any URL (Open Graph) + per-platform adapters |
+| Visible in `astro dev` / `preview` | **No** | Yes |
+| Works off Cloudflare | **No** | Yes |
+| Configuration lives in | The Cloudflare dashboard, per zone | The owner's git repo |
+| Survives the platform deleting the post | No | **Yes** |
+| Survives the platform retiring its API | No | **Yes** |
+
+The dashboard-versus-repo row is the one that decides it: a per-zone dashboard toggle is
+exactly the kind of invisible, unportable configuration ADR-0011 and the git-is-the-source-
+of-truth rule exist to keep out of a site. Zaraz is recorded here as a rejected alternative,
+not a fallback.
+
+### Rejected: `astro-embed` as shipped
+
+`astro-embed` renders X, Bluesky, and Mastodon posts without client-side JavaScript, which
+is most of the way there, and it was already a declared dependency. But it fetches from the
+platform on **every build** and hotlinks the platform's images. That makes builds
+network-dependent and non-deterministic, leaves the visitor-tracking image requests in
+place, and means a deleted upstream post silently empties the embed on the next rebuild —
+the durability failure this decision most wants to avoid. The dependency was removed.
+
+### Rejected: status quo (static screenshots)
+
+Manual, produces no machine-readable citation, and gives reply context no `h-cite` markup.
+It survives here only as the documented escape hatch for platforms that cannot be
+snapshotted automatically (Instagram blocks automated requests and gates its API behind a
+Meta app token), where the owner supplies the screenshot by hand.
+
+## Consequences
+
+* Good, because visitors are not tracked by any embed, by script or by image
+* Good, because the CSP and ADR-0008's exception list are untouched
+* Good, because an embed outlives the platform it came from
+* Good, because builds are hermetic and cannot fail on a remote
+* Good, because reply context becomes parseable `h-cite` instead of a bare link
+* Bad, because capturing a snapshot is an explicit step — pasting a URL is not enough
+* Bad, because committed media grows the site repo
+* Bad, because a snapshot is a point-in-time capture and will not reflect a later-edited
+  post (arguably correct for a citation, but it is a behaviour change from live embeds)
+* Bad, because each platform adapter is a small ongoing maintenance liability; the generic
+  Open Graph fallback bounds the blast radius, since an adapter breaking degrades that
+  platform to a link card rather than to a build failure
+
+### Confirmation
+
+The pre-deploy scan fails any deploy whose built output references a known platform media
+host in a resource-loading context (`src`, `srcset`, CSS `url()`), and the renderer refuses
+any asset path that is not repo-relative. Per ADR-0007 the owner cannot override the scan.
+
+## More Information
+
+Implemented in `Anglesite-app` (the template is app-owned):
+[Anglesite/Anglesite-app#979](https://github.com/Anglesite/Anglesite-app/pull/979),
+issue [#682](https://github.com/Anglesite/Anglesite-app/issues/682). The evaluation this
+ADR records is set out in full in that repo's
+`docs/superpowers/specs/2026-07-25-privacy-preserving-embeds-design.md`.
+
+Source for the rejected option:
+[Zaraz supports server-side rendering of embeds](https://blog.cloudflare.com/zaraz-supports-server-side-rendering-of-embeds/).
+
+Related: ADR-0007 (mandatory pre-deploy scans), ADR-0008 (no third-party JavaScript),
+ADR-0011 (owner controls everything), ADR-0006 (IndieWeb principles).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -34,3 +34,4 @@ ADRs follow the [MADR](https://adr.github.io/madr/) format.
 - [ADR-0022](0022-passkey-indieauth.md) — Authenticate the IndieAuth owner with passkeys (`@dwk/webauthn`)
 - [ADR-0023](0023-native-mac-app.md) — Ship a native macOS host (`Anglesite-app`) that embeds — not forks — this plugin
 - [ADR-0024](0024-safari-rendered-extraction-backend.md) — Safari's MCP server as an optional rendered-extraction backend
+- [ADR-0025](0025-snapshotted-embeds.md) — Snapshot social embeds into the owner's repo instead of rendering them remotely


### PR DESCRIPTION
## Summary

- Adds **ADR-0025 — Snapshot social embeds into the owner's repo instead of rendering them remotely**, recording the evaluation asked for in [Anglesite-app#682](https://github.com/Anglesite/Anglesite-app/issues/682).
- Amends **ADR-0008**'s alternatives table: the social-embed row moves from "static screenshots with links to original posts" to snapshotted first-party embed cards, and the YouTube row from "link to video with a thumbnail image" to a snapshotted card with a self-hosted thumbnail.
- Regenerates `agent-skills/` so the 34 vendored copies of ADR-0008 match the canonical file — CI fails on a stale export.

## Paired PR check

- [x] This change is **self-contained** to the plugin (skills / hooks / template / docs / MCP server with no consumer-visible contract change).
- [ ] This change **needs a paired PR** in [`Anglesite/Anglesite-app`](https://github.com/Anglesite/Anglesite-app). Link it here:

Docs-only, no MCP schema change. The implementation it records is [Anglesite/Anglesite-app#979](https://github.com/Anglesite/Anglesite-app/pull/979), which does not depend on this PR landing — merge order doesn't matter.

## Test plan

- [x] Plugin self-checks pass — `npm run build:agent-skills` is clean and **idempotent** (a second run produces no further changes), so the committed export is not stale. Diff is confined to the 34 vendored `0008-no-third-party-javascript.md` copies plus the three intentional `docs/decisions/` changes; nothing unrelated moved.
- [ ] If touching the template: `scripts/scaffold.sh` produces a buildable site — n/a, no template change.
- [ ] If touching the MCP server: paired app PR exercises the new/changed messages — n/a, no MCP change.

## Why ADR-0008 needed amending, not just an exception

The point worth making explicit — and now stated in ADR-0008 itself — is that these two rows add **no exception to the list**. A snapshotted card is first-party HTML and first-party images served from the owner's own domain, so it needs no CSP allowlist entry at all. That is the test of whether an "alternative" genuinely preserves this ADR or quietly widens it, and it's why hotlinking the platform's images was rejected alongside the scripts: a hotlinked image still leaks every visitor's IP and `Referer` to the platform.

## Why Zaraz was rejected

Zaraz's server-side rendering of embeds genuinely does solve the third-party-JavaScript problem — Cloudflare fetches the post at the edge, strips the scripts, and proxies images through the owner's domain. On the narrow ADR-0008 question it is a valid answer, which is why it's recorded as a considered option rather than dismissed.

It was rejected because it solves the problem *at request time, at the edge*: the rendered artifact is invisible in `astro dev` and `preview`, evaporates if the site leaves Cloudflare, and is configured in a per-zone dashboard rather than the owner's repo — exactly the invisible, unportable configuration ADR-0011 and the git-is-the-source-of-truth rule exist to keep out. It also covers X and Instagram only, and cannot outlive the platform. Since the premise of the whole feature is that these platforms are decaying, that last point is decisive rather than incidental.

`astro-embed` was also considered and rejected (fetches on every build, hotlinks media, and a deleted upstream post silently empties the embed), and the app PR removes it as an unused dependency.

## Note on cross-references

ADR-0008's new "(see ADR-0025)" mentions are not bundled into the skills that vendor ADR-0008 — the generator bundles only the ADRs each `SKILL.md` explicitly links. That matches the existing shipped state, where ADR-0008's own "(see ADR-0005)" is likewise an unbundled cross-reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
