### PR TITLE
fix(server): give recordEdit's commit-tree a git identity

### DIFF
--- a/server/edit-history.mjs
+++ b/server/edit-history.mjs
@@ -20,6 +20,7 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { ANGLESITE_COMMIT_IDENTITY } from "./git-identity.mjs";
 
 const EDITS_REF = "refs/heads/anglesite/edits";
 
@@ -93,15 +94,9 @@ export async function recordEdit(projectRoot, { file, files, range, message }) {
       }
       const tree = runGit(projectRoot, ["write-tree"], env);
       const parent = runGit(projectRoot, ["rev-parse", EDITS_REF]);
-      const commitEnv = {
-        GIT_AUTHOR_NAME: "Anglesite",
-        GIT_AUTHOR_EMAIL: "edits@anglesite.local",
-        GIT_COMMITTER_NAME: "Anglesite",
-        GIT_COMMITTER_EMAIL: "edits@anglesite.local",
-      };
       const commit = runGit(projectRoot, [
         "commit-tree", tree, "-p", parent, "-m", formatMessage({ file, files, range, message }),
-      ], commitEnv);
+      ], ANGLESITE_COMMIT_IDENTITY);
       // CAS update with OLDVALUE so two concurrent recordEdits can't silently clobber each other.
       runGit(projectRoot, ["update-ref", EDITS_REF, commit, parent]);
       return commit;

--- a/server/edit-history.mjs
+++ b/server/edit-history.mjs
@@ -93,9 +93,15 @@ export async function recordEdit(projectRoot, { file, files, range, message }) {
       }
       const tree = runGit(projectRoot, ["write-tree"], env);
       const parent = runGit(projectRoot, ["rev-parse", EDITS_REF]);
+      const commitEnv = {
+        GIT_AUTHOR_NAME: "Anglesite",
+        GIT_AUTHOR_EMAIL: "edits@anglesite.local",
+        GIT_COMMITTER_NAME: "Anglesite",
+        GIT_COMMITTER_EMAIL: "edits@anglesite.local",
+      };
       const commit = runGit(projectRoot, [
         "commit-tree", tree, "-p", parent, "-m", formatMessage({ file, files, range, message }),
-      ]);
+      ], commitEnv);
       // CAS update with OLDVALUE so two concurrent recordEdits can't silently clobber each other.
       runGit(projectRoot, ["update-ref", EDITS_REF, commit, parent]);
       return commit;

--- a/server/git-identity.mjs
+++ b/server/git-identity.mjs
@@ -1,0 +1,15 @@
+/**
+ * Shared git identity for commits Anglesite itself authors on the hidden
+ * `refs/heads/anglesite/edits` branch (`edit-history.mjs`'s `recordEdit` and
+ * `undo-edit.mjs`'s `undoEdit`). Both call `commit-tree` directly, which — unlike
+ * `git commit` — never falls back to a "system default" identity: it needs
+ * GIT_AUTHOR_* / GIT_COMMITTER_* env (or matching git config) or it fails outright
+ * with "unable to auto-detect email address" in guest environments that have
+ * neither (see #428). Centralized here so the two callers can't drift.
+ */
+export const ANGLESITE_COMMIT_IDENTITY = {
+  GIT_AUTHOR_NAME: "Anglesite",
+  GIT_AUTHOR_EMAIL: "edits@anglesite.local",
+  GIT_COMMITTER_NAME: "Anglesite",
+  GIT_COMMITTER_EMAIL: "edits@anglesite.local",
+};

--- a/server/undo-edit.mjs
+++ b/server/undo-edit.mjs
@@ -16,6 +16,7 @@
 import { execFileSync } from "node:child_process";
 import { writeFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
+import { ANGLESITE_COMMIT_IDENTITY } from "./git-identity.mjs";
 
 const EDITS_REF = "refs/heads/anglesite/edits";
 
@@ -100,16 +101,10 @@ export async function undoEdit(projectRoot, { commit, force = false } = {}) {
   // 7. Advance the hidden branch with a new commit whose tree matches parent's tree.
   const parentTree = runGit(projectRoot, ["rev-parse", `${parent}^{tree}`]);
   const message = `undo: ${files.join(", ")}`;
-  const env = {
-    GIT_AUTHOR_NAME: "Anglesite",
-    GIT_AUTHOR_EMAIL: "edits@anglesite.local",
-    GIT_COMMITTER_NAME: "Anglesite",
-    GIT_COMMITTER_EMAIL: "edits@anglesite.local",
-  };
   const newCommit = runGit(
     projectRoot,
     ["commit-tree", parentTree, "-p", head, "-m", message],
-    env,
+    ANGLESITE_COMMIT_IDENTITY,
   );
   // CAS update: only advance if HEAD is still what we read in step 1.
   runGit(projectRoot, ["update-ref", EDITS_REF, newCommit, head]);

--- a/test/edit-history.test.js
+++ b/test/edit-history.test.js
@@ -122,3 +122,41 @@ describe("recordEdit — multi-file (extract-component)", () => {
     expect(git(["show", `${sha}:README.md`])).toBe("edited");
   });
 });
