### PR TITLE
chore: regen agent-skills export after v1.8.0 release

### DIFF
--- a/agent-skills/README.md
+++ b/agent-skills/README.md
@@ -9,7 +9,7 @@ material lives in its `references/` directory.
 > Generated — do not edit by hand. Edit the plugin sources in `skills/` and run
 > `npm run build:agent-skills`.
 
-**Version:** 1.7.0 · **License:** ISC · 56 skills
+**Version:** 1.8.0 · **License:** ISC · 56 skills
 
 ## Install
 

--- a/agent-skills/add-store/SKILL.md
+++ b/agent-skills/add-store/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npx wrangler *), Bash(npm run build), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/animate/SKILL.md
+++ b/agent-skills/animate/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/backup/SKILL.md
+++ b/agent-skills/backup/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(git status *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git log *), Bash(git diff *), Bash(git checkout *), Bash(git branch *), Bash(git tag *), Bash(git show *), Bash(git stash *), Bash(git fetch *), Bash(git rev-parse *), Bash(npx tsx *), Read
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/booking/SKILL.md
+++ b/agent-skills/booking/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob, Bash(npm run build), Bash(npx astro check)
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/business-info/SKILL.md
+++ b/agent-skills/business-info/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/buy-button/SKILL.md
+++ b/agent-skills/buy-button/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/check/SKILL.md
+++ b/agent-skills/check/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run *), Bash(npx astro check), Bash(npx pa11y *), Bash(npx pa11y-ci *), Bash(npx tsx scripts/link-check.ts *), Bash(npx tsx scripts/a11y-audit.ts *), Bash(npx tsx scripts/a14y-audit.ts *), Bash(npx a14y *), Bash(a14y *), Bash(grep *), Bash(find dist/ *), Bash(stat *), Bash(npm audit *), Bash(lsof *), Bash(netstat *), Bash(getent *), Bash(nslookup *), Bash(gh issue *), Bash(gh label *), Write, Read, Glob, mcp__cloudflare__accounts_list, mcp__cloudflare__search_cloudflare_documentation, mcp__cloudflare__workers_list, mcp__cloudflare__workers_get_worker, mcp__cloudflare__workers_get_worker_code
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[optional: describe the problem]"

--- a/agent-skills/consent/SKILL.md
+++ b/agent-skills/consent/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(grep *), Write, Read, Glob, Edit
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/contact/SKILL.md
+++ b/agent-skills/contact/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(npx astro check), Bash(grep *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/convert/SKILL.md
+++ b/agent-skills/convert/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: ["Bash(npm run build)", "Bash(npm install)", "Bash(npm run ai-alt)", "Bash(zsh *)", "Bash(node *)", "Bash(npx sharp-cli *)", "Bash(mkdir *)", "Bash(git add *)", "Bash(git commit *)", "Bash(ls *)", "Bash(wc *)", "Bash(cp *)", "Bash(find src/content/posts *)", "Bash(find public/images *)", "Bash(find */images *)", "Bash(find */public *)", "Bash(find */static *)", "Bash(find */source *)", "Bash(find */content *)", "Bash(find */docs *)", "Bash(find */_posts *)", "Bash(find */layouts *)", "Bash(find */templates *)", "Bash(find */_includes *)", "Write", "Read", "Glob", "Edit"]
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/copy-edit/SKILL.md
+++ b/agent-skills/copy-edit/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/creative-canvas/SKILL.md
+++ b/agent-skills/creative-canvas/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm install *), Bash(npm run dev), Bash(npm run build), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
   argument-hint: "[effect description or library name]"

--- a/agent-skills/deploy/SKILL.md
+++ b/agent-skills/deploy/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npm run deploy *), Bash(npm run preview *), Bash(npm run ai-linkcheck *), Bash(npm run ai-a11y *), Bash(npm run ai-a14y *), Bash(npm run ai-perf *), Bash(npm run ai-webmention-send *), Bash(npx wrangler *), Bash(grep *), Bash(find dist/ *), Bash(gh *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git checkout *), Bash(git merge *), Bash(git branch *), Bash(kill *), Write, Read, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__search_cloudflare_documentation
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/design-import/SKILL.md
+++ b/agent-skills/design-import/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: ["Bash(node *)", "Bash(npx sharp-cli *)", "Bash(npx playwright install *)", "Bash(npm install *)", "Bash(npm run dev *)", "Bash(npm run build)", "Bash(mkdir *)", "Bash(curl *)", "Bash(git add *)", "Bash(git commit *)", "Bash(git push *)", "Bash(ls *)", "Bash(npm ls *)", "Bash(grep *)", "WebFetch", "Write", "Read", "Edit", "Glob"]
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[Canva site URL, Figma file URL, or freedesignmd.com system URL]"

