### PR TITLE
feat(server): adopt MCP 2026-07-28 stateless spec over HTTP

### DIFF
--- a/agent-skills/update/references/package.json
+++ b/agent-skills/update/references/package.json
@@ -27,6 +27,8 @@
     "url": "https://github.com/Anglesite/anglesite"
   },
   "devDependencies": {
+    "@modelcontextprotocol/client": "^2.0.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@types/semver": "^7.7.1",
     "html-validate": "^10.11.2",
     "jsdom": "^29.1.1",
@@ -48,8 +50,10 @@
   },
   "dependencies": {
     "@astrojs/compiler": "^4.0.0",
-    "@modelcontextprotocol/sdk": "^1.28.0",
+    "@modelcontextprotocol/node": "^2.0.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "css-tree": "^3.2.1",
-    "sharp": "^0.33.0"
+    "sharp": "^0.33.0",
+    "zod": "^4.2.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,15 @@
       "license": "ISC",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
-        "@modelcontextprotocol/sdk": "^1.28.0",
+        "@modelcontextprotocol/node": "^2.0.0",
+        "@modelcontextprotocol/server": "^2.0.0",
         "css-tree": "^3.2.1",
-        "sharp": "^0.33.0"
+        "sharp": "^0.33.0",
+        "zod": "^4.2.0"
       },
       "devDependencies": {
+        "@modelcontextprotocol/client": "^2.0.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@types/semver": "^7.7.1",
         "html-validate": "^10.11.2",
         "jsdom": "^29.1.1",
@@ -1248,13 +1252,66 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/server": "^2.0.0",
+        "hono": "^4.11.4"
+      },
+      "peerDependenciesMeta": {
+        "hono": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1286,6 +1343,19 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1887,6 +1957,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -1900,6 +1971,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1916,6 +1988,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -2009,6 +2082,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -2033,6 +2107,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2072,6 +2147,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2105,6 +2181,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2118,6 +2195,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2262,6 +2340,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2275,6 +2354,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2284,6 +2364,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2293,6 +2374,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -2302,6 +2384,7 @@
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -2346,6 +2429,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2410,6 +2494,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2458,6 +2543,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2500,6 +2586,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2514,6 +2601,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
@@ -2527,6 +2615,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2576,6 +2665,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2585,6 +2675,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2601,6 +2692,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2655,6 +2747,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/estree-walker": {
@@ -2671,6 +2764,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2680,6 +2774,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.1"
@@ -2692,6 +2787,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
       "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -2711,6 +2807,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -2754,6 +2851,7 @@
       "version": "8.5.2",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
       "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.2.0"
@@ -2772,6 +2870,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -2795,6 +2894,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
       "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2854,6 +2954,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -2894,6 +2995,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2903,6 +3005,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2926,6 +3029,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2948,6 +3052,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2972,6 +3077,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3085,6 +3191,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3110,6 +3217,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3135,6 +3243,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3242,6 +3351,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -3262,6 +3372,7 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -3316,6 +3427,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -3329,6 +3441,7 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3338,6 +3451,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -3464,18 +3578,21 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/jose": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -3579,12 +3696,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/jsonc-parser": {
@@ -3798,6 +3917,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3831,6 +3951,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3853,6 +3974,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4464,6 +4586,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4473,6 +4596,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -4525,6 +4649,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4550,6 +4675,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4569,6 +4695,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4578,6 +4705,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4590,6 +4718,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -4602,6 +4731,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -4663,6 +4793,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4672,6 +4803,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4698,6 +4830,7 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -4745,6 +4878,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -4887,6 +5021,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -4940,6 +5075,7 @@
       "version": "6.15.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
       "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",
@@ -4977,6 +5113,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
       "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4990,6 +5127,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -5005,6 +5143,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5090,6 +5229,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -5130,6 +5270,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -5184,6 +5325,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -5210,6 +5352,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -5229,6 +5372,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/sharp": {
@@ -5274,6 +5418,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5286,6 +5431,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5295,6 +5441,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5314,6 +5461,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5330,6 +5478,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5348,6 +5497,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5463,6 +5613,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5845,6 +5996,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -5921,6 +6073,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^2.0.0",
@@ -5939,6 +6092,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5997,6 +6151,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6013,6 +6168,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6300,6 +6456,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6332,6 +6489,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -6377,6 +6535,7 @@
       "version": "3.25.2",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "url": "https://github.com/Anglesite/anglesite"
   },
   "devDependencies": {
+    "@modelcontextprotocol/client": "^2.0.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@types/semver": "^7.7.1",
     "html-validate": "^10.11.2",
     "jsdom": "^29.1.1",
@@ -48,8 +50,10 @@
   },
   "dependencies": {
     "@astrojs/compiler": "^4.0.0",
-    "@modelcontextprotocol/sdk": "^1.28.0",
+    "@modelcontextprotocol/node": "^2.0.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "css-tree": "^3.2.1",
-    "sharp": "^0.33.0"
+    "sharp": "^0.33.0",
+    "zod": "^4.2.0"
   }
 }