+
+describe("recordEdit — no ambient git identity (#428)", () => {
+  it("still commits when the guest has no git config and no GIT_AUTHOR/COMMITTER env", async () => {
+    // Reproduces the container guest environment from #428: no ~/.gitconfig, no
+    // GIT_AUTHOR_NAME/EMAIL or GIT_COMMITTER_NAME/EMAIL in the ambient environment.
+    // `commit-tree` must not depend on either — recordEdit has to supply its own identity.
+    git(["config", "--unset", "user.email"]);
+    git(["config", "--unset", "user.name"]);
+    // Also isolate from this sandbox's own ~/.gitconfig (which sets user.name/email for its
+    // unrelated commit-signing needs) and any system config, so the ambient environment matches
+    // the container guest in #428: no identity available from config OR env, anywhere.
+    const identityKeys = [
+      "GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL",
+      "GIT_CONFIG_GLOBAL", "GIT_CONFIG_SYSTEM", "GIT_CONFIG_NOSYSTEM",
+    ];
+    const saved = Object.fromEntries(identityKeys.map((k) => [k, process.env[k]]));
+    identityKeys.forEach((k) => delete process.env[k]);
+    process.env.GIT_CONFIG_GLOBAL = "/dev/null";
+    process.env.GIT_CONFIG_NOSYSTEM = "1";
+
+    try {
+      writeFileSync(join(repo, "README.md"), "edited\n");
+      const sha = await recordEdit(repo, {
+        file: "README.md",
+        range: { start: 0, end: 7 },
+        message: "anglesite: edit README.md",
+      });
+
+      expect(sha).toMatch(/^[0-9a-f]{40}$/);
+      expect(git(["show", `${sha}:README.md`])).toBe("edited");
+    } finally {
+      identityKeys.forEach((k) => {
+        if (saved[k] === undefined) delete process.env[k];
+        else process.env[k] = saved[k];
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- `recordEdit`'s `commit-tree` call in `server/edit-history.mjs` had no `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env, so it depended entirely on ambient git config/env for an identity.
- In the container-backed dev pipeline's guest environment (no `~/.gitconfig`, no identity env vars), `commit-tree` fails with `fatal: unable to auto-detect email address`, `recordEdit`'s catch-all swallows it and returns `undefined`, and `apply_edit`'s reply omits `commit` — so Anglesite-app's persist-to-`Source/` pipeline never fires and the edit is silently lost on container teardown.
- Fix: pass the same `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL`/`GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL` (`Anglesite` / `edits@anglesite.local`) that `undo-edit.mjs` already uses for its own `commit-tree` call, so `recordEdit` never depends on ambient identity.

## Paired PR check

- [x] This change is **self-contained** to the plugin (MCP server fix with no consumer-visible contract change — `apply_edit`'s reply schema already had an optional `commit` field; this just makes it populate reliably in identity-less guest environments instead of silently omitting it).
- [ ] This change **needs a paired PR** in [`Anglesite/Anglesite-app`](https://github.com/Anglesite/Anglesite-app)

## Test plan

- [x] Added a regression test (`test/edit-history.test.js`) that reproduces the container guest exactly: no repo-local `user.name`/`user.email`, `GIT_CONFIG_GLOBAL=/dev/null` + `GIT_CONFIG_NOSYSTEM=1` to strip this sandbox's own global config, and no `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env — verified it fails on the pre-fix code (`sha` is `undefined`) and passes with the fix.
- [x] Full `edit-history.test.js` + `undo-edit.test.js` suites pass (17/17).

Fixes #428


---
_Generated by [Claude Code](https://claude.ai/code/session_01ToF6XqGGxVVjzVSpQ4RJf8)_