### PR TITLE
feat(animate): escalate to baked-in @astroanimate components (#426)

### DIFF
--- a/agent-skills/animate/SKILL.md
+++ b/agent-skills/animate/SKILL.md
@@ -16,7 +16,7 @@ You're a motion designer who wins CSS Design Awards. Read `.site-config` for `SI
 ## Architecture decisions
 
 - [ADR-0004 Vanilla CSS](references/docs/decisions/0004-vanilla-css-custom-properties.md) — animations use CSS custom properties, not a framework
-- [ADR-0008 No third-party JS](references/docs/decisions/0008-no-third-party-javascript.md) — no JavaScript animation libraries
+- [ADR-0008 No third-party JS](references/docs/decisions/0008-no-third-party-javascript.md) — no JavaScript animation *runtimes*; the baked-in CSS-first component library is the recorded exception (ADR-0008)
 
 Read `EXPLAIN_STEPS` from `.site-config`. If `true` or not set, explain before every tool call that will trigger a permission prompt. If `false`, proceed without pre-announcing tool calls.
 
@@ -38,6 +38,23 @@ You have the full power of modern CSS. Use these techniques to create award-qual
 - **Custom easing** — `cubic-bezier()` curves for personality (bouncy, snappy, gentle, dramatic)
 
 **Never use JavaScript for animation.** If you think you need JS, find the CSS-only approach. The only exception is adding a class to trigger an animation — and even that should use `IntersectionObserver` only if scroll-driven CSS animations can't achieve the effect.
+
+## Escalation: the baked-in component library
+
+The site template ships `@astroanimate/core` (see `integrations/docs/animations.md`
+in the site for the curated list). Vanilla CSS remains your default craft. Reach for
+a library component only when it beats hand-written CSS for the request — marquees,
+typewriter/staggered text, card-stack effects, loaders — and then:
+
+- Use only components listed in `integrations/docs/animations.md`, with the exact
+  import style shown there (`import X from "@astroanimate/core/X"`).
+- **Never set `enhance={true}`** — it emits inline scripts the site's CSP blocks in
+  production. CSS-only mode is the supported mode.
+- The reduced-motion rule still applies: library components carry their own
+  `prefers-reduced-motion` guard; your surrounding CSS keeps its own.
+- Preview-before-apply still applies. For library components, preview on a draft
+  page via the dev server (the static `_animation-preview.html` flow can't render
+  `.astro` components).
 
 ## The conversation
 

--- a/agent-skills/animate/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/animate/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/booking/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/booking/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/business-info/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/business-info/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/buy-button/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/buy-button/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/check/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/check/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/consent/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/consent/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/contact/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/contact/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/convert/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/convert/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/creative-canvas/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/creative-canvas/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/deploy/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/deploy/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/design-import/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/design-import/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/donations/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/donations/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/experiment/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/experiment/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/export/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/export/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/forms/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/forms/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/freedesignmd/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/freedesignmd/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/giscus/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/giscus/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/import/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/import/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/lemon-squeezy/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/lemon-squeezy/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/membership/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/membership/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/newsletter/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/newsletter/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/paddle/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/paddle/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/podcast/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/podcast/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/print/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/print/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/pwa/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/pwa/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/qr/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/qr/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/search/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/search/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/seo/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/seo/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/share/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/share/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/shopify-buy-button/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/shopify-buy-button/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/snipcart/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/snipcart/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/stats/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/stats/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/testimonials/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/testimonials/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/agent-skills/tracking/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/tracking/references/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/docs/decisions/0008-no-third-party-javascript.md
+++ b/docs/decisions/0008-no-third-party-javascript.md
@@ -46,6 +46,15 @@ All other external scripts are blocked by default, enforced by the Content Secur
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
 
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+
 ### Consequences
 
 * Good, because visitors are not tracked, fingerprinted, or profiled

--- a/skills/animate/SKILL.md
+++ b/skills/animate/SKILL.md
@@ -10,7 +10,7 @@ You're a motion designer who wins CSS Design Awards. Read `.site-config` for `SI
 ## Architecture decisions
 
 - [ADR-0004 Vanilla CSS](${CLAUDE_PLUGIN_ROOT}/docs/decisions/0004-vanilla-css-custom-properties.md) — animations use CSS custom properties, not a framework
-- [ADR-0008 No third-party JS](${CLAUDE_PLUGIN_ROOT}/docs/decisions/0008-no-third-party-javascript.md) — no JavaScript animation libraries
+- [ADR-0008 No third-party JS](${CLAUDE_PLUGIN_ROOT}/docs/decisions/0008-no-third-party-javascript.md) — no JavaScript animation *runtimes*; the baked-in CSS-first component library is the recorded exception (ADR-0008)
 
 Read `EXPLAIN_STEPS` from `.site-config`. If `true` or not set, explain before every tool call that will trigger a permission prompt. If `false`, proceed without pre-announcing tool calls.
 
@@ -32,6 +32,23 @@ You have the full power of modern CSS. Use these techniques to create award-qual
 - **Custom easing** — `cubic-bezier()` curves for personality (bouncy, snappy, gentle, dramatic)
 
 **Never use JavaScript for animation.** If you think you need JS, find the CSS-only approach. The only exception is adding a class to trigger an animation — and even that should use `IntersectionObserver` only if scroll-driven CSS animations can't achieve the effect.
+
+## Escalation: the baked-in component library
+
+The site template ships `@astroanimate/core` (see `integrations/docs/animations.md`
+in the site for the curated list). Vanilla CSS remains your default craft. Reach for
+a library component only when it beats hand-written CSS for the request — marquees,
+typewriter/staggered text, card-stack effects, loaders — and then:
+
+- Use only components listed in `integrations/docs/animations.md`, with the exact
+  import style shown there (`import X from "@astroanimate/core/X"`).
+- **Never set `enhance={true}`** — it emits inline scripts the site's CSP blocks in
+  production. CSS-only mode is the supported mode.
+- The reduced-motion rule still applies: library components carry their own
+  `prefers-reduced-motion` guard; your surrounding CSS keeps its own.
+- Preview-before-apply still applies. For library components, preview on a draft
+  page via the dev server (the static `_animation-preview.html` flow can't render
+  `.astro` components).
 
 ## The conversation
 


### PR DESCRIPTION
## Summary

- Extends ADR-0008's "Creative coding libraries (not third-party)" carve-out to cover npm-installed animation component libraries, naming the template's pinned `@astroanimate/core@0.1.2` dependency and its CSS-only (`enhance=false`) constraint under the site's CSP.
- Adds an "Escalation: the baked-in component library" section to the `/animate` skill (`skills/animate/SKILL.md`): vanilla CSS stays the default craft, with cataloged `@astroanimate/core` components as an escalation for effects CSS does poorly (marquees, typewriter text, card stacks, loaders). Reconciles the ADR-0008 reference line to describe the recorded exception instead of a blanket "no JavaScript animation libraries".
- Regenerates `agent-skills/animate/` (spec-compliant Open Agent Skills output) via `npm run build:agent-skills -- animate` so the generated mirror of `skills/animate/SKILL.md` and its bundled ADR-0008 reference stay in sync — hand-edited nowhere, per `bin/build-agent-skills.ts`'s "do not edit manually" contract.

Design context: https://github.com/Anglesite/Anglesite-app/blob/claude/astro-animate-anglesite-217472/docs/superpowers/specs/2026-07-27-astro-animate-design.md (Astro Animate in Anglesite — design), Workstream 3.

**Ordering:** this PR documents a capability that ships in the app repo. Merge after [Anglesite/Anglesite-app#1006](https://github.com/Anglesite/Anglesite-app/pull/1006) (or once that work lands on `main`) so the `/animate` skill's references to `integrations/docs/animations.md` describe a capability that actually exists in shipped sites. Not an MCP schema change, so no paired-PR CI requirement — this can be reviewed independently.

## Test plan

- [x] `npm ci` (fresh install in the worktree)
- [x] `npx tsx bin/build-agent-skills.ts animate` — regenerated `agent-skills/animate/` from the edited `skills/animate/SKILL.md`; diffed to confirm only the two edited passages changed
- [x] `npx vitest run tests/skill-registry.test.ts tests/build-agent-skills.test.ts` — 111 passed
- [x] `npx vitest run` (full suite) — 150 files / 3083 tests passed, including `tests/adr-status.test.ts` and `tests/markdownlint.test.ts`

Closes #426.