### PR TITLE
docs(adr): extend ADR-0008 for baked-in @astroanimate/core components

### DIFF
--- a/agent-skills/animate/SKILL.md
+++ b/agent-skills/animate/SKILL.md
@@ -16,7 +16,7 @@ You're a motion designer who wins CSS Design Awards. Read `.site-config` for `SI
 ## Architecture decisions
 
 - [ADR-0004 Vanilla CSS](references/docs/decisions/0004-vanilla-css-custom-properties.md) — animations use CSS custom properties, not a framework
-- [ADR-0008 No third-party JS](references/docs/decisions/0008-no-third-party-javascript.md) — no JavaScript animation libraries
+- [ADR-0008 No third-party JS](references/docs/decisions/0008-no-third-party-javascript.md) — no JavaScript animation libraries; npm-installed animation component libraries (`@astroanimate/core`) are first-party but CSS-only (see "Escalating beyond vanilla CSS" below)
 
 Read `EXPLAIN_STEPS` from `.site-config`. If `true` or not set, explain before every tool call that will trigger a permission prompt. If `false`, proceed without pre-announcing tool calls.
 
@@ -38,6 +38,13 @@ You have the full power of modern CSS. Use these techniques to create award-qual
 - **Custom easing** — `cubic-bezier()` curves for personality (bouncy, snappy, gentle, dramatic)
 
 **Never use JavaScript for animation.** If you think you need JS, find the CSS-only approach. The only exception is adding a class to trigger an animation — and even that should use `IntersectionObserver` only if scroll-driven CSS animations can't achieve the effect.
+
+## Escalating beyond vanilla CSS
+
+Vanilla CSS stays the default craft — reach for it first, every time. If the site's template has `@astroanimate/core` baked in, check the site's `integrations/docs/animations.md` for its curated component list before reaching for anything beyond vanilla CSS. That list is authoritative — don't use `@astroanimate/core` components outside it.
+
+- **Never set `enhance={true}`.** The `enhance` prop emits inline `<script>` tags that the template's Content Security Policy blocks. CSS-only usage is the only supported mode (ADR-0008).
+- Everything below — the reduced-motion requirement and the preview-before-apply workflow — applies identically to `@astroanimate/core` components. There is no exception.
 
 ## The conversation
 

--- a/agent-skills/animate/references/docs/decisions/0008-no-third-party-javascript.md
+++ b/agent-skills/animate/references/docs/decisions/0008-no-third-party-javascript.md
@@ -42,9 +42,11 @@ Chosen option: "No third-party JavaScript", with eight exceptions:
 
 All other external scripts are blocked by default, enforced by the Content Security Policy and pre-deploy scans.
 
-### Creative coding libraries (not third-party)
+### Creative coding libraries and animation component libraries (not third-party)
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
+
+The same carve-out extends to npm-installed animation component libraries baked into the template, such as `@astroanimate/core`. Like the creative coding libraries above, they're bundled by Astro and served first-party — no CSP allowlist entry needed for the components themselves. The constraint is narrower, though: `@astroanimate/core`'s `enhance` prop emits inline `<script>` tags at render time, which the template's CSP blocks (`script-src 'self'`, no `unsafe-inline`). CSS-only usage — the library's components and custom properties without `enhance={true}` — is the only supported mode on Anglesite sites. This is an extension of the recorded first-party rule, not a policy reversal; the `animate` skill enforces the CSS-only constraint (see `docs/decisions/README.md` and `skills/animate/SKILL.md`).
 
 ### Consequences
 

--- a/docs/decisions/0008-no-third-party-javascript.md
+++ b/docs/decisions/0008-no-third-party-javascript.md
@@ -42,9 +42,11 @@ Chosen option: "No third-party JavaScript", with eight exceptions:
 
 All other external scripts are blocked by default, enforced by the Content Security Policy and pre-deploy scans.
 
-### Creative coding libraries (not third-party)
+### Creative coding libraries and animation component libraries (not third-party)
 
 npm-installed creative coding libraries (p5.js, Three.js, GSAP, Tone.js, D3.js, and others) are **not** third-party scripts. They are bundled by Astro's build process and served as first-party JavaScript from the same origin. The CSP `script-src 'self'` policy covers them without modification. These libraries are used by the `creative-canvas` skill to add interactive visual effects to any site — from a web artist's generative art portfolio to a bakery's holiday snow effect. No CSP allowlist entry or pre-deploy scan exception is needed.
