### PR TITLE
docs(adr): note Instagram is a wash, not a win, on coverage

### DIFF
--- a/docs/decisions/0025-snapshotted-embeds.md
+++ b/docs/decisions/0025-snapshotted-embeds.md
@@ -83,7 +83,7 @@ rendered artifact exists nowhere the owner can see, keep, or move:
 |---|---|---|
 | Third-party JS on page | None | None |
 | Third-party image requests | Proxied via the owner's domain | Self-hosted |
-| Platform coverage | X + Instagram only | Any URL (Open Graph) + per-platform adapters |
+| Platform coverage | X + Instagram only | Any URL (Open Graph) + per-platform adapters — but **Instagram is a wash**, not a win: it blocks automated requests, so it falls back to the manual screenshot below, where Zaraz renders it automatically |
 | Visible in `astro dev` / `preview` | **No** | Yes |
 | Works off Cloudflare | **No** | Yes |
 | Configuration lives in | The Cloudflare dashboard, per zone | The owner's git repo |


### PR DESCRIPTION
## Summary

- Re-lands the one-line fix for the review nit on #424 that **did not make it into the merge**. The Zaraz-vs-Snapshot coverage row still reads as a strict superset, while the same ADR's "Rejected: status quo" section says Instagram specifically can't be snapshotted automatically.
- The row now states it plainly: Instagram is a wash, not a win — it blocks automated requests and falls back to the manual screenshot, where Zaraz renders it automatically. That's the one place Zaraz is genuinely ahead, and the ADR should say so.

## Paired PR check

- [x] This change is **self-contained** to the plugin (docs only — one line of one ADR).
- [ ] This change **needs a paired PR** in [`Anglesite/Anglesite-app`](https://github.com/Anglesite/Anglesite-app). Link it here:

## Test plan

- [x] Plugin self-checks pass — `npm run build:agent-skills` produces no changes (ADR-0025 isn't vendored into any skill's `references/`, since the generator bundles only ADRs a `SKILL.md` explicitly links).
- [ ] If touching the template: n/a.
- [ ] If touching the MCP server: n/a.

## Why this needs a second PR

The merge of #424 raced a push. GitHub recorded the PR head as `0bbadb9` and merged that; the fix commit `a23cc49` had landed on the branch but wasn't picked up, so `origin/docs/adr-privacy-preserving-embeds` still points at it while `main` does not contain it. My "Fixed in a23cc49" reply on the original thread was true of the branch but not of what got merged — flagging that explicitly so the thread isn't misleading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