--- a/agent-skills/design-interview/SKILL.md
+++ b/agent-skills/design-interview/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run *), WebFetch, Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/domain/SKILL.md
+++ b/agent-skills/domain/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(curl *), Write, Read, mcp__cloudflare__search_cloudflare_documentation
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[email, bluesky, or service name]"

--- a/agent-skills/donations/SKILL.md
+++ b/agent-skills/donations/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/email/SKILL.md
+++ b/agent-skills/email/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(curl *), Write, Read
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/experiment/SKILL.md
+++ b/agent-skills/experiment/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/export/SKILL.md
+++ b/agent-skills/export/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(mkdir *), Bash(cp *), Bash(rsync *), Bash(zip *), Bash(ls *), Bash(find *), Bash(du *), Bash(grep *), Bash(date *), Bash(git rev-parse *), Bash(npx wrangler r2 *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, Read, Write
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/forms/SKILL.md
+++ b/agent-skills/forms/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(npx astro check), Bash(grep *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/freedesignmd/SKILL.md
+++ b/agent-skills/freedesignmd/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: WebFetch, Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/giscus/SKILL.md
+++ b/agent-skills/giscus/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx astro check), Bash(grep *), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/i18n/SKILL.md
+++ b/agent-skills/i18n/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx astro check), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/import/SKILL.md
+++ b/agent-skills/import/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: ["WebFetch", "Bash(curl *)", "Bash(npx sharp-cli *)", "Bash(mkdir *)", "Bash(npm run build)", "Bash(npm install)", "Bash(npm run ai-alt)", "Bash(zsh *)", "Bash(node *)", "Bash(git add *)", "Bash(git commit *)", "Bash(git push *)", "Bash(ls *)", "Bash(wc *)", "Bash(grep *)", "Bash(find src/content/posts *)", "Bash(find public/images *)", "Bash(find */images *)", "Bash(find */public *)", "Bash(find */static *)", "Bash(find */source *)", "Bash(find */content *)", "Bash(find */docs *)", "Bash(find */_posts *)", "Bash(cp *)", "Write", "Read", "Glob", "Edit"]
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[website URL or local path]"

--- a/agent-skills/inbox/SKILL.md
+++ b/agent-skills/inbox/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run *), Bash(npx wrangler *), Bash(grep *), Write, Read, Edit, Glob, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__d1_database_create, mcp__cloudflare__d1_databases_list, mcp__cloudflare__d1_database_get, mcp__cloudflare__d1_database_query
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/indieweb/SKILL.md
+++ b/agent-skills/indieweb/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npm install *), Bash(npx wrangler *), Bash(openssl *), Bash(grep *), Bash(gh *), Bash(node *), Bash(mktemp *), Bash(printf *), Bash(rm *), Write, Read, Edit, Glob, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__d1_database_create, mcp__cloudflare__d1_databases_list, mcp__cloudflare__d1_database_get, mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_buckets_list
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/lemon-squeezy/SKILL.md
+++ b/agent-skills/lemon-squeezy/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/membership/SKILL.md
+++ b/agent-skills/membership/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(npx astro check), Bash(grep *), Bash(node *), Write, Read, Edit, Glob, mcp__cloudflare__kv_namespace_create, mcp__cloudflare__kv_namespace_get, mcp__cloudflare__kv_namespaces_list, mcp__cloudflare__accounts_list
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/menu/SKILL.md
+++ b/agent-skills/menu/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run dev), Bash(npm run build), Read, Write, Glob, Grep
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/new-page/SKILL.md
+++ b/agent-skills/new-page/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
   argument-hint: "[page name or purpose]"

--- a/agent-skills/newsletter/SKILL.md
+++ b/agent-skills/newsletter/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(curl *), Bash(grep *), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/og-images/SKILL.md
+++ b/agent-skills/og-images/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run ai-images), Bash(npm run ai-og), Bash(npx wrangler r2 *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, Read, Glob, Write
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/optimize-images/SKILL.md
+++ b/agent-skills/optimize-images/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run ai-optimize), Bash(npx wrangler r2 *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/paddle/SKILL.md
+++ b/agent-skills/paddle/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Edit, Glob, Bash(npm run build), Bash(npx astro check)
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/photography/SKILL.md
+++ b/agent-skills/photography/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Read, Glob, Write
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/podcast/SKILL.md
+++ b/agent-skills/podcast/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npm run dev), Bash(npx wrangler r2 *), Bash(wc -c *), Bash(stat *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, mcp__cloudflare__r2_bucket_delete, Read, Write, Edit, Glob, Grep
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/print/SKILL.md
+++ b/agent-skills/print/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob, Bash(npm run ai-qr)
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/pwa/SKILL.md
+++ b/agent-skills/pwa/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(node *), Write, Read, Glob, Edit
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/qr/SKILL.md
+++ b/agent-skills/qr/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run ai-qr), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/redirects/SKILL.md
+++ b/agent-skills/redirects/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Read, Write, Edit, Glob, Bash(grep *), Bash(find *), Bash(wc *), Bash(sort *), Bash(awk *), Bash(test *), Bash(ls *), Bash(cat *)
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[add | remove | list | validate | import | review]"