--- a/server/http-server.mjs
+++ b/server/http-server.mjs
@@ -1,21 +1,7 @@
 import { createServer } from "node:http";
-import { randomUUID } from "node:crypto";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { createMcpHandler } from "@modelcontextprotocol/server";
+import { toNodeHandler } from "@modelcontextprotocol/node";
 import { buildServer } from "./index-tools.mjs";
-
-/** Read and JSON-parse a request body. Returns `undefined` for an empty body. */
-function readJsonBody(req) {
-  return new Promise((resolve, reject) => {
-    const chunks = [];
-    req.on("data", (chunk) => { chunks.push(chunk); });
-    req.on("end", () => {
-      if (chunks.length === 0) return resolve(undefined);
-      try { resolve(JSON.parse(Buffer.concat(chunks).toString("utf8"))); } catch (e) { reject(e); }
-    });
-    req.on("error", reject);
-  });
-}
 
 function sendJson(res, status, payload) {
   res.writeHead(status, { "Content-Type": "application/json" });
@@ -24,56 +10,28 @@ function sendJson(res, status, payload) {
 
 /**
  * Start the Anglesite MCP server over Streamable HTTP on a single `/mcp` endpoint.
- * Session-managed: an `initialize` POST mints a session + per-session transport;
- * subsequent requests carry `Mcp-Session-Id`.
+ *
+ * Stateless (MCP 2026-07-28): every request is self-contained, so no session is
+ * minted and no `Mcp-Session-Id` handling exists. `createMcpHandler` serves the
+ * 2026-07-28 protocol and, via its built-in `legacy: 'stateless'` fallback,
+ * still answers 2025-era Streamable HTTP traffic — including the
+ * `initialize`/`notifications/initialized` handshake older clients (the
+ * Anglesite-app's current `MCPClient`) send — per-request from the same
+ * `buildServer` factory, so the two protocol eras can never drift apart.
  *
  * Returns `{ url, close }` where `url` is the full endpoint (`http://host:port/mcp`).
  */
 export async function startHttpServer({ projectRoot, host = "127.0.0.1", port = 4399 }) {
-  /** @type {Map<string, StreamableHTTPServerTransport>} */
-  const transports = new Map();
+  const handler = createMcpHandler(() => buildServer(projectRoot), {
+    onerror: (err) => console.error("[anglesite] MCP handler error:", err),
+  });
+  const nodeHandler = toNodeHandler(handler);
 
   const httpServer = createServer(async (req, res) => {
     try {
       const url = new URL(req.url, `http://${req.headers.host}`);
       if (url.pathname !== "/mcp") { res.writeHead(404).end(); return; }
-
-      const sid = req.headers["mcp-session-id"];
-
-      if (req.method === "POST") {
-        const body = await readJsonBody(req);
-        let transport = typeof sid === "string" ? transports.get(sid) : undefined;
-
-        if (!transport) {
-          if (!isInitializeRequest(body)) {
-            sendJson(res, 400, {
-              jsonrpc: "2.0",
-              error: { code: -32000, message: "Bad Request: no valid session ID provided" },
-              id: null,
-            });
-            return;
-          }
-          transport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID() });
-          transport.onclose = () => {
-            if (transport.sessionId) transports.delete(transport.sessionId);
-          };
-          const server = buildServer(projectRoot);
-          await server.connect(transport);
-        }
-
-        await transport.handleRequest(req, res, body);
-        if (transport.sessionId) transports.set(transport.sessionId, transport);
-        return;
-      }
-
-      if (req.method === "GET" || req.method === "DELETE") {
-        const transport = typeof sid === "string" ? transports.get(sid) : undefined;
-        if (!transport) { res.writeHead(400).end("Invalid or missing session ID"); return; }
-        await transport.handleRequest(req, res);
-        return;
-      }
-
-      res.writeHead(405).end();
+      await nodeHandler(req, res);
     } catch (err) {
       if (!res.headersSent) sendJson(res, 500, { jsonrpc: "2.0", error: { code: -32603, message: String(err) }, id: null });
     }
@@ -87,8 +45,7 @@ export async function startHttpServer({ projectRoot, host = "127.0.0.1", port = 
   return {
     url: endpoint,
     close: async () => {
-      await Promise.all([...transports.values()].map((t) => t.close?.()));
-      transports.clear();
+      await handler.close();
       await new Promise((resolve) => httpServer.close(() => resolve()));
     },
   };

--- a/server/index-tools.mjs
+++ b/server/index-tools.mjs
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { McpServer } from "@modelcontextprotocol/server";
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
 import { z } from "zod";
 import {
   addAnnotation,
@@ -48,17 +48,19 @@ export function buildServer(projectRoot) {
     version: pluginVersion(),
   });
 
-  server.tool(
+  server.registerTool(
     "add_annotation",
-    "Pin a feedback note to a page element",
     {
-      path: z.string().describe("Page path, e.g. /about"),
-      selector: z.string().describe("CSS selector of the target element"),
-      text: z.string().describe("The feedback note text"),
-      sourceFile: z
-        .string()
-        .optional()
-        .describe("Source file path, e.g. src/pages/about.astro"),
+      description: "Pin a feedback note to a page element",
+      inputSchema: z.object({
+        path: z.string().describe("Page path, e.g. /about"),
+        selector: z.string().describe("CSS selector of the target element"),
+        text: z.string().describe("The feedback note text"),
+        sourceFile: z
+          .string()
+          .optional()
+          .describe("Source file path, e.g. src/pages/about.astro"),
+      }),
     },
     ({ path, selector, text, sourceFile }) => {
       const annotation = addAnnotation(projectRoot, {
@@ -71,17 +73,19 @@ export function buildServer(projectRoot) {
     },
   );
 
-  server.tool(
+  server.registerTool(
     "list_annotations",
-    "List unresolved feedback annotations",
     {
-      path: z.string().optional().describe("Filter by page path"),
-      resolved: z
-        .boolean()
-        .optional()
-        .describe("Include resolved annotations too. Default false (unresolved only)."),
-      limit: z.number().int().positive().optional().describe("Max annotations to return"),
-      offset: z.number().int().nonnegative().optional().describe("Skip this many before applying limit"),
+      description: "List unresolved feedback annotations",
+      inputSchema: z.object({
+        path: z.string().optional().describe("Filter by page path"),
+        resolved: z
+          .boolean()
+          .optional()
+          .describe("Include resolved annotations too. Default false (unresolved only)."),
+        limit: z.number().int().positive().optional().describe("Max annotations to return"),
+        offset: z.number().int().nonnegative().optional().describe("Skip this many before applying limit"),
+      }),
     },
     ({ path, resolved, limit, offset }) => {
       const annotations = listAnnotations(projectRoot, path, { resolved, limit, offset });
@@ -89,11 +93,13 @@ export function buildServer(projectRoot) {
     },
   );
 
-  server.tool(
+  server.registerTool(
     "resolve_annotation",
-    "Mark a feedback annotation as resolved",
     {
-      id: z.string().describe("Annotation ID to resolve"),
+      description: "Mark a feedback annotation as resolved",
+      inputSchema: z.object({
+        id: z.string().describe("Annotation ID to resolve"),
+      }),
     },
     ({ id }) => {
       try {
@@ -116,10 +122,13 @@ export function buildServer(projectRoot) {
   // back as `commit` on the edit-applied response. `onApplied` is called with `{file, range}` for
   // every single-file op, or `{files, message}` for extract-component's two-file write (Component
   // Editor slice 5, Anglesite-app#495) — `recordEdit`'s `files` mode commits both onto ONE commit.
-  server.tool(
+  server.registerTool(
     "apply_edit",
-    "Apply an edit to the underlying source for a previewed page element. The selector is the structured ElementInfo payload built by the WKWebView overlay; the server resolves it via selector.mjs and patches the matching source file. Successful edits are also committed onto the hidden anglesite/edits branch for per-edit undo.",
-    applyEditInputShape,
+    {
+      description:
+        "Apply an edit to the underlying source for a previewed page element. The selector is the structured ElementInfo payload built by the WKWebView overlay; the server resolves it via selector.mjs and patches the matching source file. Successful edits are also committed onto the hidden anglesite/edits branch for per-edit undo.",
+      inputSchema: z.object(applyEditInputShape),
+    },
     async (input) =>
       applyEdit(projectRoot, input, {
         onApplied: ({ file, range, files, message }) =>
@@ -129,12 +138,15 @@ export function buildServer(projectRoot) {
       }),
   );
 
-  server.tool(
+  server.registerTool(
     "undo_edit",
-    "Undo the most-recent commit on the hidden anglesite/edits branch by writing the parent commit's blobs back to disk. HEAD-only in v1: an optional `commit` argument must equal current HEAD (or be omitted). `force: true` skips the working-tree-modification check and overwrites any external changes to the touched files.",
     {
-      commit: z.string().optional().describe("SHA to undo. Must equal current HEAD of refs/heads/anglesite/edits if provided."),
-      force: z.boolean().optional().describe("Skip the working-tree-modification check and overwrite any external changes. Default false."),
+      description:
+        "Undo the most-recent commit on the hidden anglesite/edits branch by writing the parent commit's blobs back to disk. HEAD-only in v1: an optional `commit` argument must equal current HEAD (or be omitted). `force: true` skips the working-tree-modification check and overwrites any external changes to the touched files.",
+      inputSchema: z.object({
+        commit: z.string().optional().describe("SHA to undo. Must equal current HEAD of refs/heads/anglesite/edits if provided."),
+        force: z.boolean().optional().describe("Skip the working-tree-modification check and overwrite any external changes. Default false."),
+      }),
     },
     async ({ commit, force }) => {
       const result = await undoEdit(projectRoot, { commit, force });
@@ -145,11 +157,14 @@ export function buildServer(projectRoot) {
     },
   );
 
-  server.tool(
+  server.registerTool(
     "get_component_model",
-    "Parse an .astro component into a structured, read-only model: template node tree with source spans, frontmatter Props interface, scoped style rules, and client script zone. Used by the app's Component Editor.",
     {
-      path: z.string().describe("Component path relative to the project root, e.g. src/components/Card.astro"),
+      description:
+        "Parse an .astro component into a structured, read-only model: template node tree with source spans, frontmatter Props interface, scoped style rules, and client script zone. Used by the app's Component Editor.",
+      inputSchema: z.object({
+        path: z.string().describe("Component path relative to the project root, e.g. src/components/Card.astro"),
+      }),
     },
     async ({ path }) => {
       try {
@@ -179,20 +194,23 @@ export function buildServer(projectRoot) {
 
   // Siri AI Phase A content tools (#140 / A.6). `list_content` feeds the Anglesite-app's
   // SiteContentGraph (#142); `create_page`/`create_post` back the Add-Page/Add-Post intents (A.5).
-  server.tool(
+  server.registerTool(
     "list_content",
-    "List the site's pages, article-like content-collection entries (posts, notes, episodes, experiments), and images under public/images, as structured JSON. Read-only; the filesystem is the source of truth.",
     {
-      type: z
-        .enum(["pages", "posts", "images"])
-        .optional()
-        .describe("Return only this bucket; the other two come back empty. Default: all three."),
-      limit: z.number().int().positive().optional().describe("Max entries to return per bucket"),
-      offset: z.number().int().nonnegative().optional().describe("Skip this many entries per bucket before applying limit"),
-      fields: z
-        .array(z.string())
-        .optional()
-        .describe("Project each entry down to only these field names, e.g. [\"title\", \"filePath\"]"),
+      description:
+        "List the site's pages, article-like content-collection entries (posts, notes, episodes, experiments), and images under public/images, as structured JSON. Read-only; the filesystem is the source of truth.",
+      inputSchema: z.object({
+        type: z
+          .enum(["pages", "posts", "images"])
+          .optional()
+          .describe("Return only this bucket; the other two come back empty. Default: all three."),
+        limit: z.number().int().positive().optional().describe("Max entries to return per bucket"),
+        offset: z.number().int().nonnegative().optional().describe("Skip this many entries per bucket before applying limit"),
+        fields: z
+          .array(z.string())
+          .optional()
+          .describe("Project each entry down to only these field names, e.g. [\"title\", \"filePath\"]"),
+      }),
     },
     ({ type, limit, offset, fields }) => {
       const listing = listContent(projectRoot, { type, limit, offset, fields });
@@ -200,15 +218,18 @@ export function buildServer(projectRoot) {
     },
   );
 
-  server.tool(
+  server.registerTool(
     "create_page",
-    "Scaffold a new Astro page under src/pages/ from a BaseLayout template and commit it. Does not overwrite an existing page.",
     {
-      name: z.string().describe("Human-readable page name, e.g. 'About Us'. Used as the title."),
-      route: z
-        .string()
-        .optional()
-        .describe("URL route, e.g. /about or /services/web. Derived from name when omitted."),
+      description:
+        "Scaffold a new Astro page under src/pages/ from a BaseLayout template and commit it. Does not overwrite an existing page.",
+      inputSchema: z.object({
+        name: z.string().describe("Human-readable page name, e.g. 'About Us'. Used as the title."),
+        route: z
+          .string()
+          .optional()
+          .describe("URL route, e.g. /about or /services/web. Derived from name when omitted."),
+      }),
     },
     ({ name, route }) => {
       try {
@@ -220,16 +241,19 @@ export function buildServer(projectRoot) {
     },
   );
 
-  server.tool(
+  server.registerTool(
     "create_post",
-    "Scaffold a new content-collection entry (default collection: posts) as a draft from a template and commit it. Does not overwrite an existing entry.",
     {
-      title: z.string().describe("Post title. Used as the slug source when slug is omitted."),
-      collection: z
-        .string()
-        .optional()
-        .describe("Content collection name, e.g. posts (default) or notes."),
-      slug: z.string().optional().describe("URL slug. Derived from title when omitted."),
+      description:
+        "Scaffold a new content-collection entry (default collection: posts) as a draft from a template and commit it. Does not overwrite an existing entry.",
+      inputSchema: z.object({
+        title: z.string().describe("Post title. Used as the slug source when slug is omitted."),
+        collection: z
+          .string()
+          .optional()
+          .describe("Content collection name, e.g. posts (default) or notes."),
+        slug: z.string().optional().describe("URL slug. Derived from title when omitted."),
+      }),
     },
     ({ title, collection, slug }) => {
       try {
@@ -243,17 +267,20 @@ export function buildServer(projectRoot) {
 
   // Typed content objects (#377 / V-1). Scaffolds an h-entry-family or business entry from the
   // shared content-type registry, byte-faithful to the app's native createTyped path.
-  server.tool(
+  server.registerTool(
     "create_content",
-    "Scaffold a typed content entry (e.g. note, article, photo, event, review) as a draft from the shared content-type registry and commit it. Collection-stored types only; does not overwrite an existing entry.",
     {
-      type: z
-        .enum(creatableContentTypeIds)
-        .describe("Content type id, e.g. note, article, event. Determines the collection and frontmatter."),
-      title: z
-        .string()
-        .optional()
-        .describe("Entry title. Used for the title/name field (when the type has one) and as the slug source."),
+      description:
+        "Scaffold a typed content entry (e.g. note, article, photo, event, review) as a draft from the shared content-type registry and commit it. Collection-stored types only; does not overwrite an existing entry.",
+      inputSchema: z.object({
+        type: z
+          .enum(creatableContentTypeIds)
+          .describe("Content type id, e.g. note, article, event. Determines the collection and frontmatter."),
+        title: z
+          .string()
+          .optional()
+          .describe("Entry title. Used for the title/name field (when the type has one) and as the slug source."),
+      }),
     },
     ({ type, title }) => {
       try {

--- a/test/mcp-http-transport.test.js
+++ b/test/mcp-http-transport.test.js
@@ -2,9 +2,24 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+// v1 SDK client: the 2025-era Streamable HTTP dialect the shipped Anglesite-app
+// still speaks. Kept as a devDependency for exactly this drain-window coverage.
+import { Client as LegacyClient } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport as LegacyHTTPTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+// v2 SDK client: the MCP 2026-07-28 stateless protocol.
+import { Client } from "@modelcontextprotocol/client";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
 import { startHttpServer } from "../server/http-server.mjs";
+
+/** Decode a Streamable HTTP response body: SSE frame(s) or a plain JSON object. */
+async function decodeBody(res) {
+  const text = await res.text();
+  if (res.headers.get("content-type")?.includes("text/event-stream")) {
+    const data = text.split("\n").filter((l) => l.startsWith("data:"));
+    return JSON.parse(data.map((l) => l.slice(5).trim()).join("\n"));
+  }
+  return JSON.parse(text);
+}
 
 describe("MCP Streamable HTTP transport", () => {
   let root;
@@ -20,17 +35,120 @@ describe("MCP Streamable HTTP transport", () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it("serves initialize, tools/list and a tool call over HTTP", async () => {
+  it("serves a legacy (2025-era) v1 SDK client end to end", async () => {
     handle = await startHttpServer({ projectRoot: root, host: "127.0.0.1", port: 0 });
     expect(handle.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp$/);
 
-    const client = new Client({ name: "test", version: "0.0.0" });
-    await client.connect(new StreamableHTTPClientTransport(new URL(handle.url)));
+    const client = new LegacyClient({ name: "test", version: "0.0.0" });
+    await client.connect(new LegacyHTTPTransport(new URL(handle.url)));
 
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toContain("list_annotations");
     expect(names).toContain("apply_edit");
+
+    const res = await client.callTool({ name: "list_annotations", arguments: {} });
+    expect(res.isError).toBeFalsy();
+    expect(JSON.parse(res.content[0].text)).toEqual([]);
+
+    await client.close();
+  });
+
+  it("serves the Anglesite-app's raw 2024-11-05 wire dialect statelessly", async () => {
+    // Mirrors the app's `HTTPTransport`/`MCPClient` exactly: an `initialize`
+    // handshake pinned to 2024-11-05, `notifications/initialized`, then plain
+    // requests — every POST self-contained, no `Mcp-Session-Id` expected back.
+    handle = await startHttpServer({ projectRoot: root, host: "127.0.0.1", port: 0 });
+
+    const post = (body) =>
+      fetch(handle.url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept": "application/json, text/event-stream",
+          "MCP-Protocol-Version": "2024-11-05",
+        },
+        body: JSON.stringify(body),
+      });
+
+    const init = await post({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "anglesite-app", version: "0.0.0" },
+      },
+    });
+    expect(init.status).toBe(200);
+    // Stateless: the server must not mint a session.
+    expect(init.headers.get("mcp-session-id")).toBeNull();
+    const initBody = await decodeBody(init);
+    expect(initBody.result.protocolVersion).toBe("2024-11-05");
+    expect(initBody.result.serverInfo.name).toBe("anglesite");
+
+    const inited = await post({ jsonrpc: "2.0", method: "notifications/initialized" });
+    expect(inited.status).toBe(202);
+
+    const list = await post({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+    expect(list.status).toBe(200);
+    const listBody = await decodeBody(list);
+    expect(listBody.result.tools.map((t) => t.name)).toContain("apply_edit");
+
+    const call = await post({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name: "list_annotations", arguments: {} },
+    });
+    expect(call.status).toBe(200);
+    const callBody = await decodeBody(call);
+    expect(JSON.parse(callBody.result.content[0].text)).toEqual([]);
+  });
+
+  it("serves a modern (2026-07-28) stateless request with the _meta envelope", async () => {
+    handle = await startHttpServer({ projectRoot: root, host: "127.0.0.1", port: 0 });
+
+    const res = await fetch(handle.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "MCP-Protocol-Version": "2026-07-28",
+        "Mcp-Method": "tools/call",
+        "Mcp-Name": "list_annotations",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "list_annotations",
+          arguments: {},
+          _meta: {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientInfo": { name: "test-2026", version: "0.0.0" },
+            "io.modelcontextprotocol/clientCapabilities": {},
+          },
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = await decodeBody(res);
+    expect(body.error).toBeUndefined();
+    expect(body.result.resultType).toBe("complete");
+    expect(JSON.parse(body.result.content[0].text)).toEqual([]);
+  });
+
+  it("serves a modern v2 SDK client end to end", async () => {
+    handle = await startHttpServer({ projectRoot: root, host: "127.0.0.1", port: 0 });
+
+    const client = new Client({ name: "test-v2", version: "0.0.0" });
+    await client.connect(new StreamableHTTPClientTransport(new URL(handle.url)));
+
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toContain("list_annotations");
 
     const res = await client.callTool({ name: "list_annotations", arguments: {} });
     expect(res.isError).toBeFalsy();


### PR DESCRIPTION
## Summary

- Migrates the MCP server to the v2 TypeScript SDK (`@modelcontextprotocol/server` + `@modelcontextprotocol/node`, explicit `zod@^4.2`) and adopts the **MCP 2026-07-28 stateless spec** on the HTTP path: `createMcpHandler` serves the modern protocol (`_meta` envelope, `Mcp-Method`/`Mcp-Name` headers, `resultType`, cache hints) and its built-in `legacy: 'stateless'` fallback keeps answering 2025-era Streamable HTTP traffic — including the `initialize` handshake the shipped Anglesite-app `MCPClient` (pinned `2024-11-05`) sends — from the **same** `buildServer` factory, per-request, with no session minted. The hand-rolled `Mcp-Session-Id` session map is gone.
- Tool registrations move from v1 `server.tool()` to v2 `registerTool()` with explicit `z.object()` input schemas; stdio stays on the same server via the v2 stdio transport (verified to still negotiate `2024-11-05` with the app's raw JSON-RPC handshake).
- The v1 SDK stays as a **devDependency** so the old client remains exercised in tests for the drain window; `@modelcontextprotocol/client` v2 covers the modern era.

## Paired PR check

- [ ] This change is **self-contained** to the plugin (skills / hooks / template / docs / MCP server with no consumer-visible contract change).
- [x] This change **needs a paired PR** in [`Anglesite/Anglesite-app`](https://github.com/Anglesite/Anglesite-app) (MCP message schema, template fields the app reads, hook surface, anything the native app embeds or shells out to). Link it here: Anglesite/Anglesite#1277 (app PR to follow — bump `protocolVersion`, drop the `initialize`/session plumbing from `MCPClient`/`HTTPTransport`, re-vendor the container image)

Backward compatible by design: the legacy fallback means the current app keeps working against this server before the app PR lands, so this can ship first in a tagged release per the two-repo flow.

## Test plan

- [x] `npx vitest run test/mcp-http-transport.test.js` — 4 tests: v1-SDK client (drain-window regression), raw `2024-11-05` wire mirroring the app's `HTTPTransport` (asserts **no** `Mcp-Session-Id` is minted), raw 2026-07-28 stateless request with the `_meta` envelope (asserts `resultType: "complete"`), v2-SDK client
- [x] `npx vitest run tests/mcp-server.test.ts` — 11 stdio tests pass unchanged (raw JSON-RPC `initialize` pinned to `2024-11-05`)
- [x] `npm test` — 149/150 files pass; the one failing file (`tests/build-agent-skills.test.ts`, 56 SKILL.md drift assertions) **also fails on clean `main`** and is unrelated
- [x] App-side e2e against this checkout: `ANGLESITE_PLUGIN_PATH=<this worktree> swift test --filter "AppliesEditEndToEnd|MCPClientHTTPEndToEnd"` — real Swift `MCPClient`/`HTTPTransport` pass over stdio and HTTP

## Notes

- Deprecated-feature audit per the issue: the server uses none of Roots, Sampling, Logging, or elicitation — nothing to migrate there.
- Legacy-leg behavior change: session-less GET/DELETE on `/mcp` now answer `405` (previously `400`). The app only sends DELETE when it holds a session id, which a stateless server never mints, so no consumer is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)