### PR TITLE
fix(server): log recordEdit failures instead of swallowing them silently

### DIFF
--- a/server/edit-history.mjs
+++ b/server/edit-history.mjs
@@ -103,7 +103,16 @@ export async function recordEdit(projectRoot, { file, files, range, message }) {
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
     }
-  } catch {
+  } catch (error) {
+    // Silent here means a real recordEdit failure is indistinguishable from the routine
+    // "no commits yet" / "not a git repo" early returns above — the dispatcher already
+    // treats `undefined` as "history not recorded, on-disk patch still landed" and omits
+    // `commit` from the edit-applied reply with no error surfaced anywhere else in the
+    // pipeline. That silence is exactly why #428 (a missing-identity `commit-tree` failure)
+    // went undetected for as long as it did: every edit "succeeded" with no history and no
+    // trace. stderr is captured into the app's debug pane alongside the rest of this guest
+    // process's output (Anglesite-app CLAUDE.md: "logs are sacred").
+    console.error(`recordEdit: git operation failed, edit history not recorded: ${error.message}`);
     return undefined;
   }
 }

--- a/test/edit-history.test.js
+++ b/test/edit-history.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -81,6 +81,22 @@ describe("recordEdit", () => {
     const sha = await recordEdit(repo, { file: "src/new.txt", range: { start: 0, end: 0 }, message: "add" });
     expect(sha).toMatch(/^[0-9a-f]{40}$/);
     expect(git(["show", `${sha}:src/new.txt`])).toBe("fresh content");
+  });
+
+  it("logs the underlying git failure instead of swallowing it silently (#1066)", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // No such file on disk — hash-object -w fails, caught by recordEdit's outer try/catch.
+      const sha = await recordEdit(repo, {
+        file: "does/not/exist.txt",
+        range: { start: 0, end: 0 },
+        message: "x",
+      });
+      expect(sha).toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("recordEdit: git operation failed"));
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it("returns undefined when projectRoot is not a git repository", async () => {


### PR DESCRIPTION
## Summary

While investigating [Anglesite/Anglesite#1066](https://github.com/Anglesite/Anglesite/issues/1066) (edit-overlay WYSIWYG edits landing in the container but never reaching the host's canonical `Source/` repo, with no error surfaced anywhere), I traced the root cause to `recordEdit`'s `commit-tree` call failing for lack of a git identity in the container/podman guest — confirmed empirically against the `node:22-bookworm-slim` guest base image (`fatal: unable to auto-detect email address`). That's already fixed here on `main` (unreleased) by #428/#429.

What #429 didn't change: `recordEdit`'s outer `catch` still discards *any* failure with zero trace — `console.error`, log line, anything. That silence is exactly why #428 went undetected for as long as it did: the dispatcher (`apply-edit-dispatcher.mjs`) treats a swallowed error identically to the benign "no commits yet"/"not a git repo" early returns and returns a normal `edit-applied` reply with no `commit` — so every failure in this block, past or future, is invisible end-to-end (sidecar stderr, MCP reply, app debug pane — nowhere).

This PR adds one line: log the underlying error to stderr before returning `undefined`, so it's captured in the app's debug pane (`LocalContainerSiteRuntime` wires this guest process's stdout/stderr into `LogCenter`) instead of vanishing. Anglesite-app#1066 itself is otherwise resolved by #429 once a release including it is cut and consumed there — see that issue for the remaining app-side pin/release follow-up.

## Test plan

- [x] Added a test that spies on `console.error` and confirms `recordEdit` logs before returning `undefined` on a real git failure (missing file → `hash-object -w` failure)
- [x] `npm test` — 150/150 files, 3085/3085 tests passing