--- a/agent-skills/repurpose/SKILL.md
+++ b/agent-skills/repurpose/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/reputation/SKILL.md
+++ b/agent-skills/reputation/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(date *), Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/search/SKILL.md
+++ b/agent-skills/search/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm install *), Bash(npm run build), Bash(npx astro check), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/seasonal/SKILL.md
+++ b/agent-skills/seasonal/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(date *), Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/seo/SKILL.md
+++ b/agent-skills/seo/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npm run ai-seo*), Bash(npx astro check), Bash(grep *), Bash(find dist/ *), Bash(git log *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
   argument-hint: "[page /about | schema | sitemap | og-images]"

--- a/agent-skills/share/SKILL.md
+++ b/agent-skills/share/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Write, Read, Glob, Edit
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/shopify-buy-button/SKILL.md
+++ b/agent-skills/shopify-buy-button/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Edit, Glob, Bash(npm run build), Bash(npx astro check)
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/snipcart/SKILL.md
+++ b/agent-skills/snipcart/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Edit, Glob, Bash(npm run build), Bash(npx astro check)
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/social-media/SKILL.md
+++ b/agent-skills/social-media/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/start/SKILL.md
+++ b/agent-skills/start/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(zsh *), Bash(npm install), Bash(npm run *), Bash(gh *), Bash(git remote *), Bash(git push *), Bash(git branch *), Bash(git add *), Bash(git commit *), WebFetch, Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/stats/SKILL.md
+++ b/agent-skills/stats/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(curl *), Bash(grep *), Bash(git log *), Bash(cat perf-trend.json), Write, Edit, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/testimonials/SKILL.md
+++ b/agent-skills/testimonials/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/themes/SKILL.md
+++ b/agent-skills/themes/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: WebFetch, Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "model-only"
 ---

--- a/agent-skills/tracking/SKILL.md
+++ b/agent-skills/tracking/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(npm install *), Bash(npm run build), Bash(npx astro check), Bash(grep *), Write, Read, Edit, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/update/SKILL.md
+++ b/agent-skills/update/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Designed for Claude Code / compatible agents operating inside an
 allowed-tools: Bash(zsh *), Bash(npm run *), Bash(npm install *), Bash(npm update *), Bash(npm outdated *), Bash(npm audit *), Bash(npx astro check), Bash(git add *), Bash(git commit *), Bash(git diff *), Write, Read, Glob
 metadata:
   author: "David W. Keith"
-  version: "1.7.0"
+  version: "1.8.0"
   source: "https://github.com/Anglesite/anglesite"
   invocation: "user-facing"
 ---

--- a/agent-skills/update/references/package.json
+++ b/agent-skills/update/references/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anglesite",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "description": "AI webmaster that scaffolds, designs, and deploys Astro + Keystatic sites on Cloudflare Workers.",
   "scripts": {

--- a/agent-skills/update/references/template/package.json
+++ b/agent-skills/update/references/template/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dwk/anglesite",
   "type": "module",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "scripts": {
     "dev": "astro dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anglesite",
-  "version": "1.5.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anglesite",
-      "version": "1.5.0",
+      "version": "1.8.0",
       "license": "ISC",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",


### PR DESCRIPTION
## Summary

- Re-commits the `npm run build:agent-skills` output (version strings only, `1.7.0`/`1.5.0` → `1.8.0`) and syncs the `package-lock.json` root-version entries the v1.8.0 release bump left behind.
- Main's CI has been red since the `chore: release v1.8.0` push (2026-07-28): `tests/build-agent-skills.test.ts` fails 56 SKILL.md drift assertions and the `agent-skills-export` staleness gate trips. This unblocks CI for every open PR, including #432.

## Paired PR check

- [x] This change is **self-contained** to the plugin (skills / hooks / template / docs / MCP server with no consumer-visible contract change).
- [ ] This change **needs a paired PR** in [`Anglesite/Anglesite-app`](https://github.com/Anglesite/Anglesite-app).

## Test plan

- [x] `npx vitest run tests/build-agent-skills.test.ts` — 87/87 pass (was 56 failing)
- [x] `npm run registry` produces no diff (registry was already in sync)
- [x] Diff reviewed: version-string-only changes across the 56 generated SKILL.md files, `agent-skills/README.md`, the bundled template `package.json`, and the lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)