+
+The same carve-out extends to npm-installed animation component libraries baked into the template, such as `@astroanimate/core`. Like the creative coding libraries above, they're bundled by Astro and served first-party — no CSP allowlist entry needed for the components themselves. The constraint is narrower, though: `@astroanimate/core`'s `enhance` prop emits inline `<script>` tags at render time, which the template's CSP blocks (`script-src 'self'`, no `unsafe-inline`). CSS-only usage — the library's components and custom properties without `enhance={true}` — is the only supported mode on Anglesite sites. This is an extension of the recorded first-party rule, not a policy reversal; the `animate` skill enforces the CSS-only constraint (see `docs/decisions/README.md` and `skills/animate/SKILL.md`).
 
 ### Consequences
 

--- a/skills/animate/SKILL.md
+++ b/skills/animate/SKILL.md
@@ -10,7 +10,7 @@ You're a motion designer who wins CSS Design Awards. Read `.site-config` for `SI
 ## Architecture decisions
 
 - [ADR-0004 Vanilla CSS](${CLAUDE_PLUGIN_ROOT}/docs/decisions/0004-vanilla-css-custom-properties.md) — animations use CSS custom properties, not a framework
-- [ADR-0008 No third-party JS](${CLAUDE_PLUGIN_ROOT}/docs/decisions/0008-no-third-party-javascript.md) — no JavaScript animation libraries
+- [ADR-0008 No third-party JS](${CLAUDE_PLUGIN_ROOT}/docs/decisions/0008-no-third-party-javascript.md) — no JavaScript animation libraries; npm-installed animation component libraries (`@astroanimate/core`) are first-party but CSS-only (see "Escalating beyond vanilla CSS" below)
 
 Read `EXPLAIN_STEPS` from `.site-config`. If `true` or not set, explain before every tool call that will trigger a permission prompt. If `false`, proceed without pre-announcing tool calls.
 
@@ -32,6 +32,13 @@ You have the full power of modern CSS. Use these techniques to create award-qual
 - **Custom easing** — `cubic-bezier()` curves for personality (bouncy, snappy, gentle, dramatic)
 
 **Never use JavaScript for animation.** If you think you need JS, find the CSS-only approach. The only exception is adding a class to trigger an animation — and even that should use `IntersectionObserver` only if scroll-driven CSS animations can't achieve the effect.
+
+## Escalating beyond vanilla CSS
+
+Vanilla CSS stays the default craft — reach for it first, every time. If the site's template has `@astroanimate/core` baked in, check the site's `integrations/docs/animations.md` for its curated component list before reaching for anything beyond vanilla CSS. That list is authoritative — don't use `@astroanimate/core` components outside it.
+
+- **Never set `enhance={true}`.** The `enhance` prop emits inline `<script>` tags that the template's Content Security Policy blocks. CSS-only usage is the only supported mode (ADR-0008).
+- Everything below — the reduced-motion requirement and the preview-before-apply workflow — applies identically to `@astroanimate/core` components. There is no exception.
 
 ## The conversation
 


### PR DESCRIPTION
## Summary

- Extends the "creative coding libraries (not third-party)" carve-out in ADR-0008 to cover npm-installed animation component libraries (`@astroanimate/core`), noting the CSP constraint: the library's `enhance` prop emits inline scripts the template CSP blocks, so CSS-only usage is the supported mode.
- Adds an "Escalating beyond vanilla CSS" section to `skills/animate/SKILL.md`: vanilla CSS stays the default craft, consult the site's `integrations/docs/animations.md` for the curated component list, never `enhance={true}`, and the existing reduced-motion / preview-before-apply rules apply unchanged.
- Regenerates the `agent-skills/animate` Open Agent Skills export (`npm run build:agent-skills animate`) so it stays in sync with the source skill.

This is an extension of the recorded first-party-JS rule, not a policy reversal.

## Ordering

Per #426, this should merge **after** [Anglesite/Anglesite-app#1006](https://github.com/Anglesite/Anglesite-app/pull/1006), which bakes `@astroanimate/core@0.1.2` into the website template. This PR is docs-only and doesn't depend on app-side code, but the `integrations/docs/animations.md` file it references is added by that template work.

## Paired PR check

- [x] This change is **self-contained** to the plugin (docs / skill guidance, no consumer-visible contract change).
- [ ] This change needs a paired PR in `Anglesite/Anglesite-app`.

## Test plan

- [x] `npm test` — all tests pass except 3 pre-existing failures in `apply-edit-dispatcher` tests unrelated to this change (filesystem-permission simulation fails in this sandbox because it runs as root)
- [x] `tests/adr-status.test.ts` and `tests/build-agent-skills.test.ts` / `tests/agent-skills-imports.test.ts` pass
- [x] `agent-skills/animate` regenerated and matches `skills/animate/SKILL.md`

Closes #426


---
_Generated by [Claude Code](https://claude.ai/code/session_01QegVjfRwRpUeoHfYW53ebm)_