### PR TITLE
feat: page block-model service + invertible WYSIWYG ops protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,8 @@ Two levels of agent instructions exist — do not confuse them:
 | Tool | Purpose |
 |---|---|
 | `add_annotation` / `list_annotations` / `resolve_annotation` | Pin, list, and resolve feedback notes anchored to page elements |
-| `apply_edit` | Patch source from an `ElementInfo` selector. Closed op enum: `replace-text`, `replace-attr`, `replace-image-src`, `edit-style`, `apply-instruction`. Supports `dry_run` (returns `edit-preview`); responses are `edit-applied` / `edit-failed` (`server/apply-edit-schema.mjs`, `apply-edit-dispatcher.mjs`) |
+| `apply_edit` | Patch source from an `ElementInfo` selector or a `component` payload. Closed op enum: `replace-text`, `replace-attr`, `replace-image-src`, `edit-style`, `apply-instruction`, the Component Editor ops, and the WYSIWYG block-editor ops `insertBlock`/`moveBlock`/`deleteBlock`/`setProp`/`editText`/`setDesignToken` — every block-editor op returns a computed `inverse` for host-side undo. Supports `dry_run`; responses are `edit-applied` / `edit-failed` (`server/apply-edit-schema.mjs`, `apply-edit-dispatcher.mjs`) |
+| `get_page_model` | Parse a page `.astro` file into a block-annotated template tree — `get_component_model`'s shape plus a `block` descriptor on nodes that resolve against `blocks.manifest.json` |
 | `undo_edit` | Revert the last applied edit via the `anglesite/edits` history branch |
 | `list_content` | Enumerate pages/posts |
 | `create_page` / `create_post` | Scaffold new content with frontmatter |
@@ -41,6 +42,8 @@ Two levels of agent instructions exist — do not confuse them:
 **Runtime.** The app vendors a pinned Node (`Anglesite-app/scripts/node-version.txt`) to execute `server/*.mjs`; the CI test matrix should track it so the shipped interpreter is exercised here.
 
 **Typed content.** `server/content-types.mjs` is a mirror of the app's `ContentTypeRegistry.swift` — the Swift file is the source of truth. Change it there first, then mirror the change here.
+
+**Block manifest.** `blocks.manifest.json` (project root) registers Astro components and custom elements that the WYSIWYG block editor can insert, move, and edit (via `insertBlock`, `moveBlock`, `deleteBlock`, `setProp`, `editText`, `setDesignToken` ops in `apply_edit`). The file is optional — absence means no registered blocks. See `server/block-manifest-schema.mjs` for the source of truth on structure, validation, and prop-editor kinds.
 
 ## Skills reference
 

--- a/docs/superpowers/plans/2026-08-10-page-block-model-ops-protocol.md
+++ b/docs/superpowers/plans/2026-08-10-page-block-model-ops-protocol.md
@@ -1,0 +1,1909 @@
+# Page Block-Model Service + Ops Protocol Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the sidecar a page-level block-model read service (`get_page_model`) and a small
+invertible semantic-ops vocabulary (`insertBlock`, `moveBlock`, `deleteBlock`, `setProp`,
+`editText`, `setDesignToken`) that the WYSIWYG block editor (Anglesite-app #1221) will drive.
+
+**Architecture:** Extends the Component Editor's proven read/write split rather than inventing a
+parallel one. The read path (`get_page_model`) is `get_component_model`'s exact tree shape
+(`component-node-index.mjs`'s shared depth-first walk) plus one enrichment pass that annotates
+`kind: "component"` nodes against a new theme block manifest. The write path reuses
+`apply_edit`'s existing `insert-node`/`move-node`/`remove-node`/`set-attr` resolvers verbatim —
+those already operate on any `.astro` template, page or component — registering
+`insertBlock`/`moveBlock`/`deleteBlock`/`setProp` as protocol-facing names for the same dispatch,
+and adding the one capability that doesn't exist yet anywhere in the codebase: **every structural
+op now computes and returns its own inverse**. `editText` (rich-text runs) and `setDesignToken`
+(global CSS custom properties) are genuinely new resolvers modeled on the existing
+`component-style-edit.mjs`/`style-edit.mjs` splice-and-write conventions.
+
+**Tech Stack:** Node.js (`server/*.mjs`, plain ESM, untyped), `@astrojs/compiler` (Astro template
+AST), `css-tree` (CSS parsing), `zod` (MCP tool input schemas), Vitest (`tests/*.test.ts` +
+`test/*.test.js`).
+
+## Global Constraints
+
+- **MCP schema change → paired PR.** Per `Anglesite-app/CLAUDE.md` ▸ Two-repo coordination, this
+  entire plan ships as a sidecar PR first; the Anglesite-app consumer PR follows once this one is
+  tagged and released. Do not start the app-side PR from this plan.
+- **Never trust `node.span`/`position.offset` off a fresh `@astrojs/compiler` parse** for
+  element/component/slot/fragment/expression nodes — always re-derive via `resolveAllSpans`
+  (lexical relocation) before splicing. This is existing, hard-won discipline in
+  `component-structure-edit.mjs`; every new resolver in this plan follows it.
+- **Content-hash staleness guard on every write.** Every mutating op carries `baseVersion`; every
+  resolver re-reads the file fresh and refuses with reason `"stale"` on mismatch
+  (`fileVersion()` from `server/file-version.mjs`, unchanged).
+- **No AST re-print — string-splice patches only**, matching every existing resolver
+  (`{file, range, replacement}`). Do not introduce a re-serializing formatter.
+- **No new runtime dependencies beyond what's already in the root `package.json`**
+  (`@astrojs/compiler`, `css-tree`, `zod` transitively via `@modelcontextprotocol/sdk`) — the spec
+  explicitly rejected a markdown/mdast parser for this slice (§4: "Content pages stay
+  markdown/MDX... `editText` ops write markdown / semantic HTML runs"); `editText` in this plan
+  is scoped to `.astro` template rich-text nodes only (see Task 6's Scope Note) precisely to avoid
+  needing one. If a future slice needs Markdoc body editing, that is new dependency-approval work,
+  not a silent extension of this plan.
+- **`server/` stays flat** — no subdirectories. New files land directly in `server/` following the
+  existing `component-*`/`page-*` naming convention.
+- **Tests:** unit tests in `tests/*.test.ts` (Vitest, TypeScript) mirroring
+  `tests/component-model.test.ts`/`tests/component-structure-edit.test.ts`; end-to-end stdio round
+  trips added as new `it()` blocks in `tests/mcp-server.test.ts`. Run `npm test` (`vitest run`)
+  after every task.
+
+---
+
+## File Structure
+
+```
+server/
+├── component-node-index.mjs      MODIFY — export toPublicNode() (moved from component-model.mjs)
+├── component-model.mjs           MODIFY — import toPublicNode instead of a local copy
+├── component-structure-edit.mjs  MODIFY — inverse computation, `raw` insert kind, alias dispatch
+├── block-manifest-schema.mjs     NEW — zod schema for the theme's blocks.manifest.json
+├── block-manifest.mjs            NEW — loadBlockManifest(), indexManifestByPath/Name()
+├── page-model.mjs                NEW — buildPageModel() — get_page_model backend
+├── apply-edit-schema.mjs         MODIFY — new op names, `raw`/`manifestBlock` fields, editText/
+│                                          setDesignToken payload shapes
+├── apply-edit-dispatcher.mjs     MODIFY — stamp inverse.component.baseVersion post-write
+├── patcher.mjs                   MODIFY — route new op names to their resolvers
+├── text-run-edit.mjs             NEW — editText resolver (rich-text runs → HTML/inline markup)
+├── css-rule-index.mjs            MODIFY — factor out a baseOffset-free declaration walk
+├── design-token-edit.mjs         NEW — setDesignToken resolver (global.css :root custom props)
+└── index-tools.mjs               MODIFY — register get_page_model
+
+tests/
+├── page-model.test.ts            NEW
+├── component-structure-edit.test.ts  MODIFY — inverse assertions on existing ops
+├── text-run-edit.test.ts         NEW
+├── design-token-edit.test.ts     NEW
+├── page-ops-roundtrip.test.ts    NEW — golden op → source diff → re-parsed model round trips
+└── mcp-server.test.ts            MODIFY — get_page_model + new ops over stdio
+```
+
+---
+
+## Task 1: Share `toPublicNode` between the component and page models
+
+**Files:**
+- Modify: `server/component-node-index.mjs`
+- Modify: `server/component-model.mjs:104-117` (removes the private `toPublicNode`)
+- Test: `tests/component-model.test.ts` (existing suite — must still pass unchanged)
+
+**Interfaces:**
+- Produces: `toPublicNode(byId: Map<string, IndexedNode>, id: string): TemplateNode` — exported
+  from `component-node-index.mjs`, consumed by both `component-model.mjs` (Task unchanged) and
+  `page-model.mjs` (Task 3).
+
+- [ ] **Step 1: Move `toPublicNode` into `component-node-index.mjs` and export it**
+
+Add to the end of `server/component-node-index.mjs`:
+
+```js
+/** Projects one indexed node (and its subtree) into the public TemplateNode shape returned by
+ *  get_component_model / get_page_model. Shared so both read paths serialize identically. */
+export function toPublicNode(byId, id) {
+  const r = byId.get(id);
+  const node = {
+    id: r.id,
+    kind: r.kind,
+    tag: r.tag,
+    attrs: r.attrs.map(({ name, value }) => ({ name, value })),
+    span: r.span,
+    loc: r.loc,
+    children: r.childIds.map((cid) => toPublicNode(byId, cid)),
+  };
+  if (r.text !== undefined) node.text = r.text;
+  return node;
+}
+```
+
+- [ ] **Step 2: Delete the private copy in `component-model.mjs` and import the shared one**
+
+```js
+// server/component-model.mjs — top of file
+import { buildTemplateNodeIndex, buildLineStarts, offsetFromLineColumn, toPublicNode } from "./component-node-index.mjs";
+```
+
+Delete the `function toPublicNode(byId, id) { ... }` block (lines 104-117 in the current file).
+
+- [ ] **Step 3: Run the existing suite to confirm the refactor is behavior-preserving**
+
+Run: `npx vitest run tests/component-model.test.ts`
+Expected: PASS, identical to before the move (no assertions change — this step is pure
+relocation).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/component-node-index.mjs server/component-model.mjs
+git commit -m "refactor(server): share toPublicNode for the upcoming page-model read path"
+```
+
+---
+
+## Task 2: Theme block manifest — schema and loader
+
+**Files:**
+- Create: `server/block-manifest-schema.mjs`
+- Create: `server/block-manifest.mjs`
+- Test: `tests/block-manifest.test.ts`
+
+**Interfaces:**
+- Produces: `loadBlockManifest(projectRoot: string): BlockManifest`,
+  `indexManifestByPath(manifest): Map<string, BlockManifestModule>`,
+  `indexManifestByName(manifest): Map<string, BlockManifestModule>`, `BlockManifestError` (reasons
+  `"parse-failed"` | `"invalid-manifest"`). Consumed by `page-model.mjs` (Task 3) and
+  `component-structure-edit.mjs`'s manifest-aware `insertBlock` (Task 4).
+- Design decision (record here, not self-evident from the spec): the theme manifest is a
+  **project-root file `blocks.manifest.json`**, not a per-component sidecar file or a generated
+  artifact — CEM itself is normally one `custom-elements.json` per package, and a single file is
+  what a theme author (or, later, an app-side "regenerate manifest" action) edits directly. A
+  theme with none — the case for every existing scaffolded site today — is valid: `get_page_model`
+  degrades to "no blocks recognized, everything is opaque markup," never a hard failure.
+
+- [ ] **Step 1: Write the failing schema test**
+
+Create `tests/block-manifest.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { blockManifestSchema } from "../server/block-manifest-schema.mjs";
+
+describe("blockManifestSchema", () => {
+  it("accepts a minimal valid manifest", () => {
+    const result = blockManifestSchema.safeParse({
+      schemaVersion: "anglesite-block-manifest/1",
+      modules: [
+        {
+          path: "src/components/Hcard.astro",
+          export: "Hcard",
+          kind: "astro",
+          name: "Business Card",
+          description: "Name, photo, and contact details as an h-card.",
+          icon: null,
+          propEditors: [{ prop: "name", editor: "text" }],
+          slots: [],
+          placement: { allowedParents: null },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unknown propEditor kind", () => {
+    const result = blockManifestSchema.safeParse({
+      schemaVersion: "anglesite-block-manifest/1",
+      modules: [
+        {
+          path: "src/components/Hcard.astro",
+          export: "Hcard",
+          name: "Business Card",
+          propEditors: [{ prop: "name", editor: "not-a-real-editor" }],
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails (module doesn't exist yet)**
+
+Run: `npx vitest run tests/block-manifest.test.ts`
+Expected: FAIL with "Cannot find module '../server/block-manifest-schema.mjs'"
+
+- [ ] **Step 3: Write `server/block-manifest-schema.mjs`**
+
+```js
+import { z } from "zod";
+
+export const propEditorKinds = ["text", "richtext", "image", "boolean", "number", "select", "color", "array"];
+
+const blockManifestModuleSchema = z.object({
+  path: z.string().describe("Project-relative component path, e.g. src/components/Hcard.astro"),
+  export: z.string().describe("Default export name as imported, e.g. Hcard"),
+  kind: z.enum(["astro", "custom-element"]).default("astro"),
+  name: z.string().describe("Owner-facing block name shown in the Insert menu/palette"),
+  description: z.string().default(""),
+  icon: z.string().nullable().default(null),
+  propEditors: z
+    .array(
+      z.object({
+        prop: z.string(),
+        editor: z.enum(propEditorKinds),
+        options: z.array(z.string()).optional(),
+      }),
+    )
+    .default([]),
+  slots: z.array(z.string()).default([]),
+  placement: z.object({ allowedParents: z.array(z.string()).nullable().default(null) }).default({ allowedParents: null }),
+});
+
+export const blockManifestSchema = z.object({
+  schemaVersion: z.literal("anglesite-block-manifest/1"),
+  readme: z.string().optional(),
+  modules: z.array(blockManifestModuleSchema),
+});
+```
+
+- [ ] **Step 4: Run it again to verify the schema tests pass**
+
+Run: `npx vitest run tests/block-manifest.test.ts`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Write the failing loader test**
+
+Append to `tests/block-manifest.test.ts`:
+
+```ts
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadBlockManifest, indexManifestByPath, indexManifestByName, BlockManifestError } from "../server/block-manifest.mjs";
+
+describe("loadBlockManifest", () => {
+  it("returns an empty manifest when blocks.manifest.json is absent", () => {
+    const dir = mkdtempSync(join(tmpdir(), "anglesite-manifest-"));
+    try {
+      const manifest = loadBlockManifest(dir);
+      expect(manifest.modules).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads, validates, and indexes a real manifest file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "anglesite-manifest-"));
+    try {
+      writeFileSync(
+        join(dir, "blocks.manifest.json"),
+        JSON.stringify({
+          schemaVersion: "anglesite-block-manifest/1",
+          modules: [{ path: "src/components/Hcard.astro", export: "Hcard", name: "Business Card" }],
+        }),
+      );
+      const manifest = loadBlockManifest(dir);
+      expect(indexManifestByPath(manifest).get("src/components/Hcard.astro")?.name).toBe("Business Card");
+      expect(indexManifestByName(manifest).get("Business Card")?.path).toBe("src/components/Hcard.astro");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws BlockManifestError with reason invalid-manifest on schema violation", () => {
+    const dir = mkdtempSync(join(tmpdir(), "anglesite-manifest-"));
+    try {
+      writeFileSync(join(dir, "blocks.manifest.json"), JSON.stringify({ schemaVersion: "wrong", modules: [] }));
+      expect(() => loadBlockManifest(dir)).toThrow(BlockManifestError);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `npx vitest run tests/block-manifest.test.ts`
+Expected: FAIL with "Cannot find module '../server/block-manifest.mjs'"
+
+- [ ] **Step 7: Write `server/block-manifest.mjs`**
+
+```js
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { blockManifestSchema } from "./block-manifest-schema.mjs";
+
+export class BlockManifestError extends Error {
+  constructor(reason, message) {
+    super(message);
+    this.reason = reason;
+  }
+}
+
+const MANIFEST_FILENAME = "blocks.manifest.json";
+
+/** Loads and validates the theme's block manifest from the project root. A missing file is
+ *  valid (empty manifest) — every component in the page tree simply stays unregistered rather
+ *  than failing get_page_model. A present-but-invalid file throws. */
+export function loadBlockManifest(projectRoot) {
+  const absPath = join(projectRoot, MANIFEST_FILENAME);
+  if (!existsSync(absPath)) return { schemaVersion: "anglesite-block-manifest/1", modules: [] };
+  let raw;
+  try {
+    raw = JSON.parse(readFileSync(absPath, "utf-8"));
+  } catch (err) {
+    throw new BlockManifestError("parse-failed", `parse ${MANIFEST_FILENAME}: ${err.message}`);
+  }
+  const parsed = blockManifestSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new BlockManifestError(
+      "invalid-manifest",
+      parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "),
+    );
+  }
+  return parsed.data;
+}
+
+export function indexManifestByPath(manifest) {
+  return new Map(manifest.modules.map((m) => [m.path, m]));
+}
+
+export function indexManifestByName(manifest) {
+  return new Map(manifest.modules.map((m) => [m.name, m]));
+}
+```
+
+- [ ] **Step 8: Run the full file to verify all pass**
+
+Run: `npx vitest run tests/block-manifest.test.ts`
+Expected: PASS (5 tests)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add server/block-manifest-schema.mjs server/block-manifest.mjs tests/block-manifest.test.ts
+git commit -m "feat(server): add theme block-manifest schema and loader"
+```
+
+---
+
+## Task 3: `get_page_model` — the page-level block-model read service
+
+**Files:**
+- Create: `server/page-model.mjs`
+- Modify: `server/index-tools.mjs` (register the tool, alongside `get_component_model` at
+  line ~148)
+- Test: `tests/page-model.test.ts`
+- Test: `tests/mcp-server.test.ts` (append one `it()` for the stdio round trip)
+
+**Interfaces:**
+- Consumes: `buildTemplateNodeIndex`, `toPublicNode` (Task 1) from `component-node-index.mjs`;
+  `parseImports` from `frontmatter-imports.mjs`; `loadBlockManifest`, `indexManifestByPath`
+  (Task 2) from `block-manifest.mjs`; `fileVersion` from `file-version.mjs`.
+- Produces: `buildPageModel(projectRoot: string, relPath: string): Promise<PageModel>`,
+  `PageModelError` (reasons `"invalid-input"` | `"read-failed"` | `"parse-failed"`), where
+  `PageModel = { version: string, path: string, tree: PageNode }` and `PageNode` is a
+  `TemplateNode` (Task 1's shape) plus one added field: `block: BlockDescriptor | null`.
+  `BlockDescriptor = { manifestPath: string, name: string, description: string, icon: string |
+  null, propEditors: PropEditor[], slots: string[] }`. This is what Task 4's manifest-aware
+  `insertBlock` and the app-side editor both consume.
+
+- [ ] **Step 1: Write the failing test — block annotation on a manifest-registered component**
+
+Create `tests/page-model.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildPageModel, PageModelError } from "../server/page-model.mjs";
+
+const HCARD = `---\ninterface Props { name: string; }\nconst { name } = Astro.props;\n---\n<div class="h-card">{name}</div>\n`;
+
+const MANIFEST = JSON.stringify({
+  schemaVersion: "anglesite-block-manifest/1",
+  modules: [
+    { path: "src/components/Hcard.astro", export: "Hcard", name: "Business Card", description: "An h-card.", propEditors: [{ prop: "name", editor: "text" }] },
+  ],
+});
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "anglesite-page-model-"));
+  mkdirSync(join(dir, "src", "pages"), { recursive: true });
+  mkdirSync(join(dir, "src", "components"), { recursive: true });
+  writeFileSync(join(dir, "blocks.manifest.json"), MANIFEST);
+  writeFileSync(join(dir, "src", "components", "Hcard.astro"), HCARD);
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("buildPageModel", () => {
+  it("annotates a manifest-registered component instance with its block descriptor", async () => {
+    writeFileSync(
+      join(dir, "src", "pages", "index.astro"),
+      `---\nimport Hcard from "../components/Hcard.astro";\n---\n<main><Hcard name="Ana" /></main>\n`,
+    );
+    const model = await buildPageModel(dir, "src/pages/index.astro");
+    expect(model.path).toBe("src/pages/index.astro");
+    expect(model.version).toMatch(/^sha256:/);
+    const main = model.tree.children.find((n) => n.tag === "main")!;
+    const hcard = main.children.find((n) => n.tag === "Hcard")!;
+    expect(hcard.block).toEqual({
+      manifestPath: "src/components/Hcard.astro",
+      name: "Business Card",
+      description: "An h-card.",
+      icon: null,
+      propEditors: [{ prop: "name", editor: "text" }],
+      slots: [],
+    });
+  });
+
+  it("leaves an unregistered component's block field null", async () => {
+    writeFileSync(
+      join(dir, "src", "pages", "index.astro"),
+      `---\n---\n<main><Untracked /></main>\n`,
+    );
+    const model = await buildPageModel(dir, "src/pages/index.astro");
+    const untracked = model.tree.children.find((n) => n.tag === "main")!.children[0];
+    expect(untracked.block).toBeNull();
+  });
+
+  it("throws PageModelError(invalid-input) for a non-.astro path", async () => {
+    await expect(buildPageModel(dir, "src/pages/index.md")).rejects.toBeInstanceOf(PageModelError);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run tests/page-model.test.ts`
+Expected: FAIL with "Cannot find module '../server/page-model.mjs'"
+
+- [ ] **Step 3: Write `server/page-model.mjs`**
+
+```js
+import { readFileSync } from "node:fs";
+import { join, normalize, dirname, sep } from "node:path";
+import { parse } from "@astrojs/compiler";
+import { fileVersion } from "./file-version.mjs";
+import { buildTemplateNodeIndex, toPublicNode } from "./component-node-index.mjs";
+import { parseImports } from "./frontmatter-imports.mjs";
+import { loadBlockManifest, indexManifestByPath } from "./block-manifest.mjs";
+
+export class PageModelError extends Error {
+  constructor(reason, message) {
+    super(message);
+    this.reason = reason;
+  }
+}
+
+function validPagePath(relPath) {
+  return (
+    typeof relPath === "string" &&
+    relPath.endsWith(".astro") &&
+    !normalize(relPath).startsWith("..") &&
+    !relPath.startsWith("/")
+  );
+}
+
+/** Resolves each locally-imported tag name to a project-relative path via the page's own
+ *  frontmatter default imports — the join key against the block manifest's `path` field.
+ *  Only relative specifiers are resolved; a package import is never a theme block. */
+function resolveComponentPaths(relPath, frontmatterSource) {
+  const pageDir = dirname(relPath);
+  const byLocalName = new Map();
+  for (const { localName, specifier } of parseImports(frontmatterSource ?? "")) {
+    if (!specifier.startsWith(".")) continue;
+    const resolved = normalize(join(pageDir, specifier)).split(sep).join("/");
+    byLocalName.set(localName, resolved);
+  }
+  return byLocalName;
+}
+
+function annotateBlocks(node, byLocalName, manifestByPath) {
+  let block = null;
+  if (node.kind === "component" && node.tag) {
+    const path = byLocalName.get(node.tag);
+    const entry = path ? manifestByPath.get(path) : undefined;
+    if (entry) {
+      block = {
+        manifestPath: entry.path,
+        name: entry.name,
+        description: entry.description,
+        icon: entry.icon,
+        propEditors: entry.propEditors,
+        slots: entry.slots,
+      };
+    }
+  }
+  return { ...node, block, children: node.children.map((c) => annotateBlocks(c, byLocalName, manifestByPath)) };
+}
+
+export async function buildPageModel(projectRoot, relPath) {
+  if (!validPagePath(relPath)) {
+    throw new PageModelError("invalid-input", `not a project-relative .astro path: ${relPath}`);
+  }
+  const absPath = join(projectRoot, relPath);
+  let source;
+  try {
+    source = readFileSync(absPath, "utf-8");
+  } catch (err) {
+    throw new PageModelError("read-failed", `read ${relPath}: ${err.message}`);
+  }
+  let ast;
+  try {
+    ({ ast } = await parse(source, { position: true }));
+  } catch (err) {
+    throw new PageModelError("parse-failed", `parse ${relPath}: ${err.message}`);
+  }
+  const { byId, rootId } = buildTemplateNodeIndex(ast, source);
+  const tree = toPublicNode(byId, rootId);
+  const fmNode = (ast.children ?? []).find((n) => n.type === "frontmatter");
+  const byLocalName = resolveComponentPaths(relPath, fmNode?.value ?? "");
+  const manifestByPath = indexManifestByPath(loadBlockManifest(projectRoot));
+  return { version: fileVersion(source), path: relPath, tree: annotateBlocks(tree, byLocalName, manifestByPath) };
+}
+```
+
+- [ ] **Step 4: Run to verify the unit tests pass**
+
+Run: `npx vitest run tests/page-model.test.ts`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Register the MCP tool**
+
+In `server/index-tools.mjs`, add the import near the top (alongside the existing
+`buildComponentModel`/`ComponentModelError` import):
+
+```js
+import { buildPageModel, PageModelError } from "./page-model.mjs";
+```
+
+Add the tool registration directly after the existing `get_component_model` registration
+(~line 178):
+
+```js
+server.tool(
+  "get_page_model",
+  "Parse a page .astro file into a block-annotated template tree: the same node shape get_component_model returns, with each component instance that resolves to a theme block-manifest entry carrying owner-facing name/description/icon/propEditors/slots. Used by the WYSIWYG block editor.",
+  {
+    path: z.string().describe("Page path relative to the project root, e.g. src/pages/index.astro"),
+  },
+  async ({ path }) => {
+    try {
+      const model = await buildPageModel(projectRoot, path);
+      return { content: [{ type: "text", text: JSON.stringify(model) }] };
+    } catch (err) {
+      const reason = err instanceof PageModelError ? err.reason : "internal-error";
+      return {
+        content: [
+          { type: "text", text: JSON.stringify({ type: "anglesite:page-model-failed", reason, detail: String(err?.message ?? err) }) },
+        ],
+        isError: true,
+      };
+    }
+  },
+);
+```
+
+- [ ] **Step 6: Write the failing stdio round-trip test**
+
+Append to `tests/mcp-server.test.ts`, near the existing `it("get_component_model returns a
+structured model over stdio", …)` block (~line 505), reusing the file's existing `startServer`/
+`initialize`/`callTool` helpers:
+
+```ts
+it("get_page_model returns a block-annotated tree over stdio", async () => {
+  mkdirSync(join(tmpDir, "src", "pages"), { recursive: true });
+  mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+  writeFileSync(
+    join(tmpDir, "blocks.manifest.json"),
+    JSON.stringify({ schemaVersion: "anglesite-block-manifest/1", modules: [{ path: "src/components/Hcard.astro", export: "Hcard", name: "Business Card" }] }),
+  );
+  writeFileSync(join(tmpDir, "src", "components", "Hcard.astro"), `---\n---\n<div>card</div>\n`);
+  writeFileSync(
+    join(tmpDir, "src", "pages", "index.astro"),
+    `---\nimport Hcard from "../components/Hcard.astro";\n---\n<Hcard />\n`,
+  );
+  const result = await callTool(proc, "get_page_model", { path: "src/pages/index.astro" });
+  const model = JSON.parse(result.content[0].text);
+  expect(model.tree.children[0].block.name).toBe("Business Card");
+});
+```
+
+- [ ] **Step 7: Run the full suite to verify everything passes**
+
+Run: `npm test`
+Expected: PASS, no regressions in any existing suite.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/page-model.mjs server/index-tools.mjs tests/page-model.test.ts tests/mcp-server.test.ts
+git commit -m "feat(server): add get_page_model block-annotated page tree service"
+```
+
+---
+
+## Task 4: Invertible structural ops — `insertBlock`/`moveBlock`/`deleteBlock`/`setProp`
+
+**Files:**
+- Modify: `server/apply-edit-schema.mjs` (new op names, `raw` insert kind, `manifestBlock` field)
+- Modify: `server/component-structure-edit.mjs` (inverse computation, alias dispatch, `raw` kind)
+- Modify: `server/patcher.mjs` (route the new op names)
+- Test: `tests/component-structure-edit.test.ts` (append inverse assertions)
+
+**Interfaces:**
+- Consumes: `resolveAllSpans`, `SpanResolutionError`, `collectComponentTags`, `escapeAttr`
+  (already exported from `component-structure-edit.mjs`); `indexManifestByName` (Task 2) for
+  `insertBlock`'s `manifestBlock` resolution.
+- Produces: every `apply*` resolver in `component-structure-edit.mjs` now returns
+  `{ file, range, replacement, inverse }` on success, where `inverse` is an **unstamped** op
+  object `{ op: string, component: object }` (no `baseVersion` yet — Task 5 stamps it after the
+  write completes, since the inverse targets the *post-edit* file version). `editOps` gains four
+  new entries: `"insertBlock"`, `"moveBlock"`, `"deleteBlock"`, `"setProp"` — each dispatched
+  identically to `insert-node`/`move-node`/`remove-node`/`set-attr` (a canonical-name lookup, not
+  a duplicated switch arm). `componentEditSchema.node.kind` gains `"raw"` (a `markup` string
+  spliced verbatim, no import handling) — this is what lets `deleteBlock`'s inverse reconstruct
+  an exact removed subtree without a second typed-insert code path.
+
+- [ ] **Step 1: Write the failing inverse test for `setProp` (the simplest case)**
+
+Append to `tests/component-structure-edit.test.ts`:
+
+```ts
+it("setProp's inverse restores the previous attribute value", async () => {
+  const source = `---\n---\n<div id="a" title="old">x</div>\n`;
+  const { byId, rootId } = /* existing test helper that parses `source` into byId/rootId */ await indexSource(source);
+  const divId = [...byId.values()].find((n) => n.tag === "div")!.id;
+  const result = await resolveComponentStructure(projectRoot, {
+    op: "setProp",
+    component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), nodeId: divId, name: "title", value: "new" },
+  });
+  expect(result.inverse).toEqual({
+    op: "setProp",
+    component: { path: "src/pages/index.astro", nodeId: divId, name: "title", value: "old" },
+  });
+});
+
+it("setProp's inverse removes an attribute that didn't exist before", async () => {
+  const source = `---\n---\n<div id="a">x</div>\n`;
+  const { byId } = await indexSource(source);
+  const divId = [...byId.values()].find((n) => n.tag === "div")!.id;
+  const result = await resolveComponentStructure(projectRoot, {
+    op: "setProp",
+    component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), nodeId: divId, name: "title", value: "new" },
+  });
+  expect(result.inverse.component.value).toBeNull();
+});
+```
+
+(`indexSource` is a small helper to add at the top of the test file — writes `source` to a temp
+`.astro` file and returns `buildTemplateNodeIndex` over it; follow the existing file's
+`beforeEach`/`afterEach` tmpdir pattern for `projectRoot`.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/component-structure-edit.test.ts -t "inverse"`
+Expected: FAIL — `result.inverse` is `undefined` (the field doesn't exist yet).
+
+- [ ] **Step 3: Add `raw` to the node-spec union and `manifestBlock` to `componentEditSchema`**
+
+In `server/apply-edit-schema.mjs`, extend `editOps`:
+
+```js
+export const editOps = [
+  "replace-text",
+  "replace-attr",
+  "replace-image-src",
+  "edit-style",
+  "apply-instruction",
+  "set-style-property",
+  "remove-style-property",
+  "add-style-rule",
+  "set-rule-selector",
+  "insert-node",
+  "move-node",
+  "remove-node",
+  "set-attr",
+  "insertBlock",
+  "moveBlock",
+  "deleteBlock",
+  "setProp",
+  "editText",
+  "setDesignToken",
+  "set-props-interface",
+  "set-script-zone",
+  "extract-component",
+];
+
+/** insertBlock/moveBlock/deleteBlock/setProp are protocol-facing aliases for the identical
+ *  insert-node/move-node/remove-node/set-attr dispatch (see COMPONENT_STRUCTURE_OPS below) —
+ *  the WYSIWYG ops-protocol vocabulary (spec 2026-08-03-modern-wysiwyg-editor-design.md §3.2)
+ *  targeting the exact same span-resolution machinery, now with a computed inverse attached. */
+export const COMPONENT_STRUCTURE_OPS = new Set([
+  "insert-node", "move-node", "remove-node", "set-attr",
+  "insertBlock", "moveBlock", "deleteBlock", "setProp",
+]);
+```
+
+Add `manifestBlock` and extend `node.kind` in `componentEditSchema`:
+
+```js
+  node: z
+    .object({
+      kind: z.enum(["element", "component", "slot", "raw"]),
+      tag: z.string().optional().describe("HTML tag name (element) or component name (component); omitted for slot/raw"),
+      componentPath: z.string().optional().describe("Project-relative .astro path to import, required when kind=component"),
+      slotName: z.string().optional().describe("Named slot, for kind=slot; omitted means the default slot"),
+      markup: z.string().optional().describe("Verbatim source markup to splice in as-is, required when kind=raw — used by deleteBlock's computed inverse to reconstruct an exact removed subtree"),
+    })
+    .optional()
+    .describe("New node spec for insert-node/insertBlock"),
+  manifestBlock: z
+    .string()
+    .optional()
+    .describe("Owner-facing block-manifest name for insertBlock (e.g. \"Business Card\") — resolved server-side to {tag, componentPath} via blocks.manifest.json instead of the caller supplying them directly. Mutually exclusive with node.tag/node.componentPath."),
+```
+
+Add `editText` and `setDesignToken` payload fields (used by Tasks 6-7; adding now keeps the enum
+and its payload shape changes in one place):
+
+```js
+  textNodeId: z.string().optional().describe("Target node id for editText — must be an element/component node (get_page_model's block-annotated tree)"),
+  runs: z
+    .array(z.object({ text: z.string(), marks: z.array(z.enum(["strong", "em", "code"])).default([]), href: z.string().optional() }))
+    .optional()
+    .describe("Replacement rich-text runs for editText — see text-run-edit.mjs"),
+  token: z.string().optional().describe("CSS custom-property name for setDesignToken, e.g. --color-primary (no --var()/calc() wrapping)"),
+  tokenValue: z.string().optional().describe("New value for setDesignToken"),
+```
+
+- [ ] **Step 4: Compute and attach `inverse` in `applySetAttr`**
+
+In `server/component-structure-edit.mjs`, modify `applySetAttr` (all three return branches):
+
+```js
+function applySetAttr(file, source, byId, component) {
+  const { nodeId, name, value } = component;
+  if (typeof nodeId !== "string" || typeof name !== "string") {
+    return refuse("invalid-input", "set-attr requires component.nodeId and component.name");
+  }
+  const node = byId.get(nodeId);
+  if (!node || node.span[0] == null || node.span[1] == null) {
+    return refuse("no-match", "no node found at the given id — the file may have changed");
+  }
+  if (node.kind !== "element" && node.kind !== "component" && node.kind !== "slot") {
+    return refuse("invalid-input", `set-attr requires a tag-shaped node (element/component/slot), got kind=${node.kind}`);
+  }
+  const existing = node.attrs.find((a) => a.name === name);
+  const inverse = { op: "setProp", component: { path: file, nodeId, name, value: existing ? existing.value : null } };
+
+  if (value === null || value === undefined) {
+    if (!existing) return refuse("no-match", `node has no attribute "${name}" to remove`);
+    let start = existing.span[0];
+    while (start > 0 && (source[start - 1] === " " || source[start - 1] === "\t")) start--;
+    if (start > 0 && source[start - 1] === "\n") start--;
+    return { file, range: { start, end: existing.span[1] }, replacement: "", inverse };
+  }
+
+  if (existing) {
+    return { file, range: { start: existing.span[0], end: existing.span[1] }, replacement: `${name}="${escapeAttr(value)}"`, inverse };
+  }
+  const lastAttr = node.attrs[node.attrs.length - 1];
+  const insertAt = lastAttr ? lastAttr.span[1] : node.span[0] + 1 + (node.tag?.length ?? 0);
+  return { file, range: { start: insertAt, end: insertAt }, replacement: ` ${name}="${escapeAttr(value)}"`, inverse };
+}
+```
+
+- [ ] **Step 5: Run to verify Step 1's tests pass**
+
+Run: `npx vitest run tests/component-structure-edit.test.ts -t "inverse"`
+Expected: PASS (2 tests)
+
+- [ ] **Step 6: Write the failing test for `deleteBlock`'s inverse (raw re-insertion)**
+
+Append to `tests/component-structure-edit.test.ts`:
+
+```ts
+it("deleteBlock's inverse is a raw insertBlock reconstructing the exact removed markup", async () => {
+  const source = `---\n---\n<main><p id="keep">a</p><p id="gone">b</p></main>\n`;
+  const { byId, rootId } = await indexSource(source);
+  const main = [...byId.values()].find((n) => n.tag === "main")!;
+  const gone = [...byId.values()].find((n) => n.tag === "p" && n.attrs.some((a) => a.name === "id" && a.value === "gone"))!;
+  const goneIndex = main.childIds.indexOf(gone.id);
+  const result = await resolveComponentStructure(projectRoot, {
+    op: "deleteBlock",
+    component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), nodeId: gone.id },
+  });
+  expect(result.inverse.op).toBe("insertBlock");
+  expect(result.inverse.component.parentId).toBe(main.id);
+  expect(result.inverse.component.index).toBe(goneIndex);
+  expect(result.inverse.component.node).toEqual({ kind: "raw", markup: `<p id="gone">b</p>` });
+});
+```
+
+- [ ] **Step 7: Run to verify it fails**
+
+Run: `npx vitest run tests/component-structure-edit.test.ts -t "deleteBlock"`
+Expected: FAIL — `result.inverse` undefined.
+
+- [ ] **Step 8: Add `raw` handling to `buildMarkup` and attach `deleteBlock`'s inverse in `applyRemoveNode`**
+
+Find `buildMarkup(nodeSpec)` (the function `applyInsertNode` calls to synthesize markup for
+`element`/`component`/`slot`) and add a `raw` branch as its first check:
+
+```js
+function buildMarkup(nodeSpec) {
+  if (nodeSpec.kind === "raw") return nodeSpec.markup;
+  // ...existing element/component/slot branches unchanged...
+}
+```
+
+In `applyRemoveNode`, capture the exact removed markup and parent/index before building the
+replacement string, and attach `inverse` to all three return points:
+
+```js
+function applyRemoveNode(file, source, byId, rootId, component) {
+  const { nodeId } = component;
+  if (typeof nodeId !== "string") {
+    return refuse("invalid-input", "remove-node requires component.nodeId");
+  }
+  const node = byId.get(nodeId);
+  if (!node) return refuse("no-match", "no node found at the given id — the file may have changed");
+  if (node.parentId === null) return refuse("invalid-input", "cannot remove the component's root");
+
+  let spans;
+  try {
+    spans = resolveAllSpans(byId, rootId, source);
+  } catch (err) {
+    if (!(err instanceof SpanResolutionError)) throw err;
+    return refuse("no-match", "could not lexically re-locate the node's true source span without trusting compiler offsets — refusing rather than risking corruption");
+  }
+  const span = spans.get(nodeId);
+  if (!span) {
+    return refuse("no-match", "could not lexically re-locate the node's true source span without trusting compiler offsets — refusing rather than risking corruption");
+  }
+
+  const parent = byId.get(node.parentId);
+  const removedIndex = parent.childIds.indexOf(nodeId);
+  const inverse = {
+    op: "insertBlock",
+    component: { path: file, parentId: node.parentId, index: removedIndex, node: { kind: "raw", markup: source.slice(span[0], span[1]) } },
+  };
+
+  let start = span[0];
+  while (start > 0 && (source[start - 1] === " " || source[start - 1] === "\t")) start--;
+  if (start > 0 && source[start - 1] === "\n") start--;
+
+  const withoutNode = source.slice(0, start) + source.slice(span[1]);
+
+  const removedComponentNames = collectComponentTags(byId, nodeId);
+  if (removedComponentNames.length === 0) {
+    return { file, range: { start: 0, end: source.length }, replacement: withoutNode, inverse };
+  }
+
+  const fmMatch = withoutNode.match(/^(---\r?\n)([\s\S]*?)(\r?\n---)/);
+  if (!fmMatch) {
+    return { file, range: { start: 0, end: source.length }, replacement: withoutNode, inverse };
+  }
+  const [whole, open, fmBody] = fmMatch;
+  const fmStart = fmMatch.index;
+  const fmBodyStart = fmStart + open.length;
+  let newFmBody = fmBody;
+  for (const name of removedComponentNames) {
+    newFmBody = pruneImportIfUnused(newFmBody, withoutNode.slice(fmStart + whole.length), name).source;
+  }
+  const rewritten = withoutNode.slice(0, fmBodyStart) + newFmBody + withoutNode.slice(fmBodyStart + fmBody.length);
+  return { file, range: { start: 0, end: source.length }, replacement: rewritten, inverse };
+}
+```
+
+Note: `deleteBlock`'s inverse deliberately does **not** re-add a pruned component import — if the
+removed subtree was the last usage of a component, its raw markup on reinsertion won't have a
+matching import either. This is a known, documented v1 gap (flag it in Task 8's golden-test
+coverage note rather than silently special-casing it): round-tripping a `deleteBlock` whose
+subtree was the sole user of an import needs the reinserted `raw` markup's tag re-detected and its
+import re-added, which duplicates `applyInsertNode`'s component-import logic against a `raw` blob.
+Out of scope for this slice; the round-trip test in Task 8 should cover this gap explicitly with
+a `.skip`-and-comment or an assertion of the current (import-less) behavior, not silence.
+
+- [ ] **Step 9: Run to verify Step 6's test passes**
+
+Run: `npx vitest run tests/component-structure-edit.test.ts -t "deleteBlock"`
+Expected: PASS
+
+- [ ] **Step 10: Write the failing test for `insertBlock`'s inverse (post-edit id resolution)**
+
+Append to `tests/component-structure-edit.test.ts`:
+
+```ts
+it("insertBlock's inverse is a deleteBlock targeting the newly created node's post-edit id", async () => {
+  const source = `---\n---\n<main></main>\n`;
+  const { byId, rootId } = await indexSource(source);
+  const main = [...byId.values()].find((n) => n.tag === "main")!;
+  const result = await resolveComponentStructure(projectRoot, {
+    op: "insertBlock",
+    component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), parentId: main.id, index: 0, node: { kind: "element", tag: "p" } },
+  });
+  expect(result.inverse.op).toBe("deleteBlock");
+  // Re-parse the RESULT and confirm the inverse's nodeId actually resolves to the inserted <p>.
+  const rewritten = result.replacement; // whole-file replacement per the {start:0,end:len} range
+  const { byId: newById } = await indexSource(rewritten);
+  const target = newById.get(result.inverse.component.nodeId);
+  expect(target?.tag).toBe("p");
+});
+```
+
+- [ ] **Step 11: Run to verify it fails**
+
+Run: `npx vitest run tests/component-structure-edit.test.ts -t "insertBlock's inverse"`
+Expected: FAIL — `result.inverse` undefined.
+
+- [ ] **Step 12: Compute `insertBlock`'s inverse by re-indexing the rewritten source**
+
+Modify `applyInsertNode` to compute the inverse after building `rewritten`/`withNode` (whichever
+is the final returned replacement), by locating the inserted node's fresh id via
+`resolveAllSpans` over the NEW source, matched against the known insertion offset (adjusted for
+any frontmatter growth from a newly-added import):
+
+```js
+async function computeInsertInverse(file, finalSource, insertAtInFinalSource) {
+  const { ast } = await parse(finalSource, { position: true });
+  const { byId: newById, rootId: newRootId } = buildTemplateNodeIndex(ast, finalSource);
+  let newSpans;
+  try {
+    newSpans = resolveAllSpans(newById, newRootId, finalSource);
+  } catch {
+    return null; // best-effort: if relocation fails, ship no inverse rather than a wrong one
+  }
+  for (const [id, span] of newSpans) {
+    if (span[0] === insertAtInFinalSource) {
+      return { op: "deleteBlock", component: { path: file, nodeId: id } };
+    }
+  }
+  return null;
+}
+
+function applyInsertNode(file, source, byId, rootId, component) {
+  // ...existing validation and `insertAt`/`markup`/`withNode` computation unchanged...
+
+  if (nodeSpec.kind !== "component") {
+    return { file, range: { start: 0, end: source.length }, replacement: withNode, __insertAt: insertAt, __final: withNode };
+  }
+
+  const fmMatch = withNode.match(/^(---\r?\n)([\s\S]*?)(\r?\n---)/);
+  if (!fmMatch) {
+    const importLine = `import ${nodeSpec.tag} from "${importSpecifier(file, nodeSpec.componentPath)}";\n`;
+    const rewritten = `---\n${importLine}---\n${withNode}`;
+    return { file, range: { start: 0, end: source.length }, replacement: rewritten, __insertAt: insertAt + `---\n${importLine}---\n`.length, __final: rewritten };
+  }
+  const [, open, fmBody] = fmMatch;
+  const fmBodyStart = fmMatch.index + open.length;
+  const { source: newFmBody, added } = ensureImport(fmBody, { localName: nodeSpec.tag, specifier: importSpecifier(file, nodeSpec.componentPath) });
+  const rewritten = withNode.slice(0, fmBodyStart) + newFmBody + withNode.slice(fmBodyStart + fmBody.length);
+  const importShift = added ? newFmBody.length - fmBody.length : 0;
+  return { file, range: { start: 0, end: source.length }, replacement: rewritten, __insertAt: insertAt + importShift, __final: rewritten };
+}
+```
+
+Then, in `resolveComponentStructure`'s `insert-node`/`insertBlock` dispatch (the switch
+statement), await the inverse computation and strip the internal `__insertAt`/`__final` fields
+before returning:
+
+```js
+    case "insert-node":
+    case "insertBlock": {
+      const result = applyInsertNode(relPath, source, byId, rootId, component);
+      if (result.refused) return result;
+      const { __insertAt, __final, ...rest } = result;
+      const inverse = await computeInsertInverse(relPath, __final, __insertAt);
+      return inverse ? { ...rest, inverse } : rest;
+    }
+```
+
+(`resolveComponentStructure` is already `async` — Task 3's `loadFresh` awaits `parse`, so no
+signature change is needed here, just the added `await`.)
+
+- [ ] **Step 13: Run to verify Step 10's test passes**
+
+Run: `npx vitest run tests/component-structure-edit.test.ts -t "insertBlock's inverse"`
+Expected: PASS
+
+- [ ] **Step 14: Write the failing test for `moveBlock`'s inverse, then implement it the same way**
+
+Append to `tests/component-structure-edit.test.ts`:
+
+```ts
+it("moveBlock's inverse moves the node back to its original parent/index", async () => {
+  const source = `---\n---\n<main><section id="from"><p id="m">x</p></section><section id="to"></section></main>\n`;
+  const { byId } = await indexSource(source);
+  const p = [...byId.values()].find((n) => n.attrs.some((a) => a.name === "id" && a.value === "m"))!;
+  const to = [...byId.values()].find((n) => n.attrs.some((a) => a.name === "id" && a.value === "to"))!;
+  const from = [...byId.values()].find((n) => n.attrs.some((a) => a.name === "id" && a.value === "from"))!;
+  const result = await resolveComponentStructure(projectRoot, {
+    op: "moveBlock",
+    component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), nodeId: p.id, newParentId: to.id, newIndex: 0 },
+  });
+  const { byId: newById } = await indexSource(result.replacement);
+  const movedBack = newById.get(result.inverse.component.nodeId);
+  expect(movedBack?.attrs.some((a) => a.name === "id" && a.value === "m")).toBe(true);
+  const newFromParent = [...newById.values()].find((n) => n.attrs.some((a) => a.name === "id" && a.value === "from"));
+  expect(result.inverse.component.newParentId).toBe(newFromParent!.id);
+  expect(result.inverse.component.newIndex).toBe(0);
+});
+```
+
+Implement analogously to Step 12: `applyMoveNode` already computes `rewritten`; add the same
+`computeInsertInverse`-style re-indexing, except the target op is `"moveBlock"` and the
+`newParentId` is the ORIGINAL parent's id **as it exists in the re-parsed post-move tree** (find
+it by matching the moved node's un-moved sibling context — simplest robust approach: before the
+move, record the original parent's own resolved span-start in `source`; after the move, re-index
+`rewritten` and find the node whose resolved span starts at that same offset, adjusted for the
+net length delta the splice introduced before that offset). Follow the exact "resolve identity
+via `resolveAllSpans` over the fresh parse, never via id reuse" discipline Step 12 established.
+
+- [ ] **Step 15: Run the full structure-edit suite**
+
+Run: `npx vitest run tests/component-structure-edit.test.ts`
+Expected: PASS, all prior tests (non-inverse) still green.
+
+- [ ] **Step 16: Wire `patcher.mjs` to route the four new op names**
+
+`patcher.mjs` dispatches by checking `COMPONENT_STRUCTURE_OPS.has(edit.op)` (imported from
+`apply-edit-schema.mjs`) before calling `resolveComponentStructure`. Since Step 3 already added
+the four new names to that same `Set`, confirm (do not duplicate) that `patcher.mjs`'s existing
+branch reads the Set rather than hardcoding the four legacy op strings — if it hardcodes them,
+replace the hardcoded check with `COMPONENT_STRUCTURE_OPS.has(edit.op)`.
+
+- [ ] **Step 17: Add manifest-aware resolution to `insertBlock`'s `manifestBlock` field**
+
+In `resolveComponentStructure`, before dispatching to `applyInsertNode`, resolve `manifestBlock`
+if present:
+
+```js
+    case "insert-node":
+    case "insertBlock": {
+      let effectiveComponent = component;
+      if (component.manifestBlock) {
+        const manifest = loadBlockManifest(projectRoot);
+        const entry = indexManifestByName(manifest).get(component.manifestBlock);
+        if (!entry) return refuse("no-match", `no block named "${component.manifestBlock}" in blocks.manifest.json`);
+        effectiveComponent = {
+          ...component,
+          node: { kind: "component", tag: entry.export, componentPath: entry.path, slotName: component.node?.slotName },
+        };
+      }
+      const result = applyInsertNode(relPath, source, byId, rootId, effectiveComponent);
+      // ...rest as in Step 12...
+    }
+```
+
+Add the corresponding import at the top of `component-structure-edit.mjs`:
+
+```js
+import { loadBlockManifest, indexManifestByName } from "./block-manifest.mjs";
+```
+
+- [ ] **Step 18: Write the failing test for `manifestBlock` resolution, then confirm it passes**
+
+Append to `tests/component-structure-edit.test.ts`:
+
+```ts
+it("insertBlock resolves manifestBlock to the registered component's tag/path", async () => {
+  writeFileSync(join(projectRoot, "blocks.manifest.json"), JSON.stringify({
+    schemaVersion: "anglesite-block-manifest/1",
+    modules: [{ path: "src/components/Testimonial.astro", export: "Testimonial", name: "Testimonial" }],
+  }));
+  const source = `---\n---\n<main></main>\n`;
+  const { byId } = await indexSource(source);
+  const main = [...byId.values()].find((n) => n.tag === "main")!;
+  const result = await resolveComponentStructure(projectRoot, {
+    op: "insertBlock",
+    component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), parentId: main.id, index: 0, manifestBlock: "Testimonial" },
+  });
+  expect(result.replacement).toContain("<Testimonial");
+  expect(result.replacement).toContain(`import Testimonial from`);
+});
+```
+
+Run: `npx vitest run tests/component-structure-edit.test.ts -t "manifestBlock"`
+Expected: PASS once Step 17 lands.
+
+- [ ] **Step 19: Run the full suite and commit**
+
+Run: `npm test`
+Expected: PASS.
+
+```bash
+git add server/apply-edit-schema.mjs server/component-structure-edit.mjs server/patcher.mjs tests/component-structure-edit.test.ts
+git commit -m "feat(server): invertible insertBlock/moveBlock/deleteBlock/setProp ops"
+```
+
+---
+
+## Task 5: Dispatcher — stamp `inverse.component.baseVersion` after the write
+
+**Files:**
+- Modify: `server/apply-edit-dispatcher.mjs`
+- Test: `tests/apply-edit-dispatcher-component-structure.test.ts` (existing file — append)
+
+**Interfaces:**
+- Consumes: `inverse` field from Task 4's resolvers (unstamped — no `baseVersion`).
+- Produces: the `edit-applied` response content now includes `inverse` (fully stamped, ready to
+  send back through `apply_edit` unmodified) whenever the resolved edit carried one. This is the
+  field the app's `NSUndoManager` registration (spec §8.2) and the engine's ops log consume.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/apply-edit-dispatcher-component-structure.test.ts`:
+
+```ts
+it("stamps inverse.component.baseVersion with the post-write content hash", async () => {
+  const source = `---\n---\n<div id="a" title="old">x</div>\n`;
+  writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+  const { byId } = await indexSource(source);
+  const divId = [...byId.values()].find((n) => n.tag === "div")!.id;
+  const response = await applyEdit(projectRoot, {
+    id: "1", path: "src/pages/index.astro", op: "setProp",
+    component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), nodeId: divId, name: "title", value: "new" },
+  }, { onApplied: () => {} });
+  const payload = JSON.parse(response.content[0].text);
+  const written = readFileSync(join(projectRoot, "src/pages/index.astro"), "utf-8");
+  expect(payload.inverse.component.baseVersion).toBe(fileVersion(written));
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/apply-edit-dispatcher-component-structure.test.ts -t "stamps inverse"`
+Expected: FAIL — `payload.inverse` is `undefined` or missing `baseVersion`.
+
+- [ ] **Step 3: Stamp the inverse in `apply-edit-dispatcher.mjs`**
+
+Locate the block that already piggybacks a fresh `buildComponentModel` result onto
+`COMPONENT_OPS` success responses (per the Explore report, this reads the just-written file and
+folds it into the `edit-applied` payload). Add the inverse-stamping right alongside it, using the
+same freshly-read post-write source:
+
+```js
+  if (resolution.inverse) {
+    payload.inverse = {
+      ...resolution.inverse,
+      component: { ...resolution.inverse.component, baseVersion: fileVersion(writtenSource) },
+    };
+  }
+```
+
+(`writtenSource` here is whatever local variable the existing piggyback logic already reads post-
+`atomicWrite` — reuse it, don't re-read the file a second time.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx vitest run tests/apply-edit-dispatcher-component-structure.test.ts -t "stamps inverse"`
+Expected: PASS
+
+- [ ] **Step 5: Run the full suite and commit**
+
+Run: `npm test`
+
+```bash
+git add server/apply-edit-dispatcher.mjs tests/apply-edit-dispatcher-component-structure.test.ts
+git commit -m "feat(server): stamp inverse ops with the post-write content hash"
+```
+
+---
+
+## Task 6: `editText` — rich-text run editing
+
+**Files:**
+- Create: `server/text-run-edit.mjs`
+- Modify: `server/patcher.mjs` (dispatch `editText`)
+- Test: `tests/text-run-edit.test.ts`
+
+**Scope note (record explicitly — this is a deliberate v1 boundary, not an oversight):** per the
+Global Constraints, this task covers **`.astro` template rich-text nodes only** — toggling
+`strong`/`em`/`code`/`a` inline HTML around a target element's text content. It does **not**
+cover Markdoc/markdown content-collection body text (`src/content/**/*.mdoc`); no markdown AST
+tooling exists in this sidecar today (confirmed: no remark/mdast/micromark dependency anywhere),
+and adding one is a separate, dependency-approval-gated slice. `patcher.mjs`'s existing
+`resolveMdoc` text-search-and-replace remains the only markdown-body editing path until that
+follow-up lands.
+
+**Interfaces:**
+- Consumes: `resolveAllSpans`, `SpanResolutionError`, `escapeAttr` (Task 4's exports from
+  `component-structure-edit.mjs`); `fileVersion`.
+- Produces: `resolveTextRuns(projectRoot, edit): Promise<{file,range,replacement,inverse} |
+  {refused,reason,detail}>`, dispatched for `edit.op === "editText"`. Payload:
+  `component: { path, baseVersion, textNodeId, runs: RichTextRun[] }` where `RichTextRun = {
+  text: string, marks: ("strong"|"em"|"code")[], href?: string }` (already added to
+  `componentEditSchema` in Task 4 Step 3).
+
+- [ ] **Step 1: Write the failing test — toggling bold on a paragraph's text**
+
+Create `tests/text-run-edit.test.ts` (mirror `component-structure-edit.test.ts`'s tmpdir
+`beforeEach`/`afterEach` and `indexSource` helper):
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFileSync, mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parse } from "@astrojs/compiler";
+import { buildTemplateNodeIndex } from "../server/component-node-index.mjs";
+import { fileVersion } from "../server/file-version.mjs";
+import { resolveTextRuns } from "../server/text-run-edit.mjs";
+
+let projectRoot: string;
+beforeEach(() => {
+  projectRoot = mkdtempSync(join(tmpdir(), "anglesite-text-run-"));
+  mkdirSync(join(projectRoot, "src", "pages"), { recursive: true });
+});
+afterEach(() => rmSync(projectRoot, { recursive: true, force: true }));
+
+async function indexSource(source: string) {
+  const { ast } = await parse(source, { position: true });
+  return buildTemplateNodeIndex(ast, source);
+}
+
+describe("resolveTextRuns", () => {
+  it("re-serializes runs as honest inline HTML, replacing the element's inner content", async () => {
+    const source = `---\n---\n<p id="t">Hello world</p>\n`;
+    writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+    const { byId } = await indexSource(source);
+    const p = [...byId.values()].find((n) => n.tag === "p")!;
+    const result = await resolveTextRuns(projectRoot, {
+      op: "editText",
+      component: {
+        path: "src/pages/index.astro", baseVersion: fileVersion(source), textNodeId: p.id,
+        runs: [{ text: "Hello ", marks: [] }, { text: "world", marks: ["strong"] }],
+      },
+    });
+    expect(result.replacement).toBe("Hello <strong>world</strong>");
+  });
+
+  it("escapes text content so a run's text can never break out as markup", async () => {
+    const source = `---\n---\n<p id="t">old</p>\n`;
+    writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+    const { byId } = await indexSource(source);
+    const p = [...byId.values()].find((n) => n.tag === "p")!;
+    const result = await resolveTextRuns(projectRoot, {
+      op: "editText",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), textNodeId: p.id, runs: [{ text: "<b>x</b> & y", marks: [] }] },
+    });
+    expect(result.replacement).toBe("&lt;b&gt;x&lt;/b&gt; &amp; y");
+  });
+
+  it("computes an inverse editText restoring the original runs", async () => {
+    const source = `---\n---\n<p id="t">Hello world</p>\n`;
+    writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+    const { byId } = await indexSource(source);
+    const p = [...byId.values()].find((n) => n.tag === "p")!;
+    const result = await resolveTextRuns(projectRoot, {
+      op: "editText",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), textNodeId: p.id, runs: [{ text: "Bye", marks: [] }] },
+    });
+    expect(result.inverse).toEqual({
+      op: "editText",
+      component: { path: "src/pages/index.astro", textNodeId: p.id, runs: [{ text: "Hello world", marks: [] }] },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/text-run-edit.test.ts`
+Expected: FAIL with "Cannot find module '../server/text-run-edit.mjs'"
+
+- [ ] **Step 3: Write `server/text-run-edit.mjs`**
+
+```js
+import { readFileSync } from "node:fs";
+import { join, normalize } from "node:path";
+import { parse } from "@astrojs/compiler";
+import { fileVersion } from "./file-version.mjs";
+import { buildTemplateNodeIndex } from "./component-node-index.mjs";
+import { resolveAllSpans, SpanResolutionError, escapeAttr } from "./component-structure-edit.mjs";
+
+function refuse(reason, detail) {
+  return { refused: true, reason, detail };
+}
+
+function escapeText(s) {
+  return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+const MARK_TAGS = { strong: "strong", em: "em", code: "code" };
+
+/** Serializes runs into the small honest inline set the spec allows (§4): strong, em, code,
+ *  link. Marks nest in a fixed, deterministic order (code innermost) so round-tripping the
+ *  same runs always produces byte-identical markup — required for the golden tests in Task 8. */
+function serializeRuns(runs) {
+  return runs
+    .map(({ text, marks = [], href }) => {
+      let out = escapeText(text);
+      for (const mark of ["code", "em", "strong"]) {
+        if (marks.includes(mark)) out = `<${MARK_TAGS[mark]}>${out}</${MARK_TAGS[mark]}>`;
+      }
+      if (href !== undefined) out = `<a href="${escapeAttr(href)}">${out}</a>`;
+      return out;
+    })
+    .join("");
+}
+
+/** Reverses serializeRuns for exactly the shapes it produces — one run per top-level mark
+ *  combination, used only to reconstruct the inverse from a node's ORIGINAL rendered content,
+ *  not a general HTML-to-runs parser. Out of scope: nested/mixed structures a human hand-edit
+ *  could introduce outside the editor — those fall back to a single unmarked run of the raw
+ *  inner text (a safe, if blunt, inverse: applying it always yields valid honest markup, just
+ *  not a byte-identical restoration of hand-authored HTML). */
+function parseRunsBestEffort(innerHtml) {
+  const m = innerHtml.match(/^(?:<a href="([^"]*)">)?(?:<strong>)?(?:<em>)?(?:<code>)?([\s\S]*?)(?:<\/code>)?(?:<\/em>)?(?:<\/strong>)?(?:<\/a>)?$/);
+  if (m && m[0] === innerHtml) {
+    const marks = [];
+    if (innerHtml.includes("<strong>")) marks.push("strong");
+    if (innerHtml.includes("<em>")) marks.push("em");
+    if (innerHtml.includes("<code>")) marks.push("code");
+    const text = m[2].replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+    return [{ text, marks, ...(m[1] !== undefined ? { href: m[1] } : {}) }];
+  }
+  const text = innerHtml.replace(/<[^>]+>/g, "").replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+  return [{ text, marks: [] }];
+}
+
+export async function resolveTextRuns(projectRoot, edit) {
+  const { component } = edit;
+  if (!component || typeof component !== "object") return refuse("invalid-input", "component payload is required for editText");
+  const { path: relPath, baseVersion, textNodeId, runs } = component;
+  if (typeof relPath !== "string" || !relPath.endsWith(".astro") || normalize(relPath).startsWith("..") || relPath.startsWith("/")) {
+    return refuse("invalid-input", `not a project-relative .astro path: ${relPath}`);
+  }
+  if (typeof textNodeId !== "string" || !Array.isArray(runs)) {
+    return refuse("invalid-input", "editText requires component.textNodeId and component.runs");
+  }
+
+  const absPath = join(projectRoot, relPath);
+  let source;
+  try {
+    source = readFileSync(absPath, "utf-8");
+  } catch (err) {
+    return refuse("read-failed", `read ${relPath}: ${err.message}`);
+  }
+  if (fileVersion(source) !== baseVersion) return refuse("stale", `${relPath} changed since the model was fetched`);
+
+  let ast;
+  try {
+    ({ ast } = await parse(source, { position: true }));
+  } catch (err) {
+    return refuse("parse-failed", `parse ${relPath}: ${err.message}`);
+  }
+  const { byId, rootId } = buildTemplateNodeIndex(ast, source);
+  const node = byId.get(textNodeId);
+  if (!node || node.kind !== "element") return refuse("no-match", "editText requires an element node id from get_page_model");
+
+  let spans;
+  try {
+    spans = resolveAllSpans(byId, rootId, source);
+  } catch (err) {
+    if (!(err instanceof SpanResolutionError)) throw err;
+    return refuse("no-match", "could not lexically re-locate the node's true source span without trusting compiler offsets — refusing rather than risking corruption");
+  }
+  const outer = spans.get(textNodeId);
+  if (!outer) return refuse("no-match", "could not lexically re-locate the node's true source span");
+
+  // Inner-content boundary: the open tag's end through the matching close tag's start. Both
+  // are re-derived from the source text at the already-verified `outer` span rather than
+  // trusted from the AST — same discipline as every other resolver in this module set.
+  const openEnd = source.indexOf(">", outer[0]) + 1;
+  const closeStart = source.lastIndexOf("<", outer[1] - 1);
+  if (openEnd <= outer[0] || closeStart < openEnd) return refuse("no-match", "could not resolve the element's inner-content boundary");
+
+  const originalInner = source.slice(openEnd, closeStart);
+  const inverse = { op: "editText", component: { path: relPath, textNodeId, runs: parseRunsBestEffort(originalInner) } };
+  const replacement = serializeRuns(runs);
+  return { file: relPath, range: { start: openEnd, end: closeStart }, replacement, inverse };
+}
+```
+
+- [ ] **Step 4: Run to verify all three tests pass**
+
+Run: `npx vitest run tests/text-run-edit.test.ts`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Wire `patcher.mjs` to dispatch `editText`**
+
+In `server/patcher.mjs`, add `editText` to the priority-ordered dispatch chain (alongside the
+existing component-structure/style/frontmatter branches):
+
+```js
+import { resolveTextRuns } from "./text-run-edit.mjs";
+// ...
+  if (edit.op === "editText") return resolveTextRuns(projectRoot, edit);
+```
+
+- [ ] **Step 6: Add an end-to-end stdio test**
+
+Append to `tests/mcp-server.test.ts`:
+
+```ts
+it("editText replaces an element's inner content with re-serialized runs over stdio", async () => {
+  mkdirSync(join(tmpDir, "src", "pages"), { recursive: true });
+  const source = `---\n---\n<p id="t">Hello world</p>\n`;
+  writeFileSync(join(tmpDir, "src", "pages", "index.astro"), source);
+  const modelResult = await callTool(proc, "get_page_model", { path: "src/pages/index.astro" });
+  const model = JSON.parse(modelResult.content[0].text);
+  const p = model.tree.children.find((n: any) => n.tag === "p");
+  const result = await callTool(proc, "apply_edit", {
+    id: "1", path: "src/pages/index.astro", op: "editText",
+    component: { path: "src/pages/index.astro", baseVersion: model.version, textNodeId: p.id, runs: [{ text: "Bye", marks: ["strong"] }] },
+  });
+  const payload = JSON.parse(result.content[0].text);
+  expect(payload.inverse.op).toBe("editText");
+  const written = readFileSync(join(tmpDir, "src", "pages", "index.astro"), "utf-8");
+  expect(written).toContain("<strong>Bye</strong>");
+});
+```
+
+- [ ] **Step 7: Run the full suite and commit**
+
+Run: `npm test`
+
+```bash
+git add server/text-run-edit.mjs server/patcher.mjs server/apply-edit-schema.mjs tests/text-run-edit.test.ts tests/mcp-server.test.ts
+git commit -m "feat(server): add editText rich-text run editing with inverse"
+```
+
+---
+
+## Task 7: `setDesignToken` — global CSS custom-property editing
+
+**Files:**
+- Modify: `server/css-rule-index.mjs` (factor a baseOffset-free rule walk)
+- Create: `server/design-token-edit.mjs`
+- Modify: `server/patcher.mjs` (dispatch `setDesignToken`)
+- Test: `tests/design-token-edit.test.ts`
+
+**Scope note:** targets only the **light** `:root { }` block in `src/styles/global.css` — the
+file's own comment documents that the existing app-side theme-apply flow "upserts only the
+top-level `:root` block above and leaves [the dark-mode `@media` block] alone"; `setDesignToken`
+matches that established convention rather than inventing dark-mode-aware contrast derivation,
+which is out of scope for this slice.
+
+**Interfaces:**
+- Produces: `walkCssRules(cssText: string, baseOffset: number): CssRule[]` (extracted from
+  `indexCssRules`, exported from `css-rule-index.mjs`, reused by both the Astro-scoped-style path
+  and the new global-stylesheet path). `resolveDesignToken(projectRoot, edit): Promise<...>`,
+  dispatched for `edit.op === "setDesignToken"`. Payload: `component: { path, baseVersion, token,
+  tokenValue }` where `path` is always `"src/styles/global.css"` (validated, not inferred) and
+  `token` must match `/^--[\w-]+$/`.
+
+- [ ] **Step 1: Write the failing test — refactor safety net for `css-rule-index.mjs`**
+
+Ensure the existing `tests/component-model.test.ts` scoped-style assertions (which exercise
+`indexCssRules` indirectly through `buildComponentModel`) still pass unmodified after Step 2's
+refactor — no new test needed here, this step is a regression guard on existing coverage. Note it
+so the refactor step isn't skipped without running it.
+
+- [ ] **Step 2: Extract `walkCssRules` in `css-rule-index.mjs`**
+
+```js
+import { parse as parseCss, generate, walk } from "css-tree";
+import { offsetFromLineColumn } from "./component-node-index.mjs";
+
+function span(loc, baseOffset) {
+  if (!loc) return [null, null];
+  return [baseOffset + loc.start.offset, baseOffset + loc.end.offset];
+}
+
+/** Span-precise CSS rule index for a raw CSS string, given the byte offset that string starts
+ *  at within its owning file (0 for a whole standalone .css file). Shared by indexCssRules
+ *  (Astro <style> elements) and design-token-edit.mjs (global.css :root) so both agree
+ *  byte-for-byte on rule/declaration identity via the same css-tree walk. */
+export function walkCssRules(cssText, baseOffset) {
+  let cssAst;
+  try {
+    cssAst = parseCss(cssText, { positions: true, parseValue: false, parseAtrulePrelude: false });
+  } catch {
+    return [];
+  }
+  const rules = [];
+  walk(cssAst, {
+    visit: "Rule",
+    enter(node) {
+      const media = this.atrule && this.atrule.name === "media" && this.atrule.prelude ? generate(this.atrule.prelude).trim() : null;
+      const declarations = [];
+      node.block.children.forEach((decl) => {
+        if (decl.type !== "Declaration") return;
+        declarations.push({ property: decl.property, value: generate(decl.value).trim(), span: span(decl.loc, baseOffset) });
+      });
+      const blockSpan = span(node.block.loc, baseOffset);
+      rules.push({
+        selector: generate(node.prelude), preludeSpan: span(node.prelude.loc, baseOffset), media,
+        span: span(node.loc, baseOffset), blockInner: [blockSpan[0] + 1, blockSpan[1] - 1], declarations,
+      });
+    },
+  });
+  return rules;
+}
+
+export function indexCssRules(styleElement, lineStarts) {
+  const lang = (styleElement.attributes ?? []).find((a) => a.name === "lang")?.value;
+  if (lang && lang.trim().toLowerCase() !== "css") return [];
+  const textChild = (styleElement.children ?? []).find((c) => c.type === "text");
+  if (!textChild?.value) return [];
+  const baseOffset = offsetFromLineColumn(lineStarts, textChild.position?.start) ?? 0;
+  return walkCssRules(textChild.value, baseOffset);
+}
+```
+
+- [ ] **Step 3: Run to verify no regression**
+
+Run: `npx vitest run tests/component-model.test.ts tests/component-structure-edit.test.ts`
+Expected: PASS, unchanged.
+
+- [ ] **Step 4: Write the failing test for `setDesignToken`**
+
+Create `tests/design-token-edit.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileVersion } from "../server/file-version.mjs";
+import { resolveDesignToken } from "../server/design-token-edit.mjs";
+
+const GLOBAL_CSS = `:root {\n  --color-primary: #2563eb;\n  --spacing-unit: 0.25rem;\n}\n\n@media (prefers-color-scheme: dark) {\n  :root {\n    --color-primary: #60a5fa;\n  }\n}\n`;
+
+let projectRoot: string;
+beforeEach(() => {
+  projectRoot = mkdtempSync(join(tmpdir(), "anglesite-token-"));
+  mkdirSync(join(projectRoot, "src", "styles"), { recursive: true });
+  writeFileSync(join(projectRoot, "src", "styles", "global.css"), GLOBAL_CSS);
+});
+afterEach(() => rmSync(projectRoot, { recursive: true, force: true }));
+
+describe("resolveDesignToken", () => {
+  it("replaces the light :root declaration's value and leaves the dark block untouched", async () => {
+    const result = await resolveDesignToken(projectRoot, {
+      op: "setDesignToken",
+      component: { path: "src/styles/global.css", baseVersion: fileVersion(GLOBAL_CSS), token: "--color-primary", tokenValue: "#111111" },
+    });
+    const next = GLOBAL_CSS.slice(0, result.range.start) + result.replacement + GLOBAL_CSS.slice(result.range.end);
+    expect(next).toContain("--color-primary: #111111;");
+    expect(next).toContain("--color-primary: #60a5fa;"); // dark block unchanged
+  });
+
+  it("computes an inverse restoring the previous value", async () => {
+    const result = await resolveDesignToken(projectRoot, {
+      op: "setDesignToken",
+      component: { path: "src/styles/global.css", baseVersion: fileVersion(GLOBAL_CSS), token: "--color-primary", tokenValue: "#111111" },
+    });
+    expect(result.inverse).toEqual({
+      op: "setDesignToken",
+      component: { path: "src/styles/global.css", token: "--color-primary", tokenValue: "#2563eb" },
+    });
+  });
+
+  it("refuses an unknown token rather than inventing a declaration", async () => {
+    const result = await resolveDesignToken(projectRoot, {
+      op: "setDesignToken",
+      component: { path: "src/styles/global.css", baseVersion: fileVersion(GLOBAL_CSS), token: "--does-not-exist", tokenValue: "red" },
+    });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("no-match");
+  });
+});
+```
+
+- [ ] **Step 5: Run to verify it fails**
+
+Run: `npx vitest run tests/design-token-edit.test.ts`
+Expected: FAIL with "Cannot find module '../server/design-token-edit.mjs'"
+
+- [ ] **Step 6: Write `server/design-token-edit.mjs`**
+
+```js
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileVersion } from "./file-version.mjs";
+import { walkCssRules } from "./css-rule-index.mjs";
+
+const GLOBAL_CSS_PATH = "src/styles/global.css";
+const TOKEN_RE = /^--[\w-]+$/;
+
+function refuse(reason, detail) {
+  return { refused: true, reason, detail };
+}
+
+export async function resolveDesignToken(projectRoot, edit) {
+  const { component } = edit;
+  if (!component || typeof component !== "object") return refuse("invalid-input", "component payload is required for setDesignToken");
+  const { path: relPath, baseVersion, token, tokenValue } = component;
+  if (relPath !== GLOBAL_CSS_PATH) return refuse("invalid-input", `setDesignToken only targets ${GLOBAL_CSS_PATH}`);
+  if (typeof token !== "string" || !TOKEN_RE.test(token)) return refuse("invalid-input", `not a CSS custom-property name: ${token}`);
+  if (typeof tokenValue !== "string") return refuse("invalid-input", "setDesignToken requires component.tokenValue");
+
+  const absPath = join(projectRoot, relPath);
+  let source;
+  try {
+    source = readFileSync(absPath, "utf-8");
+  } catch (err) {
+    return refuse("read-failed", `read ${relPath}: ${err.message}`);
+  }
+  if (fileVersion(source) !== baseVersion) return refuse("stale", `${relPath} changed since it was last read`);
+
+  const rules = walkCssRules(source, 0);
+  // The light palette only: the FIRST top-level `:root` rule not nested inside any @media —
+  // matches the file's own documented convention (see this task's Scope note).
+  const rootRule = rules.find((r) => r.selector.trim() === ":root" && r.media === null);
+  if (!rootRule) return refuse("no-match", "no top-level :root rule found in global.css");
+  const decl = rootRule.declarations.find((d) => d.property === token);
+  if (!decl) return refuse("no-match", `:root has no declaration for ${token}`);
+
+  const inverse = { op: "setDesignToken", component: { path: relPath, token, tokenValue: decl.value } };
+  return { file: relPath, range: { start: decl.span[0], end: decl.span[1] }, replacement: `${token}: ${tokenValue}`, inverse };
+}
+```
+
+- [ ] **Step 7: Run to verify all three tests pass**
+
+Run: `npx vitest run tests/design-token-edit.test.ts`
+Expected: PASS (3 tests)
+
+- [ ] **Step 8: Wire `patcher.mjs` and confirm the dispatcher splices+writes+stamps correctly**
+
+```js
+import { resolveDesignToken } from "./design-token-edit.mjs";
+// ...
+  if (edit.op === "setDesignToken") return resolveDesignToken(projectRoot, edit);
+```
+
+Since `apply-edit-dispatcher.mjs`'s inverse-stamping (Task 5) reads `resolution.inverse`
+generically — not gated on `COMPONENT_STRUCTURE_OPS` membership — confirm it applies to
+`setDesignToken`'s resolution too. If Task 5's stamping code is scoped to
+`COMPONENT_OPS.has(edit.op)`, widen that guard to `resolution.inverse != null` (any resolver that
+returns one gets stamped), since `setDesignToken`/`editText` aren't in `COMPONENT_OPS`.
+
+- [ ] **Step 9: Add an end-to-end stdio test**
+
+Append to `tests/mcp-server.test.ts`:
+
+```ts
+it("setDesignToken patches global.css's :root and returns a stamped inverse over stdio", async () => {
+  mkdirSync(join(tmpDir, "src", "styles"), { recursive: true });
+  const css = `:root {\n  --color-primary: #2563eb;\n}\n`;
+  writeFileSync(join(tmpDir, "src", "styles", "global.css"), css);
+  const result = await callTool(proc, "apply_edit", {
+    id: "1", path: "src/styles/global.css", op: "setDesignToken",
+    component: { path: "src/styles/global.css", baseVersion: fileVersionOf(css), token: "--color-primary", tokenValue: "#111111" },
+  });
+  const payload = JSON.parse(result.content[0].text);
+  expect(payload.inverse.component.tokenValue).toBe("#2563eb");
+  const written = readFileSync(join(tmpDir, "src", "styles", "global.css"), "utf-8");
+  expect(written).toContain("--color-primary: #111111");
+});
+```
+
+(`fileVersionOf` — add a one-line local helper importing `fileVersion` from
+`../server/file-version.mjs`, matching the file's existing import style.)
+
+- [ ] **Step 10: Run the full suite and commit**
+
+Run: `npm test`
+
+```bash
+git add server/css-rule-index.mjs server/design-token-edit.mjs server/patcher.mjs server/apply-edit-dispatcher.mjs tests/design-token-edit.test.ts tests/mcp-server.test.ts
+git commit -m "feat(server): add setDesignToken global CSS custom-property editing"
+```
+
+---
+
+## Task 8: Golden round-trip tests — op → source diff → re-parsed model
+
+**Files:**
+- Create: `tests/page-ops-roundtrip.test.ts`
+
+**Interfaces:**
+- Consumes every resolver from Tasks 4, 6, 7 plus `buildPageModel` (Task 3). No production code
+  changes in this task — purely a test suite that exercises the full op/inverse contract
+  end-to-end, per the spec's §10 testing requirement: "golden round-trip tests (op → source diff
+  → re-parsed model) in the sidecar's node:test suite" (this repo's equivalent is Vitest, per the
+  Global Constraints correction).
+
+- [ ] **Step 1: Write the round-trip harness**
+
+Create `tests/page-ops-roundtrip.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileVersion } from "../server/file-version.mjs";
+import { resolveComponentStructure } from "../server/component-structure-edit.mjs";
+import { resolveTextRuns } from "../server/text-run-edit.mjs";
+import { resolveDesignToken } from "../server/design-token-edit.mjs";
+
+let projectRoot: string;
+beforeEach(() => {
+  projectRoot = mkdtempSync(join(tmpdir(), "anglesite-roundtrip-"));
+  mkdirSync(join(projectRoot, "src", "pages"), { recursive: true });
+  mkdirSync(join(projectRoot, "src", "styles"), { recursive: true });
+});
+afterEach(() => rmSync(projectRoot, { recursive: true, force: true }));
+
+/** Applies `resolver`'s result to `original`, then applies the computed inverse to that
+ *  result, and asserts the round trip lands back on `original` byte-for-byte — the exact
+ *  "op → source diff → re-parsed model" golden shape the spec requires (§10), proven directly
+ *  against the resolver rather than through a live subprocess for speed and clarity. */
+async function assertRoundTrips(resolver, original, edit) {
+  const forward = await resolver(projectRoot, edit);
+  expect(forward.refused).toBeFalsy();
+  const afterForward = original.slice(0, forward.range.start) + forward.replacement + original.slice(forward.range.end);
+  expect(forward.inverse).toBeTruthy();
+  const inverseEdit = { op: forward.inverse.op, component: { ...forward.inverse.component, baseVersion: fileVersion(afterForward) } };
+  const backward = await resolver(projectRoot, inverseEdit);
+  expect(backward.refused).toBeFalsy();
+  const afterBackward = afterForward.slice(0, backward.range.start) + backward.replacement + afterForward.slice(backward.range.end);
+  expect(afterBackward).toBe(original);
+  return { forward, backward };
+}
+
+describe("op round trips", () => {
+  it("setProp round-trips a changed attribute back to its original value", async () => {
+    const source = `---\n---\n<div id="a" title="old">x</div>\n`;
+    writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+    const { buildTemplateNodeIndex } = await import("../server/component-node-index.mjs");
+    const { parse } = await import("@astrojs/compiler");
+    const { ast } = await parse(source, { position: true });
+    const { byId } = buildTemplateNodeIndex(ast, source);
+    const divId = [...byId.values()].find((n: any) => n.tag === "div")!.id;
+    await assertRoundTrips(resolveComponentStructure, source, {
+      op: "setProp",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), nodeId: divId, name: "title", value: "new" },
+    });
+  });
+
+  it("editText round-trips a rewritten paragraph back to its original runs", async () => {
+    const source = `---\n---\n<p id="t">Hello world</p>\n`;
+    writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+    const { buildTemplateNodeIndex } = await import("../server/component-node-index.mjs");
+    const { parse } = await import("@astrojs/compiler");
+    const { ast } = await parse(source, { position: true });
+    const { byId } = buildTemplateNodeIndex(ast, source);
+    const p = [...byId.values()].find((n: any) => n.tag === "p")!;
+    await assertRoundTrips(resolveTextRuns, source, {
+      op: "editText",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), textNodeId: p.id, runs: [{ text: "Bye", marks: ["strong"] }] },
+    });
+  });
+
+  it("setDesignToken round-trips a changed token back to its original value", async () => {
+    const source = `:root {\n  --color-primary: #2563eb;\n}\n`;
+    writeFileSync(join(projectRoot, "src/styles/global.css"), source);
+    await assertRoundTrips(resolveDesignToken, source, {
+      op: "setDesignToken",
+      component: { path: "src/styles/global.css", baseVersion: fileVersion(source), token: "--color-primary", tokenValue: "#111111" },
+    });
+  });
+
+  // Documents Task 4 Step 8's known gap rather than leaving it silently uncovered (per this
+  // repo's "no silent caps" testing discipline): deleteBlock's raw-markup inverse does not
+  // restore a pruned import when the removed subtree was the import's only usage, so a
+  // deleteBlock → insertBlock round trip on such a subtree currently reconstructs the markup
+  // but NOT the import line. Fix (re-detect + re-add the import from the raw markup's tag
+  // name on reinsertion) is out of scope for this slice.
+  it.todo("deleteBlock/insertBlock round-trips import pruning when the block was the import's sole use");
+});
+```
+
+- [ ] **Step 2: Run to verify the three real round trips pass**
+
+Run: `npx vitest run tests/page-ops-roundtrip.test.ts`
+Expected: PASS (3 tests, 1 `.todo`)
+
+- [ ] **Step 3: Add `insertBlock`/`moveBlock`/`deleteBlock` round trips**
+
+Append three more `it(...)` blocks to the same file following the identical pattern, covering:
+insert a `<p>` into `<main>` then delete it back out (byte-identical), and move a `<p>` between
+two `<section>`s then move it back. Use the exact fixtures already written for these ops in Task
+4 Steps 6/10/14 — copy the source strings and node lookups verbatim so the golden tests exercise
+the same shapes the inverse-computation unit tests already proved correct in isolation.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `npm test`
+Expected: PASS, all suites green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/page-ops-roundtrip.test.ts
+git commit -m "test(server): golden op/inverse round-trip suite for the ops protocol"
+```
+
+---
+
+## Task 9: Documentation and version bump
+
+**Files:**
+- Modify: `CLAUDE.md` (tool table, manual-testing section)
+- Modify: `package.json`, `.claude-plugin/plugin.json`, `template/package.json` (version bump —
+  via `bin/release.ts`, not hand-edited)
+
+**Interfaces:** none — documentation and release-metadata only.
+
+- [ ] **Step 1: Add the new tool and ops to `CLAUDE.md`'s tool table**
+
+In `CLAUDE.md`'s **Tools** table (~line 30), add a row after `apply_edit`:
+
+```markdown
+| `get_page_model` | Parse a page `.astro` file into a block-annotated template tree — `get_component_model`'s shape plus a `block` descriptor on nodes that resolve against `blocks.manifest.json` |
+```
+
+Extend the `apply_edit` row's op-enum description to mention the new ops:
+
+```markdown
+| `apply_edit` | Patch source from an `ElementInfo` selector or a `component` payload. Closed op enum: `replace-text`, `replace-attr`, `replace-image-src`, `edit-style`, `apply-instruction`, the Component Editor ops, and the WYSIWYG block-editor ops `insertBlock`/`moveBlock`/`deleteBlock`/`setProp`/`editText`/`setDesignToken` — every block-editor op returns a computed `inverse` for host-side undo. Supports `dry_run`; responses are `edit-applied` / `edit-failed` (`server/apply-edit-schema.mjs`, `apply-edit-dispatcher.mjs`) |
+```
+
+- [ ] **Step 2: Document `blocks.manifest.json` briefly under "MCP server & the Anglesite-app host"**
+
+Add one paragraph noting the file's purpose, location (project root), and that it's optional
+(absent = no registered blocks), linking to `server/block-manifest-schema.mjs` as the source of
+truth for its shape — mirroring how the existing section documents `content-types.mjs`.
+
+- [ ] **Step 3: Run the manual testing snippet from `CLAUDE.md`'s "Testing changes manually" section**
+
+Follow that section's existing instructions (spawn the server, send `initialize` +
+`tools/call`), substituting `get_page_model` and one `apply_edit` block-op call, to confirm the
+documented example actually works end-to-end before committing the doc change.
+
+- [ ] **Step 4: Bump the version**
+
+```bash
+npx tsx bin/release.ts minor
+```
+
+Confirm it updated all three manifest files and created the `v*` git tag as `CLAUDE.md`'s Version
+management section describes. **Do not push the tag** — that triggers the CI release workflow;
+leave that decision to whoever merges the PR.
+
+- [ ] **Step 5: Commit the docs (separately from the version bump, which `release.ts` already
+  committed/tagged on its own)**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: document get_page_model and the WYSIWYG block-editor ops"
+```
+
+---
+
+## Self-Review Notes (from the writing-plans skill's required pass)
+
+- **Spec coverage:** §3.2's op vocabulary (Task 4/6/7) ✓, invertibility hard requirement (Tasks
+  4/5/6/7) ✓, `get_page_model`/host↔engine model shape (Task 3) ✓, content-hash versioning
+  (reused `fileVersion` throughout, unchanged) ✓, theme block manifest as a CEM superset (Task 2)
+  ✓, `custom-element` as a first-class block kind (§4.1) — **not covered**: this plan's manifest
+  schema's `kind: "custom-element"` enum value is accepted by the schema (Task 2) but no resolver
+  in Tasks 4/6/7 handles a custom-element block's insert/move/delete/prop differently from an
+  Astro component's; flagged as an explicit follow-up rather than silently assumed identical,
+  since the spec calls out real differences (shadow DOM piercing, `part()`/custom-property
+  theming) that this slice's `.astro`-only resolvers don't address. Golden round-trip tests
+  (spec §10) ✓ (Task 8, with one documented gap via `.todo`, not silence).
+- **Placeholder scan:** no TODO/TBD strings outside the one explicit, justified `it.todo` in
+  Task 8 (which documents a real, named gap rather than deferring unwritten logic).
+- **Type consistency:** `PageModel`/`PageNode`/`BlockDescriptor` (Task 3) are consumed unchanged
+  by Task 4's `insertBlock` manifest resolution (`BlockManifestModule` fields `path`/`export`/
+  `name` match `indexManifestByPath`/`indexManifestByName`'s Task 2 definitions). `RichTextRun`
+  (Task 4 Step 3's schema addition) matches Task 6's `resolveTextRuns` payload exactly. `inverse`
+  is `{op, component}` consistently across Tasks 4/6/7 (never a bare op string or a different
+  shape per resolver).

--- a/server/apply-edit-dispatcher.mjs
+++ b/server/apply-edit-dispatcher.mjs
@@ -338,13 +338,20 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
     return failed(edit.id, "write-failed", `read ${file}: ${err.message}`);
   }
 
-  // Component ops resolve via an async parser (component-style-edit.mjs's /
-  // component-structure-edit.mjs's / text-run-edit.mjs's `await parse(...)`), which opens a real yield point
-  // between that resolver's own baseVersion check and this second, independent read. A
-  // concurrent edit landing in that window would otherwise splice this call's now-stale
-  // byte offsets into the other call's already-written content — re-validate the hash
-  // against this fresh read, immediately before splicing, to close the gap.
-  if (COMPONENT_OPS.has(edit.op) && fileVersion(source) !== edit.component.baseVersion) {
+  // This `source` read is a second, independent read from whatever the resolver itself read to
+  // compute `range`/`replacement` — the two are separated by at least one microtask tick (the
+  // `await resolveEdit(...)` above), which is a real gap a concurrent write can land in even
+  // when the resolver's own internal work is fully synchronous (e.g. setDesignToken's css-tree
+  // parse — no `await` inside it doesn't mean no yield point *around* it: `await`ing a resolved
+  // promise still suspends this function back to its caller for one microtask turn). Component
+  // ops (component-style-edit.mjs's / component-structure-edit.mjs's / text-run-edit.mjs's own
+  // `await parse(...)`) have an additional, longer yield point inside the resolver itself, but
+  // that's not what makes this check necessary — the outer gap alone is enough. Gate on carrying
+  // a `component.baseVersion` at all (not just `COMPONENT_OPS` membership) so any current or
+  // future resolver that stakes a claim on a specific file version — component ops today,
+  // setDesignToken since it targets global.css via the same `component` shape — gets the same
+  // re-validation against this fresh read, immediately before splicing, closing the gap.
+  if (edit.component?.baseVersion != null && fileVersion(source) !== edit.component.baseVersion) {
     return failed(edit.id, "stale", `${file} changed since the model was fetched`);
   }
 

--- a/server/apply-edit-dispatcher.mjs
+++ b/server/apply-edit-dispatcher.mjs
@@ -339,7 +339,7 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
   }
 
   // Component ops resolve via an async parser (component-style-edit.mjs's /
-  // component-structure-edit.mjs's `await parse(...)`), which opens a real yield point
+  // component-structure-edit.mjs's / text-run-edit.mjs's `await parse(...)`), which opens a real yield point
   // between that resolver's own baseVersion check and this second, independent read. A
   // concurrent edit landing in that window would otherwise splice this call's now-stale
   // byte offsets into the other call's already-written content — re-validate the hash

--- a/server/apply-edit-dispatcher.mjs
+++ b/server/apply-edit-dispatcher.mjs
@@ -50,8 +50,8 @@ function failed(id, reason, detail) {
   return { content: [createEditFailedContent(id, reason, detail)], isError: true };
 }
 
-function applied(id, file, range, commit, result, model, newFile) {
-  return { content: [createEditAppliedContent(id, file, range, commit, result, model, newFile)] };
+function applied(id, file, range, commit, result, model, newFile, inverse) {
+  return { content: [createEditAppliedContent(id, file, range, commit, result, model, newFile, inverse)] };
 }
 
 /** Splice `replacement` into `source` at the resolved byte range. */
@@ -381,6 +381,19 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
     }
   }
 
+  // Some component-structure resolvers (insertBlock/moveBlock/deleteBlock/setProp) attach an
+  // `inverse: {op, component}` counter-edit, deliberately unstamped — the inverse targets
+  // whatever this write's post-write content hash turns out to be, which isn't knowable until
+  // the write actually happens (see component-structure-edit.mjs). Stamp it now, reusing `next`
+  // (the exact bytes atomicWrite just put on disk) rather than re-reading the file.
+  let inverse;
+  if (resolution.inverse) {
+    inverse = {
+      ...resolution.inverse,
+      component: { ...resolution.inverse.component, baseVersion: fileVersion(next) },
+    };
+  }
+
   return applied(
     edit.id,
     file,
@@ -388,5 +401,7 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
     commit,
     imageResult ? { src: imageResult.src, srcset: imageResult.srcset } : undefined,
     model,
+    undefined,
+    inverse,
   );
 }

--- a/server/apply-edit-schema.mjs
+++ b/server/apply-edit-schema.mjs
@@ -238,13 +238,18 @@ export function createEditFailedContent(id, reason, detail) {
  *  the app never needs a second round-trip to `get_component_model` after a write. `newFile` is
  *  additive (extract-component only): the project-relative path of the brand-new component file
  *  the op created, alongside `file`/`range` which still describe the SOURCE file's own edit —
- *  every other op's reply shape is unchanged by this field's addition. */
-export function createEditAppliedContent(id, file, range, commit, result, model, newFile) {
+ *  every other op's reply shape is unchanged by this field's addition. `inverse` is the
+ *  computed `{op, component}` counter-edit some component-structure ops (insertBlock/moveBlock/
+ *  deleteBlock/setProp) attach — `component.baseVersion` is stamped with the POST-write content
+ *  hash by the dispatcher (it can't be known until the write actually happens), so this field is
+ *  ready to send straight back through `apply_edit` unmodified for undo. */
+export function createEditAppliedContent(id, file, range, commit, result, model, newFile, inverse) {
   const body = { type: "anglesite:edit-applied", id, file, range };
   if (commit !== undefined) body.commit = commit;
   if (result !== undefined) body.result = result;
   if (model !== undefined) body.model = model;
   if (newFile !== undefined) body.newFile = newFile;
+  if (inverse !== undefined) body.inverse = inverse;
   return { type: "text", text: JSON.stringify(body) };
 }
 

--- a/server/apply-edit-schema.mjs
+++ b/server/apply-edit-schema.mjs
@@ -108,6 +108,14 @@ export const COMPONENT_EXTRACT_OPS = new Set(["extract-component"]);
  *  reasoning as COMPONENT_EXTRACT_OPS above. */
 export const COMPONENT_TEXT_OPS = new Set(["editText"]);
 
+/** `setDesignToken` alone — it edits the theme's global stylesheet via `component`, not a
+ *  specific .astro component's template/style/frontmatter, so it's deliberately its own Set
+ *  rather than folded into COMPONENT_OPS below (it gets no post-apply `model` refetch — there's
+ *  no single component to refetch a model for). Kept as a named Set (matching every sibling op
+ *  group's dispatch-by-Set pattern above) rather than a bare `edit.op === "setDesignToken"`
+ *  string check in patcher.mjs, purely for consistency — no behavior change. */
+export const DESIGN_TOKEN_OPS = new Set(["setDesignToken"]);
+
 /** Union of style, structure, frontmatter, extract, and text-run component ops — used by the
  *  dispatcher's shared checks (payload presence, baseVersion re-check, model refetch). */
 export const COMPONENT_OPS = new Set([
@@ -208,12 +216,12 @@ export const applyEditInputShape = {
   component: componentEditSchema
     .optional()
     .describe(
-      "Structured component-style edit payload for set-style-property/remove-style-property/add-style-rule/set-rule-selector",
+      "Structured payload for every op that targets a component/page template or its scoped style rather than a page element via `selector`: set-style-property/remove-style-property/add-style-rule/set-rule-selector (component-style ops), insert-node/move-node/remove-node/set-attr and their WYSIWYG block-editor aliases insertBlock/moveBlock/deleteBlock/setProp (component-structure ops — see node/parentId/index/nodeId/newParentId/newIndex/name/value/manifestBlock), editText (rich-text run editing via textNodeId/runs), setDesignToken (global CSS custom-property editing via token/tokenValue), set-props-interface/set-script-zone (component-frontmatter ops), and extract-component (nodeId + newName)",
     ),
   op: z
     .enum(editOps)
     .describe(
-      "Edit operation: replace-text (innerText), replace-attr (value is {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>), apply-instruction (reserved: sent only by the Anglesite-app Foundation Models chat path; always returns edit-failed/needs-agent — do not use from external callers), set-style-property/remove-style-property/add-style-rule/set-rule-selector (component-style ops), insert-node/move-node/remove-node/set-attr (component-structure ops), set-props-interface/set-script-zone (component-frontmatter ops), extract-component (nodeId + newName — writes a new src/components/<newName>.astro from the selected subtree, hoists obvious literal props, and replaces the selection in the source file with an instance + import — see componentEditSchema)",
+      "Edit operation: replace-text (innerText), replace-attr (value is {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>), apply-instruction (reserved: sent only by the Anglesite-app Foundation Models chat path; always returns edit-failed/needs-agent — do not use from external callers), set-style-property/remove-style-property/add-style-rule/set-rule-selector (component-style ops), insert-node/move-node/remove-node/set-attr (component-structure ops), set-props-interface/set-script-zone (component-frontmatter ops), extract-component (nodeId + newName — writes a new src/components/<newName>.astro from the selected subtree, hoists obvious literal props, and replaces the selection in the source file with an instance + import — see componentEditSchema), and the WYSIWYG block-editor ops (same component-structure/text/style-token machinery, protocol-facing vocabulary, each returning a computed `inverse` for host-side undo): insertBlock (component.node or component.manifestBlock + parentId/index — insert a new element/component/slot/raw-markup node, or a blocks.manifest.json-registered block, as a child), moveBlock (component.nodeId + newParentId/newIndex — reparent/reorder an existing node), deleteBlock (component.nodeId — remove a node and its subtree), setProp (component.nodeId/name/value — set or, with value null, remove an attribute), editText (component.textNodeId/runs — replace an element/component/slot's inner content with re-serialized rich-text runs), setDesignToken (component.token/tokenValue — edit a global CSS custom property)",
     ),
   value: z
     .unknown()

--- a/server/apply-edit-schema.mjs
+++ b/server/apply-edit-schema.mjs
@@ -56,6 +56,12 @@ export const editOps = [
   "move-node",
   "remove-node",
   "set-attr",
+  "insertBlock",
+  "moveBlock",
+  "deleteBlock",
+  "setProp",
+  "editText",
+  "setDesignToken",
   "set-props-interface",
   "set-script-zone",
   "extract-component",
@@ -72,8 +78,16 @@ export const COMPONENT_STYLE_OPS = new Set([
 ]);
 
 /** The subset of `editOps` that operate on a component's template structure (DOM nodes)
- *  via `component` rather than on a page element via `selector`. */
-export const COMPONENT_STRUCTURE_OPS = new Set(["insert-node", "move-node", "remove-node", "set-attr"]);
+ *  via `component` rather than on a page element via `selector`. `insertBlock`/`moveBlock`/
+ *  `deleteBlock`/`setProp` are protocol-facing aliases for the identical insert-node/move-node/
+ *  remove-node/set-attr dispatch (see `resolveComponentStructure` in
+ *  component-structure-edit.mjs) — the WYSIWYG ops-protocol vocabulary (spec
+ *  2026-08-03-modern-wysiwyg-editor-design.md §3.2) targeting the exact same span-resolution
+ *  machinery, now with a computed inverse attached. */
+export const COMPONENT_STRUCTURE_OPS = new Set([
+  "insert-node", "move-node", "remove-node", "set-attr",
+  "insertBlock", "moveBlock", "deleteBlock", "setProp",
+]);
 
 /** The subset of `editOps` that codegen/replace a component's frontmatter or client-script
  *  zone via `component` — the Props form and STTextView code-pane saves. */
@@ -122,13 +136,25 @@ export const componentEditSchema = z.object({
   newIndex: z.number().int().optional().describe("Destination child index for move-node"),
   node: z
     .object({
-      kind: z.enum(["element", "component", "slot"]),
-      tag: z.string().optional().describe("HTML tag name (element) or component name (component); omitted for slot"),
+      kind: z.enum(["element", "component", "slot", "raw"]),
+      tag: z.string().optional().describe("HTML tag name (element) or component name (component); omitted for slot/raw"),
       componentPath: z.string().optional().describe("Project-relative .astro path to import, required when kind=component"),
       slotName: z.string().optional().describe("Named slot, for kind=slot; omitted means the default slot"),
+      markup: z.string().optional().describe("Verbatim source markup to splice in as-is, required when kind=raw — used by deleteBlock's computed inverse to reconstruct an exact removed subtree"),
     })
     .optional()
-    .describe("New node spec for insert-node"),
+    .describe("New node spec for insert-node/insertBlock"),
+  manifestBlock: z
+    .string()
+    .optional()
+    .describe("Owner-facing block-manifest name for insertBlock (e.g. \"Business Card\") — resolved server-side to {tag, componentPath} via blocks.manifest.json instead of the caller supplying them directly. Mutually exclusive with node.tag/node.componentPath."),
+  textNodeId: z.string().optional().describe("Target node id for editText — must be an element/component node (get_page_model's block-annotated tree)"),
+  runs: z
+    .array(z.object({ text: z.string(), marks: z.array(z.enum(["strong", "em", "code"])).default([]), href: z.string().optional() }))
+    .optional()
+    .describe("Replacement rich-text runs for editText — see text-run-edit.mjs"),
+  token: z.string().optional().describe("CSS custom-property name for setDesignToken, e.g. --color-primary (no --var()/calc() wrapping)"),
+  tokenValue: z.string().optional().describe("New value for setDesignToken"),
   props: z
     .array(
       z.object({

--- a/server/apply-edit-schema.mjs
+++ b/server/apply-edit-schema.mjs
@@ -101,13 +101,21 @@ export const COMPONENT_FRONTMATTER_OPS = new Set(["set-props-interface", "set-sc
  *  `resolution.extract` branch). */
 export const COMPONENT_EXTRACT_OPS = new Set(["extract-component"]);
 
-/** Union of style, structure, frontmatter, and extract component ops — used by the dispatcher's
- *  shared checks (payload presence, baseVersion re-check, model refetch). */
+/** The subset of `editOps` that replaces an element's inner content with re-serialized
+ *  rich-text runs via `component` — currently just `editText` (the WYSIWYG block editor's
+ *  in-canvas text editing, see `text-run-edit.mjs`). Its own Set (rather than folding into
+ *  COMPONENT_STRUCTURE_OPS) because it's dispatched to a different resolver module, same
+ *  reasoning as COMPONENT_EXTRACT_OPS above. */
+export const COMPONENT_TEXT_OPS = new Set(["editText"]);
+
+/** Union of style, structure, frontmatter, extract, and text-run component ops — used by the
+ *  dispatcher's shared checks (payload presence, baseVersion re-check, model refetch). */
 export const COMPONENT_OPS = new Set([
   ...COMPONENT_STYLE_OPS,
   ...COMPONENT_STRUCTURE_OPS,
   ...COMPONENT_FRONTMATTER_OPS,
   ...COMPONENT_EXTRACT_OPS,
+  ...COMPONENT_TEXT_OPS,
 ]);
 
 /** Structured payload for the four component-style ops. Identifies the target rule by its exact

--- a/server/block-manifest-schema.mjs
+++ b/server/block-manifest-schema.mjs
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+export const propEditorKinds = ["text", "richtext", "image", "boolean", "number", "select", "color", "array"];
+
+const blockManifestModuleSchema = z.object({
+  path: z.string().describe("Project-relative component path, e.g. src/components/Hcard.astro"),
+  export: z.string().describe("Default export name as imported, e.g. Hcard"),
+  kind: z.enum(["astro", "custom-element"]).default("astro"),
+  name: z.string().describe("Owner-facing block name shown in the Insert menu/palette"),
+  description: z.string().default(""),
+  icon: z.string().nullable().default(null),
+  propEditors: z
+    .array(
+      z.object({
+        prop: z.string(),
+        editor: z.enum(propEditorKinds),
+        options: z.array(z.string()).optional(),
+      }),
+    )
+    .default([]),
+  slots: z.array(z.string()).default([]),
+  placement: z.object({ allowedParents: z.array(z.string()).nullable().default(null) }).default({ allowedParents: null }),
+});
+
+export const blockManifestSchema = z.object({
+  schemaVersion: z.literal("anglesite-block-manifest/1"),
+  readme: z.string().optional(),
+  modules: z.array(blockManifestModuleSchema),
+});

--- a/server/block-manifest.mjs
+++ b/server/block-manifest.mjs
@@ -1,0 +1,42 @@
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { blockManifestSchema } from "./block-manifest-schema.mjs";
+
+export class BlockManifestError extends Error {
+  constructor(reason, message) {
+    super(message);
+    this.reason = reason;
+  }
+}
+
+const MANIFEST_FILENAME = "blocks.manifest.json";
+
+/** Loads and validates the theme's block manifest from the project root. A missing file is
+ *  valid (empty manifest) — every component in the page tree simply stays unregistered rather
+ *  than failing get_page_model. A present-but-invalid file throws. */
+export function loadBlockManifest(projectRoot) {
+  const absPath = join(projectRoot, MANIFEST_FILENAME);
+  if (!existsSync(absPath)) return { schemaVersion: "anglesite-block-manifest/1", modules: [] };
+  let raw;
+  try {
+    raw = JSON.parse(readFileSync(absPath, "utf-8"));
+  } catch (err) {
+    throw new BlockManifestError("parse-failed", `parse ${MANIFEST_FILENAME}: ${err.message}`);
+  }
+  const parsed = blockManifestSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new BlockManifestError(
+      "invalid-manifest",
+      parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "),
+    );
+  }
+  return parsed.data;
+}
+
+export function indexManifestByPath(manifest) {
+  return new Map(manifest.modules.map((m) => [m.path, m]));
+}
+
+export function indexManifestByName(manifest) {
+  return new Map(manifest.modules.map((m) => [m.name, m]));
+}

--- a/server/component-model.mjs
+++ b/server/component-model.mjs
@@ -7,7 +7,7 @@ import { parse } from "@astrojs/compiler";
 import { parseProps } from "./props-interface.mjs";
 import { fileVersion } from "./file-version.mjs";
 import { indexCssRules } from "./css-rule-index.mjs";
-import { buildTemplateNodeIndex, buildLineStarts, offsetFromLineColumn } from "./component-node-index.mjs";
+import { buildTemplateNodeIndex, buildLineStarts, offsetFromLineColumn, toPublicNode } from "./component-node-index.mjs";
 
 export class ComponentModelError extends Error {
   constructor(reason, message) {
@@ -100,17 +100,3 @@ function extractRules(styleElement, lineStarts) {
   }));
 }
 
-function toPublicNode(byId, id) {
-  const r = byId.get(id);
-  const node = {
-    id: r.id,
-    kind: r.kind,
-    tag: r.tag,
-    attrs: r.attrs.map(({ name, value }) => ({ name, value })),
-    span: r.span,
-    loc: r.loc,
-    children: r.childIds.map((cid) => toPublicNode(byId, cid)),
-  };
-  if (r.text !== undefined) node.text = r.text;
-  return node;
-}

--- a/server/component-node-index.mjs
+++ b/server/component-node-index.mjs
@@ -188,3 +188,20 @@ export function buildTemplateNodeIndex(ast, source) {
 
   return { byId, rootId };
 }
+
+/** Projects one indexed node (and its subtree) into the public TemplateNode shape returned by
+ *  get_component_model / get_page_model. Shared so both read paths serialize identically. */
+export function toPublicNode(byId, id) {
+  const r = byId.get(id);
+  const node = {
+    id: r.id,
+    kind: r.kind,
+    tag: r.tag,
+    attrs: r.attrs.map(({ name, value }) => ({ name, value })),
+    span: r.span,
+    loc: r.loc,
+    children: r.childIds.map((cid) => toPublicNode(byId, cid)),
+  };
+  if (r.text !== undefined) node.text = r.text;
+  return node;
+}

--- a/server/component-structure-edit.mjs
+++ b/server/component-structure-edit.mjs
@@ -4,6 +4,7 @@ import { parse } from "@astrojs/compiler";
 import { fileVersion } from "./file-version.mjs";
 import { buildTemplateNodeIndex } from "./component-node-index.mjs";
 import { ensureImport, pruneImportIfUnused } from "./frontmatter-imports.mjs";
+import { loadBlockManifest, indexManifestByName } from "./block-manifest.mjs";
 
 // `resolveAllSpans`/`SpanResolutionError`/`VOID_ELEMENTS`/`escapeAttr`/`importSpecifier`/
 // `collectComponentTags` are exported (in addition to being used locally) so
@@ -67,13 +68,32 @@ export async function resolveComponentStructure(projectRoot, edit) {
 
   switch (edit.op) {
     case "set-attr":
+    case "setProp":
       return applySetAttr(relPath, source, byId, component);
     case "remove-node":
+    case "deleteBlock":
       return applyRemoveNode(relPath, source, byId, rootId, component);
     case "insert-node":
-      return applyInsertNode(relPath, source, byId, rootId, component);
+    case "insertBlock": {
+      let effectiveComponent = component;
+      if (component.manifestBlock) {
+        const manifest = loadBlockManifest(projectRoot);
+        const entry = indexManifestByName(manifest).get(component.manifestBlock);
+        if (!entry) return refuse("no-match", `no block named "${component.manifestBlock}" in blocks.manifest.json`);
+        effectiveComponent = {
+          ...component,
+          node: { kind: "component", tag: entry.export, componentPath: entry.path, slotName: component.node?.slotName },
+        };
+      }
+      const result = applyInsertNode(relPath, source, byId, rootId, effectiveComponent);
+      if (result.refused) return result;
+      const { __insertAt, __final, ...rest } = result;
+      const inverse = await computeInsertInverse(relPath, __final, __insertAt);
+      return inverse ? { ...rest, inverse } : rest;
+    }
     case "move-node":
-      return applyMoveNode(relPath, source, byId, rootId, component);
+    case "moveBlock":
+      return await applyMoveNode(relPath, source, byId, rootId, component);
     default:
       return refuse("invalid-input", `unsupported component-structure op: ${edit.op}`);
   }
@@ -97,6 +117,9 @@ function applySetAttr(file, source, byId, component) {
     return refuse("invalid-input", `set-attr requires a tag-shaped node (element/component/slot), got kind=${node.kind}`);
   }
   const existing = node.attrs.find((a) => a.name === name);
+  // Inverse restores the pre-edit value: whatever setProp is about to overwrite/remove, or
+  // `null` (meaning "remove it") when the attribute didn't exist before this edit at all.
+  const inverse = { op: "setProp", component: { path: file, nodeId, name, value: existing ? existing.value : null } };
 
   if (value === null || value === undefined) {
     if (!existing) return refuse("no-match", `node has no attribute "${name}" to remove`);
@@ -108,11 +131,11 @@ function applySetAttr(file, source, byId, component) {
     let start = existing.span[0];
     while (start > 0 && (source[start - 1] === " " || source[start - 1] === "\t")) start--;
     if (start > 0 && source[start - 1] === "\n") start--;
-    return { file, range: { start, end: existing.span[1] }, replacement: "" };
+    return { file, range: { start, end: existing.span[1] }, replacement: "", inverse };
   }
 
   if (existing) {
-    return { file, range: { start: existing.span[0], end: existing.span[1] }, replacement: `${name}="${escapeAttr(value)}"` };
+    return { file, range: { start: existing.span[0], end: existing.span[1] }, replacement: `${name}="${escapeAttr(value)}"`, inverse };
   }
   // Insert right after the opening tag name / last attribute — i.e. at the end of the node's
   // own attribute list. `node.span[0]` is the start of `<tag`; the tag-name end is the offset
@@ -120,7 +143,7 @@ function applySetAttr(file, source, byId, component) {
   // attribute's end when present; otherwise fall back to just after the tag name.
   const lastAttr = node.attrs[node.attrs.length - 1];
   const insertAt = lastAttr ? lastAttr.span[1] : node.span[0] + 1 + (node.tag?.length ?? 0);
-  return { file, range: { start: insertAt, end: insertAt }, replacement: ` ${name}="${escapeAttr(value)}"` };
+  return { file, range: { start: insertAt, end: insertAt }, replacement: ` ${name}="${escapeAttr(value)}"`, inverse };
 }
 
 // @astrojs/compiler (4.0.0) reports CORRUPTED source positions for ANY node kind —
@@ -441,6 +464,18 @@ function applyRemoveNode(file, source, byId, rootId, component) {
     );
   }
 
+  const parent = byId.get(node.parentId);
+  const removedIndex = parent.childIds.indexOf(nodeId);
+  // deleteBlock's inverse deliberately does NOT re-add a pruned component import — if the
+  // removed subtree was the last usage of a component, its raw markup on reinsertion won't
+  // have a matching import either. Known v1 gap; round-tripping such a delete needs the
+  // reinserted raw markup's tag re-detected and its import re-added, which duplicates
+  // applyInsertNode's component-import logic against a raw blob. Out of scope for this slice.
+  const inverse = {
+    op: "insertBlock",
+    component: { path: file, parentId: node.parentId, index: removedIndex, node: { kind: "raw", markup: source.slice(span[0], span[1]) } },
+  };
+
   // Trim a single leading run of horizontal whitespace back to (but not past) a preceding
   // newline, then swallow that newline too — mirrors remove-style-property's cleanup so
   // removing a node doesn't leave a blank line in its place.
@@ -456,12 +491,12 @@ function applyRemoveNode(file, source, byId, rootId, component) {
   // list against the POST-removal template text.
   const removedComponentNames = collectComponentTags(byId, nodeId);
   if (removedComponentNames.length === 0) {
-    return { file, range: { start: 0, end: source.length }, replacement: withoutNode };
+    return { file, range: { start: 0, end: source.length }, replacement: withoutNode, inverse };
   }
 
   const fmMatch = withoutNode.match(/^(---\r?\n)([\s\S]*?)(\r?\n---)/);
   if (!fmMatch) {
-    return { file, range: { start: 0, end: source.length }, replacement: withoutNode };
+    return { file, range: { start: 0, end: source.length }, replacement: withoutNode, inverse };
   }
   const [whole, open, fmBody, close] = fmMatch;
   const fmStart = fmMatch.index;
@@ -471,7 +506,7 @@ function applyRemoveNode(file, source, byId, rootId, component) {
     newFmBody = pruneImportIfUnused(newFmBody, withoutNode.slice(fmStart + whole.length), name).source;
   }
   const rewritten = withoutNode.slice(0, fmBodyStart) + newFmBody + withoutNode.slice(fmBodyStart + fmBody.length);
-  return { file, range: { start: 0, end: source.length }, replacement: rewritten };
+  return { file, range: { start: 0, end: source.length }, replacement: rewritten, inverse };
 }
 
 export function collectComponentTags(byId, nodeId) {
@@ -487,6 +522,7 @@ export function collectComponentTags(byId, nodeId) {
 }
 
 function buildMarkup(nodeSpec) {
+  if (nodeSpec.kind === "raw") return nodeSpec.markup;
   if (nodeSpec.kind === "slot") {
     return nodeSpec.slotName ? `<slot name="${escapeAttr(nodeSpec.slotName)}" />` : `<slot />`;
   }
@@ -573,7 +609,7 @@ function applyInsertNode(file, source, byId, rootId, component) {
   if (typeof parentId !== "string" || typeof index !== "number" || !nodeSpec || typeof nodeSpec !== "object") {
     return refuse("invalid-input", "insert-node requires component.parentId, component.index, and component.node");
   }
-  if (!["element", "component", "slot"].includes(nodeSpec.kind)) {
+  if (!["element", "component", "slot", "raw"].includes(nodeSpec.kind)) {
     return refuse("invalid-input", `unsupported node.kind: ${nodeSpec.kind}`);
   }
   if ((nodeSpec.kind === "element" || nodeSpec.kind === "component") && typeof nodeSpec.tag !== "string") {
@@ -581,6 +617,9 @@ function applyInsertNode(file, source, byId, rootId, component) {
   }
   if (nodeSpec.kind === "component" && typeof nodeSpec.componentPath !== "string") {
     return refuse("invalid-input", "node.componentPath is required for component inserts");
+  }
+  if (nodeSpec.kind === "raw" && typeof nodeSpec.markup !== "string") {
+    return refuse("invalid-input", "node.markup is required for raw inserts");
   }
 
   const parent = byId.get(parentId);
@@ -613,7 +652,7 @@ function applyInsertNode(file, source, byId, rootId, component) {
   const withNode = source.slice(0, insertAt) + markup + source.slice(insertAt);
 
   if (nodeSpec.kind !== "component") {
-    return { file, range: { start: 0, end: source.length }, replacement: withNode };
+    return { file, range: { start: 0, end: source.length }, replacement: withNode, __insertAt: insertAt, __final: withNode };
   }
 
   // Component insert: also add (or reuse) its default import in the frontmatter.
@@ -621,13 +660,40 @@ function applyInsertNode(file, source, byId, rootId, component) {
   if (!fmMatch) {
     // No frontmatter at all yet — synthesize one carrying just the import.
     const importLine = `import ${nodeSpec.tag} from "${importSpecifier(file, nodeSpec.componentPath)}";\n`;
-    return { file, range: { start: 0, end: source.length }, replacement: `---\n${importLine}---\n${withNode}` };
+    const rewritten = `---\n${importLine}---\n${withNode}`;
+    return { file, range: { start: 0, end: source.length }, replacement: rewritten, __insertAt: insertAt + `---\n${importLine}---\n`.length, __final: rewritten };
   }
   const [, open, fmBody] = fmMatch;
   const fmBodyStart = fmMatch.index + open.length;
-  const { source: newFmBody } = ensureImport(fmBody, { localName: nodeSpec.tag, specifier: importSpecifier(file, nodeSpec.componentPath) });
+  const { source: newFmBody, added } = ensureImport(fmBody, { localName: nodeSpec.tag, specifier: importSpecifier(file, nodeSpec.componentPath) });
   const rewritten = withNode.slice(0, fmBodyStart) + newFmBody + withNode.slice(fmBodyStart + fmBody.length);
-  return { file, range: { start: 0, end: source.length }, replacement: rewritten };
+  const importShift = added ? newFmBody.length - fmBody.length : 0;
+  return { file, range: { start: 0, end: source.length }, replacement: rewritten, __insertAt: insertAt + importShift, __final: rewritten };
+}
+
+// After applyInsertNode builds the final source (`finalSource`), computes insertBlock's inverse
+// by re-parsing that final source fresh and locating the newly inserted node's POST-edit id —
+// found by matching `insertAtInFinalSource` (the insertion offset, corrected for any
+// frontmatter growth from a newly-added import) against `resolveAllSpans`' freshly resolved
+// span starts. Same "resolve identity via resolveAllSpans over the fresh parse, never via id
+// reuse" discipline as everywhere else in this file — the inserted node's `byId`-assigned id
+// from the ORIGINAL parse is meaningless post-edit (the tree changed), so its true id has to be
+// rediscovered the same lexical way every other span in this module is.
+async function computeInsertInverse(file, finalSource, insertAtInFinalSource) {
+  const { ast } = await parse(finalSource, { position: true });
+  const { byId: newById, rootId: newRootId } = buildTemplateNodeIndex(ast, finalSource);
+  let newSpans;
+  try {
+    newSpans = resolveAllSpans(newById, newRootId, finalSource);
+  } catch {
+    return null; // best-effort: if relocation fails, ship no inverse rather than a wrong one
+  }
+  for (const [id, span] of newSpans) {
+    if (span[0] === insertAtInFinalSource) {
+      return { op: "deleteBlock", component: { path: file, nodeId: id } };
+    }
+  }
+  return null;
 }
 
 // True if `nodeId` is a descendant of `ancestorId`, walking `byId`'s `parentId` chain
@@ -668,7 +734,7 @@ function isDescendant(byId, ancestorId, nodeId) {
 // the very span being removed; the ancestor check earlier already rules out the structural
 // case that would cause this (moving into your own subtree), but it's guarded again below
 // as a fail-closed check rather than assumed.
-function applyMoveNode(file, source, byId, rootId, component) {
+async function applyMoveNode(file, source, byId, rootId, component) {
   const { nodeId, newParentId, newIndex } = component;
   if (typeof nodeId !== "string" || typeof newParentId !== "string" || typeof newIndex !== "number") {
     return refuse("invalid-input", "move-node requires component.nodeId, component.newParentId, and component.newIndex");
@@ -724,10 +790,71 @@ function applyMoveNode(file, source, byId, rootId, component) {
     return refuse("invalid-input", "insertion point falls inside the node's own span being moved");
   }
 
-  const rewritten =
-    insertAt <= removeStart
-      ? source.slice(0, insertAt) + nodeText + source.slice(insertAt, removeStart) + source.slice(removeEnd)
-      : source.slice(0, removeStart) + source.slice(removeEnd, insertAt) + nodeText + source.slice(insertAt);
+  const movingBeforeRemoval = insertAt <= removeStart;
+  const rewritten = movingBeforeRemoval
+    ? source.slice(0, insertAt) + nodeText + source.slice(insertAt, removeStart) + source.slice(removeEnd)
+    : source.slice(0, removeStart) + source.slice(removeEnd, insertAt) + nodeText + source.slice(insertAt);
 
-  return { file, range: { start: 0, end: source.length }, replacement: rewritten };
+  // moveBlock's inverse moves the node back to its ORIGINAL parent/index. The moved node's own
+  // new (post-move) location in `rewritten` is exactly `insertAt` in the movingBeforeRemoval
+  // case (it's spliced in first, right where P1 ends) or `removeStart + (insertAt - removeEnd)`
+  // otherwise (P1 is source[0:removeStart], then the removeEnd..insertAt carry-over segment,
+  // THEN nodeText) — same two-case splice arithmetic `applyMoveNode`'s own doc comment above
+  // describes, just solved for "where does this offset land" instead of "how do I build the
+  // string". The original parent's own span-start offset maps through the identical two cases:
+  // unchanged if it precedes the insertion point, shifted forward by nodeText's length if the
+  // splice's insertion happens before it (only possible in the movingBeforeRemoval case, since
+  // a parent always starts strictly before its own child's — and therefore removeStart's —
+  // offset, so it can never itself land inside the removed range or after removeEnd).
+  const originalParent = byId.get(node.parentId);
+  const originalIndex = originalParent.childIds.indexOf(nodeId);
+  const movedNodeOffsetInFinal = movingBeforeRemoval ? insertAt : removeStart + (insertAt - removeEnd);
+  let originParentOffsetInFinal; // null sentinel means "the fragment root — reuse newRootId directly"
+  if (originalParent.id === rootId) {
+    // The fragment root has no lexical span to re-locate (resolveAllSpans never spans it) but
+    // its id is always deterministically the first one assigned by buildTemplateNodeIndex's
+    // counter (i.e. always "n0"), so a fresh re-parse's rootId is directly reusable — no
+    // offset-matching needed for the parent side, only for the moved node itself.
+    originParentOffsetInFinal = null;
+  } else {
+    const originalParentSpan = spans.get(node.parentId);
+    originParentOffsetInFinal = originalParentSpan
+      ? (movingBeforeRemoval
+          ? (originalParentSpan[0] < insertAt ? originalParentSpan[0] : originalParentSpan[0] + nodeText.length)
+          : originalParentSpan[0]) // always < removeStart <= insertAt in this branch — unaffected
+      : undefined; // parent's own span couldn't be resolved — no inverse rather than a guess
+  }
+  const inverse =
+    originParentOffsetInFinal === undefined
+      ? null
+      : await computeMoveInverse(file, rewritten, movedNodeOffsetInFinal, originParentOffsetInFinal, originalIndex);
+
+  const result = { file, range: { start: 0, end: source.length }, replacement: rewritten };
+  return inverse ? { ...result, inverse } : result;
+}
+
+// After applyMoveNode builds the final source (`finalSource`), computes moveBlock's inverse by
+// re-parsing that final source fresh and locating (a) the moved node's own POST-move id, via
+// `movedNodeOffsetInFinal`, and (b) the ORIGINAL parent's POST-move id, via
+// `origParentOffsetInFinal` — both matched against resolveAllSpans' freshly resolved span
+// starts, same "resolve identity via resolveAllSpans over the fresh parse, never via id reuse"
+// discipline as `computeInsertInverse`. `origParentOffsetInFinal === null` means the original
+// parent was the fragment root, whose id is reused directly (see the call site's comment).
+async function computeMoveInverse(file, finalSource, movedNodeOffsetInFinal, origParentOffsetInFinal, originalIndex) {
+  const { ast } = await parse(finalSource, { position: true });
+  const { byId: newById, rootId: newRootId } = buildTemplateNodeIndex(ast, finalSource);
+  let newSpans;
+  try {
+    newSpans = resolveAllSpans(newById, newRootId, finalSource);
+  } catch {
+    return null; // best-effort: if relocation fails, ship no inverse rather than a wrong one
+  }
+  let newNodeId = null;
+  let newParentId = origParentOffsetInFinal === null ? newRootId : null;
+  for (const [id, span] of newSpans) {
+    if (span[0] === movedNodeOffsetInFinal) newNodeId = id;
+    if (origParentOffsetInFinal !== null && span[0] === origParentOffsetInFinal) newParentId = id;
+  }
+  if (newNodeId == null || newParentId == null) return null;
+  return { op: "moveBlock", component: { path: file, nodeId: newNodeId, newParentId, newIndex: originalIndex } };
 }

--- a/server/component-structure-edit.mjs
+++ b/server/component-structure-edit.mjs
@@ -471,6 +471,20 @@ function applyRemoveNode(file, source, byId, rootId, component) {
   // have a matching import either. Known v1 gap; round-tripping such a delete needs the
   // reinserted raw markup's tag re-detected and its import re-added, which duplicates
   // applyInsertNode's component-import logic against a raw blob. Out of scope for this slice.
+  //
+  // KNOWN WHITESPACE-FIDELITY GAP (documented, not fixed — out of scope for this slice, same as
+  // the import-pruning gap above): `inverse.component.node.markup` below is captured from
+  // `span[0]`/`span[1]` only — the node's OWN exact text, not the leading indentation/newline
+  // that the trim below (`start`..`span[0]`) is about to strip from the surrounding document.
+  // Re-inserting that raw markup via insertBlock therefore restores the right node at the right
+  // parent/index, but NOT the original line break + indentation around it — e.g. removing
+  // `\n  <p id="gone">b</p>` from a multi-line, indented `<main>` and reinserting via this
+  // inverse lands the reinserted `<p>` immediately after its sibling with no newline/indent in
+  // between (structurally correct, not byte-identical to the pre-delete source). Fixing this
+  // would mean capturing and re-splicing the stripped whitespace too, which `insertBlock`'s
+  // insertion-offset logic (anchored to sibling spans, not to "was there whitespace here
+  // before") doesn't currently support. Task 8's golden round-trip tests should account for this
+  // rather than assert byte-identical restoration.
   const inverse = {
     op: "insertBlock",
     component: { path: file, parentId: node.parentId, index: removedIndex, node: { kind: "raw", markup: source.slice(span[0], span[1]) } },
@@ -478,7 +492,8 @@ function applyRemoveNode(file, source, byId, rootId, component) {
 
   // Trim a single leading run of horizontal whitespace back to (but not past) a preceding
   // newline, then swallow that newline too — mirrors remove-style-property's cleanup so
-  // removing a node doesn't leave a blank line in its place.
+  // removing a node doesn't leave a blank line in its place. NOTE: this trimmed whitespace is
+  // NOT captured by `inverse` above — see the comment there for the resulting fidelity gap.
   let start = span[0];
   while (start > 0 && (source[start - 1] === " " || source[start - 1] === "\t")) start--;
   if (start > 0 && source[start - 1] === "\n") start--;
@@ -680,20 +695,34 @@ function applyInsertNode(file, source, byId, rootId, component) {
 // from the ORIGINAL parse is meaningless post-edit (the tree changed), so its true id has to be
 // rediscovered the same lexical way every other span in this module is.
 async function computeInsertInverse(file, finalSource, insertAtInFinalSource) {
-  const { ast } = await parse(finalSource, { position: true });
-  const { byId: newById, rootId: newRootId } = buildTemplateNodeIndex(ast, finalSource);
-  let newSpans;
-  try {
-    newSpans = resolveAllSpans(newById, newRootId, finalSource);
-  } catch {
-    return null; // best-effort: if relocation fails, ship no inverse rather than a wrong one
-  }
-  for (const [id, span] of newSpans) {
+  const resolved = await reresolveSpans(finalSource);
+  if (!resolved) return null;
+  for (const [id, span] of resolved.newSpans) {
     if (span[0] === insertAtInFinalSource) {
       return { op: "deleteBlock", component: { path: file, nodeId: id } };
     }
   }
   return null;
+}
+
+// Shared by computeInsertInverse/computeMoveInverse: re-parses `finalSource` fresh and resolves
+// every node's span over it — the identity-rediscovery step both callers need (see their own
+// "resolve identity via resolveAllSpans over the fresh parse, never via id reuse" comments).
+// Returns `null` (a normal, expected outcome, not a bug) only when `resolveAllSpans` throws its
+// own documented `SpanResolutionError` — an unresolvable node in freshly-generated markup means
+// "give up, ship no inverse rather than a wrong one." Any OTHER exception is rethrown rather than
+// swallowed, matching every other `resolveAllSpans` call site in this file's fail-closed
+// discipline (see applyRemoveNode/applyInsertNode/applyMoveNode above).
+async function reresolveSpans(finalSource) {
+  const { ast } = await parse(finalSource, { position: true });
+  const { byId: newById, rootId: newRootId } = buildTemplateNodeIndex(ast, finalSource);
+  try {
+    const newSpans = resolveAllSpans(newById, newRootId, finalSource);
+    return { newById, newRootId, newSpans };
+  } catch (err) {
+    if (!(err instanceof SpanResolutionError)) throw err;
+    return null;
+  }
 }
 
 // True if `nodeId` is a descendant of `ancestorId`, walking `byId`'s `parentId` chain
@@ -781,6 +810,19 @@ async function applyMoveNode(file, source, byId, rootId, component) {
   // Same whitespace/newline cleanup remove-node uses at the node's old location: trim a
   // leading run of horizontal whitespace back to (but not past) a preceding newline, then
   // swallow that newline too, so the old location doesn't leave a blank line behind.
+  //
+  // KNOWN WHITESPACE-FIDELITY GAP (documented, not fixed — same class of gap as
+  // applyRemoveNode's inverse, see the comment above that function's own trim/`inverse`
+  // construction): `nodeText` (captured above, from `nodeSpan[0]`/`nodeSpan[1]`) is the node's
+  // OWN exact text only — it does NOT include the leading indentation/newline this trim is
+  // about to strip from the node's OLD location. moveBlock's own computed inverse is itself
+  // another `moveBlock` op (see below), which on re-invocation resolves its destination offset
+  // via the same `resolveInsertionOffset` sibling-anchored logic this call already used — that
+  // lands the node correctly (right parent, right index) but without reproducing the original
+  // line break + indentation around it, so a multi-line, indented move-then-move-back round trip
+  // is structurally correct, not necessarily byte-identical to the pre-move source. Task 8's
+  // golden round-trip tests should account for this rather than assert byte-identical
+  // restoration.
   let removeStart = nodeSpan[0];
   while (removeStart > 0 && (source[removeStart - 1] === " " || source[removeStart - 1] === "\t")) removeStart--;
   if (removeStart > 0 && source[removeStart - 1] === "\n") removeStart--;
@@ -841,14 +883,9 @@ async function applyMoveNode(file, source, byId, rootId, component) {
 // discipline as `computeInsertInverse`. `origParentOffsetInFinal === null` means the original
 // parent was the fragment root, whose id is reused directly (see the call site's comment).
 async function computeMoveInverse(file, finalSource, movedNodeOffsetInFinal, origParentOffsetInFinal, originalIndex) {
-  const { ast } = await parse(finalSource, { position: true });
-  const { byId: newById, rootId: newRootId } = buildTemplateNodeIndex(ast, finalSource);
-  let newSpans;
-  try {
-    newSpans = resolveAllSpans(newById, newRootId, finalSource);
-  } catch {
-    return null; // best-effort: if relocation fails, ship no inverse rather than a wrong one
-  }
+  const resolved = await reresolveSpans(finalSource);
+  if (!resolved) return null;
+  const { newRootId, newSpans } = resolved;
   let newNodeId = null;
   let newParentId = origParentOffsetInFinal === null ? newRootId : null;
   for (const [id, span] of newSpans) {

--- a/server/component-structure-edit.mjs
+++ b/server/component-structure-edit.mjs
@@ -4,7 +4,7 @@ import { parse } from "@astrojs/compiler";
 import { fileVersion } from "./file-version.mjs";
 import { buildTemplateNodeIndex } from "./component-node-index.mjs";
 import { ensureImport, pruneImportIfUnused } from "./frontmatter-imports.mjs";
-import { loadBlockManifest, indexManifestByName } from "./block-manifest.mjs";
+import { loadBlockManifest, indexManifestByName, BlockManifestError } from "./block-manifest.mjs";
 
 // `resolveAllSpans`/`SpanResolutionError`/`VOID_ELEMENTS`/`escapeAttr`/`importSpecifier`/
 // `collectComponentTags` are exported (in addition to being used locally) so
@@ -83,7 +83,13 @@ export async function resolveComponentStructure(projectRoot, edit) {
     case "insertBlock": {
       let effectiveComponent = component;
       if (component.manifestBlock) {
-        const manifest = loadBlockManifest(projectRoot);
+        let manifest;
+        try {
+          manifest = loadBlockManifest(projectRoot);
+        } catch (err) {
+          if (!(err instanceof BlockManifestError)) throw err;
+          return refuse(err.reason, err.message);
+        }
         const entry = indexManifestByName(manifest).get(component.manifestBlock);
         if (!entry) return refuse("no-match", `no block named "${component.manifestBlock}" in blocks.manifest.json`);
         effectiveComponent = {
@@ -95,7 +101,22 @@ export async function resolveComponentStructure(projectRoot, edit) {
       if (result.refused) return result;
       const { __insertAt, __final, ...rest } = result;
       const inverse = await computeInsertInverse(relPath, __final, __insertAt);
-      return inverse ? { ...rest, inverse } : rest;
+      if (!inverse) {
+        // `raw`-kind markup is caller-supplied and otherwise unvalidated beyond `typeof ===
+        // "string"` (componentEditSchema) — computeInsertInverse re-parses the FINAL post-insert
+        // source and only returns non-null when it finds a single well-formed node whose span
+        // starts exactly at the insertion offset. A null result for a raw insert means the
+        // caller's markup did NOT parse as one clean node there (e.g. unbalanced tags), so refuse
+        // the whole op rather than leave a written-but-unparseable file with no way to undo it.
+        // Non-raw kinds build markup this module controls itself, so a null inverse there means
+        // the fresh re-parse's span resolution merely failed for some other reason (see the
+        // shared handling below) — don't broaden this specific reason to them.
+        if (effectiveComponent.node?.kind === "raw") {
+          return refuse("invalid-input", "raw markup did not resolve to a single well-formed node at the insertion point — refusing rather than writing unparseable markup");
+        }
+        return refuse("internal-error", "could not compute insertBlock's inverse (span resolution failed on the post-insert re-parse) — refusing rather than applying an edit with no undo");
+      }
+      return { ...rest, inverse };
     }
     case "move-node":
     case "moveBlock":
@@ -877,8 +898,16 @@ async function applyMoveNode(file, source, byId, rootId, component) {
       ? null
       : await computeMoveInverse(file, rewritten, movedNodeOffsetInFinal, originParentOffsetInFinal, originalIndex);
 
-  const result = { file, range: { start: 0, end: source.length }, replacement: rewritten };
-  return inverse ? { ...result, inverse } : result;
+  // Same "refuse the whole op rather than ship a no-inverse success" discipline as insertBlock
+  // above: a null inverse here means either the original parent's own span couldn't be
+  // re-located (originParentOffsetInFinal === undefined) or the post-move re-parse's span
+  // resolution failed (computeMoveInverse) — either way, applying the move without a working
+  // undo would be a silently-broken history entry from the app's perspective.
+  if (!inverse) {
+    return refuse("internal-error", "could not compute moveBlock's inverse (span resolution failed on the post-move re-parse) — refusing rather than applying an edit with no undo");
+  }
+
+  return { file, range: { start: 0, end: source.length }, replacement: rewritten, inverse };
 }
 
 // After applyMoveNode builds the final source (`finalSource`), computes moveBlock's inverse by

--- a/server/component-structure-edit.mjs
+++ b/server/component-structure-edit.mjs
@@ -15,6 +15,12 @@ import { loadBlockManifest, indexManifestByName } from "./block-manifest.mjs";
 // uses it the other direction: carrying imports for component-kind descendants INTO the new
 // file) — can reuse this module's single, carefully-tested implementation rather than a second,
 // drift-prone copy.
+//
+// `scanTagOpen` is also exported so text-run-edit.mjs's `editText` resolver can find an
+// element's TRUE opening-tag end (respecting quoted attribute values and brace-delimited
+// attribute expressions, e.g. `<p title="a>b">`) instead of a naive `indexOf(">", ...)` that a
+// stray `>` inside an attribute value would fool — same class of bug this function already
+// solves for `findMatchingClose`/`findTagOpenFrom` above, reused rather than duplicated.
 
 function refuse(reason, detail) {
   return { refused: true, reason, detail };
@@ -246,7 +252,7 @@ function scanBraceBlock(s, start) {
 // End (exclusive) of a tag's own opening `<...>` starting at `start` (s[start] === "<"),
 // honoring quoted attribute values and brace-delimited attribute expressions so a stray
 // `>` inside either doesn't prematurely close the tag. Returns null if unterminated.
-function scanTagOpen(s, start) {
+export function scanTagOpen(s, start) {
   let j = start + 1;
   while (j < s.length) {
     const ch = s[j];

--- a/server/css-rule-index.mjs
+++ b/server/css-rule-index.mjs
@@ -1,33 +1,23 @@
 import { parse as parseCss, generate, walk } from "css-tree";
 import { offsetFromLineColumn } from "./component-node-index.mjs";
 
-/**
- * Span-precise CSS rule index for one <style> element. Shared by the
- * read-only component model (component-model.mjs) and the write-side
- * resolver (component-style-edit.mjs) so both agree byte-for-byte on rule
- * identity — selector text alone is not reliable (css-tree's generate()
- * re-serializes and can normalize whitespace/quoting away from the source).
- *
- * `lineStarts` (from component-node-index.mjs's `buildLineStarts(source)`) is
- * required, not optional: @astrojs/compiler@4.0.0 reports `position.*.offset`
- * as a UTF-8 byte offset, not a JS-string (UTF-16) index, so it can't be used
- * directly as `baseOffset` — any multi-byte-UTF-8 character earlier in the
- * source (emoji, accented Latin, CJK, etc.) would silently corrupt every rule
- * and declaration span this function returns. `.line`/`.column` are reliable
- * in UTF-16 terms, so `baseOffset` is derived from those instead — the same
- * approach component-node-index.mjs and component-model.mjs already use for
- * template/frontmatter/clientScript spans.
- */
-export function indexCssRules(styleElement, lineStarts) {
-  const lang = (styleElement.attributes ?? []).find((a) => a.name === "lang")?.value;
-  if (lang && lang.trim().toLowerCase() !== "css") return []; // scss/less etc.: css-tree error-recovery emits garbage rows
-  const textChild = (styleElement.children ?? []).find((c) => c.type === "text");
-  if (!textChild?.value) return [];
-  const baseOffset = offsetFromLineColumn(lineStarts, textChild.position?.start) ?? 0;
+function span(loc, baseOffset) {
+  if (!loc) return [null, null];
+  return [baseOffset + loc.start.offset, baseOffset + loc.end.offset];
+}
 
+/**
+ * Span-precise CSS rule index for a raw CSS string, given the byte offset that string starts
+ * at within its owning file (0 for a whole standalone .css file). Shared by `indexCssRules`
+ * (Astro <style> elements, below) and `design-token-edit.mjs` (global.css's top-level :root)
+ * so both agree byte-for-byte on rule/declaration identity via the same css-tree walk —
+ * selector text alone is not reliable (css-tree's generate() re-serializes and can normalize
+ * whitespace/quoting away from the source).
+ */
+export function walkCssRules(cssText, baseOffset) {
   let cssAst;
   try {
-    cssAst = parseCss(textChild.value, { positions: true, parseValue: false, parseAtrulePrelude: false });
+    cssAst = parseCss(cssText, { positions: true, parseValue: false, parseAtrulePrelude: false });
   } catch {
     return []; // unparseable CSS: styles stay empty; template/props still usable
   }
@@ -63,7 +53,28 @@ export function indexCssRules(styleElement, lineStarts) {
   return rules;
 }
 
-function span(loc, baseOffset) {
-  if (!loc) return [null, null];
-  return [baseOffset + loc.start.offset, baseOffset + loc.end.offset];
+/**
+ * Span-precise CSS rule index for one <style> element. Shared by the
+ * read-only component model (component-model.mjs) and the write-side
+ * resolver (component-style-edit.mjs) so both agree byte-for-byte on rule
+ * identity — selector text alone is not reliable (css-tree's generate()
+ * re-serializes and can normalize whitespace/quoting away from the source).
+ *
+ * `lineStarts` (from component-node-index.mjs's `buildLineStarts(source)`) is
+ * required, not optional: @astrojs/compiler@4.0.0 reports `position.*.offset`
+ * as a UTF-8 byte offset, not a JS-string (UTF-16) index, so it can't be used
+ * directly as `baseOffset` — any multi-byte-UTF-8 character earlier in the
+ * source (emoji, accented Latin, CJK, etc.) would silently corrupt every rule
+ * and declaration span this function returns. `.line`/`.column` are reliable
+ * in UTF-16 terms, so `baseOffset` is derived from those instead — the same
+ * approach component-node-index.mjs and component-model.mjs already use for
+ * template/frontmatter/clientScript spans.
+ */
+export function indexCssRules(styleElement, lineStarts) {
+  const lang = (styleElement.attributes ?? []).find((a) => a.name === "lang")?.value;
+  if (lang && lang.trim().toLowerCase() !== "css") return []; // scss/less etc.: css-tree error-recovery emits garbage rows
+  const textChild = (styleElement.children ?? []).find((c) => c.type === "text");
+  if (!textChild?.value) return [];
+  const baseOffset = offsetFromLineColumn(lineStarts, textChild.position?.start) ?? 0;
+  return walkCssRules(textChild.value, baseOffset);
 }

--- a/server/design-token-edit.mjs
+++ b/server/design-token-edit.mjs
@@ -1,0 +1,68 @@
+/**
+ * `setDesignToken` resolver — patches a single CSS custom-property declaration inside the
+ * LIGHT `:root { }` block of a scaffolded site's `src/styles/global.css`. Deliberately leaves
+ * the dark-mode `@media (prefers-color-scheme: dark)` block untouched, matching that file's
+ * own documented convention (the app-side theme-apply flow already only upserts the top-level
+ * `:root` block and leaves the dark-mode block alone).
+ *
+ * Unlike the component-structure/text resolvers, this one has no async parse step —
+ * `walkCssRules` (css-rule-index.mjs) runs css-tree's `parse`, which is synchronous — so there's
+ * no yield point between the baseVersion check below and this function returning that a
+ * concurrent write could land in. It stays `async` for signature consistency with the sibling
+ * resolvers `patcher.mjs` dispatches to, not because it needs to await anything.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileVersion } from "./file-version.mjs";
+import { walkCssRules } from "./css-rule-index.mjs";
+
+const GLOBAL_CSS_PATH = "src/styles/global.css";
+const TOKEN_RE = /^--[\w-]+$/;
+
+function refuse(reason, detail) {
+  return { refused: true, reason, detail };
+}
+
+export async function resolveDesignToken(projectRoot, edit) {
+  const { component } = edit;
+  if (!component || typeof component !== "object") {
+    return refuse("invalid-input", "component payload is required for setDesignToken");
+  }
+  const { path: relPath, baseVersion, token, tokenValue } = component;
+  if (relPath !== GLOBAL_CSS_PATH) {
+    return refuse("invalid-input", `setDesignToken only targets ${GLOBAL_CSS_PATH}`);
+  }
+  if (typeof token !== "string" || !TOKEN_RE.test(token)) {
+    return refuse("invalid-input", `not a CSS custom-property name: ${token}`);
+  }
+  if (typeof tokenValue !== "string") {
+    return refuse("invalid-input", "setDesignToken requires component.tokenValue");
+  }
+
+  const absPath = join(projectRoot, relPath);
+  let source;
+  try {
+    source = readFileSync(absPath, "utf-8");
+  } catch (err) {
+    return refuse("read-failed", `read ${relPath}: ${err.message}`);
+  }
+  if (fileVersion(source) !== baseVersion) {
+    return refuse("stale", `${relPath} changed since it was last read`);
+  }
+
+  const rules = walkCssRules(source, 0);
+  // The light palette only: the FIRST top-level `:root` rule not nested inside any @media —
+  // matches the file's own documented convention (see this module's header comment).
+  const rootRule = rules.find((r) => r.selector.trim() === ":root" && r.media === null);
+  if (!rootRule) return refuse("no-match", "no top-level :root rule found in global.css");
+  const decl = rootRule.declarations.find((d) => d.property === token);
+  if (!decl) return refuse("no-match", `:root has no declaration for ${token}`);
+
+  const inverse = { op: "setDesignToken", component: { path: relPath, token, tokenValue: decl.value } };
+  return {
+    file: relPath,
+    range: { start: decl.span[0], end: decl.span[1] },
+    replacement: `${token}: ${tokenValue}`,
+    inverse,
+  };
+}

--- a/server/index-tools.mjs
+++ b/server/index-tools.mjs
@@ -16,6 +16,7 @@ import { listContent } from "./list-content.mjs";
 import { createPage, createPost, createTyped } from "./create-content.mjs";
 import { creatableContentTypeIds } from "./content-types.mjs";
 import { buildComponentModel, ComponentModelError } from "./component-model.mjs";
+import { buildPageModel, PageModelError } from "./page-model.mjs";
 
 /**
  * The plugin version is the single source of truth (`bin/release.ts` keeps the
@@ -170,6 +171,28 @@ export function buildServer(projectRoot) {
                 detail: String(err?.message ?? err),
               }),
             },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "get_page_model",
+    "Parse a page .astro file into a block-annotated template tree: the same node shape get_component_model returns, with each component instance that resolves to a theme block-manifest entry carrying owner-facing name/description/icon/propEditors/slots. Used by the WYSIWYG block editor.",
+    {
+      path: z.string().describe("Page path relative to the project root, e.g. src/pages/index.astro"),
+    },
+    async ({ path }) => {
+      try {
+        const model = await buildPageModel(projectRoot, path);
+        return { content: [{ type: "text", text: JSON.stringify(model) }] };
+      } catch (err) {
+        const reason = err instanceof PageModelError ? err.reason : "internal-error";
+        return {
+          content: [
+            { type: "text", text: JSON.stringify({ type: "anglesite:page-model-failed", reason, detail: String(err?.message ?? err) }) },
           ],
           isError: true,
         };

--- a/server/page-model.mjs
+++ b/server/page-model.mjs
@@ -1,0 +1,81 @@
+import { readFileSync } from "node:fs";
+import { join, normalize, dirname, sep } from "node:path";
+import { parse } from "@astrojs/compiler";
+import { fileVersion } from "./file-version.mjs";
+import { buildTemplateNodeIndex, toPublicNode } from "./component-node-index.mjs";
+import { parseImports } from "./frontmatter-imports.mjs";
+import { loadBlockManifest, indexManifestByPath } from "./block-manifest.mjs";
+
+export class PageModelError extends Error {
+  constructor(reason, message) {
+    super(message);
+    this.reason = reason;
+  }
+}
+
+function validPagePath(relPath) {
+  return (
+    typeof relPath === "string" &&
+    relPath.endsWith(".astro") &&
+    !normalize(relPath).startsWith("..") &&
+    !relPath.startsWith("/")
+  );
+}
+
+/** Resolves each locally-imported tag name to a project-relative path via the page's own
+ *  frontmatter default imports — the join key against the block manifest's `path` field.
+ *  Only relative specifiers are resolved; a package import is never a theme block. */
+function resolveComponentPaths(relPath, frontmatterSource) {
+  const pageDir = dirname(relPath);
+  const byLocalName = new Map();
+  for (const { localName, specifier } of parseImports(frontmatterSource ?? "")) {
+    if (!specifier.startsWith(".")) continue;
+    const resolved = normalize(join(pageDir, specifier)).split(sep).join("/");
+    byLocalName.set(localName, resolved);
+  }
+  return byLocalName;
+}
+
+function annotateBlocks(node, byLocalName, manifestByPath) {
+  let block = null;
+  if (node.kind === "component" && node.tag) {
+    const path = byLocalName.get(node.tag);
+    const entry = path ? manifestByPath.get(path) : undefined;
+    if (entry) {
+      block = {
+        manifestPath: entry.path,
+        name: entry.name,
+        description: entry.description,
+        icon: entry.icon,
+        propEditors: entry.propEditors,
+        slots: entry.slots,
+      };
+    }
+  }
+  return { ...node, block, children: node.children.map((c) => annotateBlocks(c, byLocalName, manifestByPath)) };
+}
+
+export async function buildPageModel(projectRoot, relPath) {
+  if (!validPagePath(relPath)) {
+    throw new PageModelError("invalid-input", `not a project-relative .astro path: ${relPath}`);
+  }
+  const absPath = join(projectRoot, relPath);
+  let source;
+  try {
+    source = readFileSync(absPath, "utf-8");
+  } catch (err) {
+    throw new PageModelError("read-failed", `read ${relPath}: ${err.message}`);
+  }
+  let ast;
+  try {
+    ({ ast } = await parse(source, { position: true }));
+  } catch (err) {
+    throw new PageModelError("parse-failed", `parse ${relPath}: ${err.message}`);
+  }
+  const { byId, rootId } = buildTemplateNodeIndex(ast, source);
+  const tree = toPublicNode(byId, rootId);
+  const fmNode = (ast.children ?? []).find((n) => n.type === "frontmatter");
+  const byLocalName = resolveComponentPaths(relPath, fmNode?.value ?? "");
+  const manifestByPath = indexManifestByPath(loadBlockManifest(projectRoot));
+  return { version: fileVersion(source), path: relPath, tree: annotateBlocks(tree, byLocalName, manifestByPath) };
+}

--- a/server/page-model.mjs
+++ b/server/page-model.mjs
@@ -4,7 +4,7 @@ import { parse } from "@astrojs/compiler";
 import { fileVersion } from "./file-version.mjs";
 import { buildTemplateNodeIndex, toPublicNode } from "./component-node-index.mjs";
 import { parseImports } from "./frontmatter-imports.mjs";
-import { loadBlockManifest, indexManifestByPath } from "./block-manifest.mjs";
+import { loadBlockManifest, indexManifestByPath, BlockManifestError } from "./block-manifest.mjs";
 
 export class PageModelError extends Error {
   constructor(reason, message) {
@@ -76,6 +76,16 @@ export async function buildPageModel(projectRoot, relPath) {
   const tree = toPublicNode(byId, rootId);
   const fmNode = (ast.children ?? []).find((n) => n.type === "frontmatter");
   const byLocalName = resolveComponentPaths(relPath, fmNode?.value ?? "");
-  const manifestByPath = indexManifestByPath(loadBlockManifest(projectRoot));
+  let manifest;
+  try {
+    manifest = loadBlockManifest(projectRoot);
+  } catch (err) {
+    // Surface the real BlockManifestError reason (parse-failed/invalid-manifest) rather than
+    // letting it propagate as an untyped exception the tool handler would report as
+    // "internal-error" — matching how every other PageModelError reason here is surfaced.
+    if (!(err instanceof BlockManifestError)) throw err;
+    throw new PageModelError(err.reason, err.message);
+  }
+  const manifestByPath = indexManifestByPath(manifest);
   return { version: fileVersion(source), path: relPath, tree: annotateBlocks(tree, byLocalName, manifestByPath) };
 }

--- a/server/patcher.mjs
+++ b/server/patcher.mjs
@@ -5,11 +5,13 @@ import { resolveComponentStyle } from "./component-style-edit.mjs";
 import { resolveComponentStructure } from "./component-structure-edit.mjs";
 import { resolveComponentFrontmatter } from "./component-frontmatter-edit.mjs";
 import { resolveComponentExtract } from "./component-extract-edit.mjs";
+import { resolveTextRuns } from "./text-run-edit.mjs";
 import {
   COMPONENT_STYLE_OPS,
   COMPONENT_STRUCTURE_OPS,
   COMPONENT_FRONTMATTER_OPS,
   COMPONENT_EXTRACT_OPS,
+  COMPONENT_TEXT_OPS,
 } from "./apply-edit-schema.mjs";
 
 /**
@@ -23,17 +25,18 @@ import {
  *
  * Tries resolvers in priority order: edit-style → component-style ops →
  * component-structure ops → component-frontmatter ops → component-extract op →
- * .mdoc → Keystatic YAML/JSON → .astro. Returns the first non-refusal. If all
- * refuse, returns the most informative refusal (from the highest-priority
- * resolver that had an opinion).
+ * editText → .mdoc → Keystatic YAML/JSON → .astro. Returns the first
+ * non-refusal. If all refuse, returns the most informative refusal (from the
+ * highest-priority resolver that had an opinion).
  *
  * Async because `resolveComponentStyle` (component-style-edit.mjs),
  * `resolveComponentStructure` (component-structure-edit.mjs),
- * `resolveComponentFrontmatter` (component-frontmatter-edit.mjs), and
- * `resolveComponentExtract` (component-extract-edit.mjs) parse the target
- * .astro file with `@astrojs/compiler`, which is itself async. Every other
- * resolver here is synchronous; awaiting their (non-Promise) return values is
- * a no-op, so this doesn't change their behavior.
+ * `resolveComponentFrontmatter` (component-frontmatter-edit.mjs),
+ * `resolveComponentExtract` (component-extract-edit.mjs), and
+ * `resolveTextRuns` (text-run-edit.mjs) parse the target .astro file with
+ * `@astrojs/compiler`, which is itself async. Every other resolver here is
+ * synchronous; awaiting their (non-Promise) return values is a no-op, so this
+ * doesn't change their behavior.
  *
  * @param {string} projectRoot
  * @param {{ path: string, selector: object, op: string, value?: unknown, component?: object }} edit
@@ -54,6 +57,9 @@ export async function resolve(projectRoot, edit) {
   }
   if (COMPONENT_EXTRACT_OPS.has(edit.op)) {
     return resolveComponentExtract(projectRoot, edit);
+  }
+  if (COMPONENT_TEXT_OPS.has(edit.op)) {
+    return resolveTextRuns(projectRoot, edit);
   }
   const resolvers = [resolveMdoc, resolveKeystatic, resolveAstro];
   let bestRefusal = /** @type {ResolveRefusal | null} */ (null);

--- a/server/patcher.mjs
+++ b/server/patcher.mjs
@@ -13,6 +13,7 @@ import {
   COMPONENT_FRONTMATTER_OPS,
   COMPONENT_EXTRACT_OPS,
   COMPONENT_TEXT_OPS,
+  DESIGN_TOKEN_OPS,
 } from "./apply-edit-schema.mjs";
 
 /**
@@ -65,7 +66,7 @@ export async function resolve(projectRoot, edit) {
   if (COMPONENT_TEXT_OPS.has(edit.op)) {
     return resolveTextRuns(projectRoot, edit);
   }
-  if (edit.op === "setDesignToken") {
+  if (DESIGN_TOKEN_OPS.has(edit.op)) {
     return resolveDesignToken(projectRoot, edit);
   }
   const resolvers = [resolveMdoc, resolveKeystatic, resolveAstro];

--- a/server/patcher.mjs
+++ b/server/patcher.mjs
@@ -6,6 +6,7 @@ import { resolveComponentStructure } from "./component-structure-edit.mjs";
 import { resolveComponentFrontmatter } from "./component-frontmatter-edit.mjs";
 import { resolveComponentExtract } from "./component-extract-edit.mjs";
 import { resolveTextRuns } from "./text-run-edit.mjs";
+import { resolveDesignToken } from "./design-token-edit.mjs";
 import {
   COMPONENT_STYLE_OPS,
   COMPONENT_STRUCTURE_OPS,
@@ -25,16 +26,19 @@ import {
  *
  * Tries resolvers in priority order: edit-style → component-style ops →
  * component-structure ops → component-frontmatter ops → component-extract op →
- * editText → .mdoc → Keystatic YAML/JSON → .astro. Returns the first
- * non-refusal. If all refuse, returns the most informative refusal (from the
- * highest-priority resolver that had an opinion).
+ * editText → setDesignToken → .mdoc → Keystatic YAML/JSON → .astro. Returns
+ * the first non-refusal. If all refuse, returns the most informative refusal
+ * (from the highest-priority resolver that had an opinion).
  *
  * Async because `resolveComponentStyle` (component-style-edit.mjs),
  * `resolveComponentStructure` (component-structure-edit.mjs),
  * `resolveComponentFrontmatter` (component-frontmatter-edit.mjs),
  * `resolveComponentExtract` (component-extract-edit.mjs), and
  * `resolveTextRuns` (text-run-edit.mjs) parse the target .astro file with
- * `@astrojs/compiler`, which is itself async. Every other resolver here is
+ * `@astrojs/compiler`, which is itself async. `resolveDesignToken`
+ * (design-token-edit.mjs) is also declared `async` for signature consistency
+ * with those siblings, but its own CSS parse (css-tree, via `walkCssRules`)
+ * is synchronous — no real yield point there. Every other resolver here is
  * synchronous; awaiting their (non-Promise) return values is a no-op, so this
  * doesn't change their behavior.
  *
@@ -60,6 +64,9 @@ export async function resolve(projectRoot, edit) {
   }
   if (COMPONENT_TEXT_OPS.has(edit.op)) {
     return resolveTextRuns(projectRoot, edit);
+  }
+  if (edit.op === "setDesignToken") {
+    return resolveDesignToken(projectRoot, edit);
   }
   const resolvers = [resolveMdoc, resolveKeystatic, resolveAstro];
   let bestRefusal = /** @type {ResolveRefusal | null} */ (null);

--- a/server/text-run-edit.mjs
+++ b/server/text-run-edit.mjs
@@ -1,0 +1,113 @@
+// `editText` — rich-text run editing for .astro template elements (WYSIWYG in-canvas text
+// editing). Replaces an element's inner content with re-serialized "honest" inline HTML:
+// strong/em/code/a href, nested in a fixed order so round-tripping the same runs is
+// byte-identical. Deliberately does NOT touch Markdoc/markdown content-collection body text
+// (src/content/**/*.mdoc) — no markdown AST parser exists in this sidecar (no remark/mdast/
+// micromark dependency), and adding one is a separate, dependency-approval-gated slice.
+// patcher.mjs's `resolveMdoc` text-search-and-replace remains the only markdown-body editing
+// path until that follow-up lands.
+import { readFileSync } from "node:fs";
+import { join, normalize } from "node:path";
+import { parse } from "@astrojs/compiler";
+import { fileVersion } from "./file-version.mjs";
+import { buildTemplateNodeIndex } from "./component-node-index.mjs";
+import { resolveAllSpans, SpanResolutionError, escapeAttr } from "./component-structure-edit.mjs";
+
+function refuse(reason, detail) {
+  return { refused: true, reason, detail };
+}
+
+function escapeText(s) {
+  return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+const MARK_TAGS = { strong: "strong", em: "em", code: "code" };
+
+/** Serializes runs into the small honest inline set the spec allows (§4): strong, em, code,
+ *  link. Marks nest in a fixed, deterministic order (code innermost) so round-tripping the
+ *  same runs always produces byte-identical markup — required for the golden tests in Task 8. */
+function serializeRuns(runs) {
+  return runs
+    .map(({ text, marks = [], href }) => {
+      let out = escapeText(text);
+      for (const mark of ["code", "em", "strong"]) {
+        if (marks.includes(mark)) out = `<${MARK_TAGS[mark]}>${out}</${MARK_TAGS[mark]}>`;
+      }
+      if (href !== undefined) out = `<a href="${escapeAttr(href)}">${out}</a>`;
+      return out;
+    })
+    .join("");
+}
+
+/** Reverses serializeRuns for exactly the shapes it produces — one run per top-level mark
+ *  combination, used only to reconstruct the inverse from a node's ORIGINAL rendered content,
+ *  not a general HTML-to-runs parser. Out of scope: nested/mixed structures a human hand-edit
+ *  could introduce outside the editor — those fall back to a single unmarked run of the raw
+ *  inner text (a safe, if blunt, inverse: applying it always yields valid honest markup, just
+ *  not a byte-identical restoration of hand-authored HTML). */
+function parseRunsBestEffort(innerHtml) {
+  const m = innerHtml.match(/^(?:<a href="([^"]*)">)?(?:<strong>)?(?:<em>)?(?:<code>)?([\s\S]*?)(?:<\/code>)?(?:<\/em>)?(?:<\/strong>)?(?:<\/a>)?$/);
+  if (m && m[0] === innerHtml) {
+    const marks = [];
+    if (innerHtml.includes("<strong>")) marks.push("strong");
+    if (innerHtml.includes("<em>")) marks.push("em");
+    if (innerHtml.includes("<code>")) marks.push("code");
+    const text = m[2].replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+    return [{ text, marks, ...(m[1] !== undefined ? { href: m[1] } : {}) }];
+  }
+  const text = innerHtml.replace(/<[^>]+>/g, "").replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+  return [{ text, marks: [] }];
+}
+
+export async function resolveTextRuns(projectRoot, edit) {
+  const { component } = edit;
+  if (!component || typeof component !== "object") return refuse("invalid-input", "component payload is required for editText");
+  const { path: relPath, baseVersion, textNodeId, runs } = component;
+  if (typeof relPath !== "string" || !relPath.endsWith(".astro") || normalize(relPath).startsWith("..") || relPath.startsWith("/")) {
+    return refuse("invalid-input", `not a project-relative .astro path: ${relPath}`);
+  }
+  if (typeof textNodeId !== "string" || !Array.isArray(runs)) {
+    return refuse("invalid-input", "editText requires component.textNodeId and component.runs");
+  }
+
+  const absPath = join(projectRoot, relPath);
+  let source;
+  try {
+    source = readFileSync(absPath, "utf-8");
+  } catch (err) {
+    return refuse("read-failed", `read ${relPath}: ${err.message}`);
+  }
+  if (fileVersion(source) !== baseVersion) return refuse("stale", `${relPath} changed since the model was fetched`);
+
+  let ast;
+  try {
+    ({ ast } = await parse(source, { position: true }));
+  } catch (err) {
+    return refuse("parse-failed", `parse ${relPath}: ${err.message}`);
+  }
+  const { byId, rootId } = buildTemplateNodeIndex(ast, source);
+  const node = byId.get(textNodeId);
+  if (!node || node.kind !== "element") return refuse("no-match", "editText requires an element node id from get_page_model");
+
+  let spans;
+  try {
+    spans = resolveAllSpans(byId, rootId, source);
+  } catch (err) {
+    if (!(err instanceof SpanResolutionError)) throw err;
+    return refuse("no-match", "could not lexically re-locate the node's true source span without trusting compiler offsets — refusing rather than risking corruption");
+  }
+  const outer = spans.get(textNodeId);
+  if (!outer) return refuse("no-match", "could not lexically re-locate the node's true source span");
+
+  // Inner-content boundary: the open tag's end through the matching close tag's start. Both
+  // are re-derived from the source text at the already-verified `outer` span rather than
+  // trusted from the AST — same discipline as every other resolver in this module set.
+  const openEnd = source.indexOf(">", outer[0]) + 1;
+  const closeStart = source.lastIndexOf("<", outer[1] - 1);
+  if (openEnd <= outer[0] || closeStart < openEnd) return refuse("no-match", "could not resolve the element's inner-content boundary");
+
+  const originalInner = source.slice(openEnd, closeStart);
+  const inverse = { op: "editText", component: { path: relPath, textNodeId, runs: parseRunsBestEffort(originalInner) } };
+  const replacement = serializeRuns(runs);
+  return { file: relPath, range: { start: openEnd, end: closeStart }, replacement, inverse };
+}

--- a/server/text-run-edit.mjs
+++ b/server/text-run-edit.mjs
@@ -17,8 +17,18 @@ function refuse(reason, detail) {
   return { refused: true, reason, detail };
 }
 
+// Matches a "&" that begins a well-formed HTML character reference — named (letters/digits,
+// e.g. `&nbsp;`) or numeric (`&#68;` / `&#x44;`), always semicolon-terminated. Used by
+// `escapeText` below to avoid re-escaping a reference `parseRunsBestEffort`'s fallback
+// deliberately left un-decoded (see `hasUnrecoverableEntity`) — re-escaping its "&" would
+// corrupt e.g. `&nbsp;` into `&amp;nbsp;` on write-back.
+const ENTITY_OR_SPECIAL = /&(?:#[0-9]+;|#[xX][0-9a-fA-F]+;|[a-zA-Z][a-zA-Z0-9]*;)|[&<>]/g;
+
 function escapeText(s) {
-  return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return String(s).replace(ENTITY_OR_SPECIAL, (m) => {
+    if (m.length > 1) return m; // a well-formed character reference — pass through untouched
+    return m === "&" ? "&amp;" : m === "<" ? "&lt;" : "&gt;";
+  });
 }
 
 const MARK_TAGS = { strong: "strong", em: "em", code: "code" };
@@ -51,6 +61,17 @@ function unescapeAttr(s) {
   return s.replace(/&quot;/g, '"').replace(/&amp;/g, "&");
 }
 
+// True when `s` contains an HTML character reference `unescapeText` doesn't fully reverse — any
+// named or numeric reference other than `&lt;`/`&gt;`/`&amp;`. The node's ORIGINAL inner HTML is
+// whatever a site author (or a prior hand-edit) wrote — it can carry ANY entity: `&nbsp;`,
+// `&mdash;`, `&hellip;`, `&copy;`, numeric refs, etc. Decoding only the three `unescapeText`
+// knows and leaving the rest untouched would smuggle a literal "&" into the reconstructed run's
+// `text`, which `escapeText` then re-escapes into `&amp;name;` on write-back — silent corruption.
+// Callers route content matching this to the blunt fallback below instead.
+function hasUnrecoverableEntity(s) {
+  return /&(?!lt;|gt;|amp;)(?:#[0-9]+;|#[xX][0-9a-fA-F]+;|[a-zA-Z][a-zA-Z0-9]*;)/.test(s);
+}
+
 /** Reverses serializeRuns for exactly the shapes it produces — one run whose marks/href nest in
  *  serializeRuns' own fixed order (a outermost, then strong, then em, then code innermost, each
  *  independently optional) — used only to reconstruct the inverse from a node's ORIGINAL
@@ -60,9 +81,13 @@ function unescapeAttr(s) {
  *  entities, so a raw "<" can only appear here as serializeRuns' own structural markup — never
  *  as user text). Out of scope: multi-run content (the normal shape after a first edit) and any
  *  other nested/mixed structure a human hand-edit could introduce outside the editor — after
- *  peeling every wrapper this function recognizes, anything with tag delimiters STILL left over
- *  falls back to a single unmarked run of the fully-stripped text (a safe, if blunt, inverse:
- *  applying it always yields valid honest markup, just not a byte-identical restoration). */
+ *  peeling every wrapper this function recognizes, anything with tag delimiters STILL left over,
+ *  OR any entity `unescapeText` can't safely reverse (`hasUnrecoverableEntity`), falls back to a
+ *  single unmarked run of the fully-stripped text — WITHOUT unescaping it (a safe, if blunt,
+ *  inverse: `escapeText`'s entity-reference passthrough leaves any character reference in that
+ *  raw text exactly as it was, so applying this inverse always yields valid honest markup AND,
+ *  for this fallback, byte-identical restoration of the entity — just not necessarily of any
+ *  marks/href the fallback also discards). */
 function parseRunsBestEffort(innerHtml) {
   let rest = innerHtml;
   let href;
@@ -84,10 +109,13 @@ function parseRunsBestEffort(innerHtml) {
     }
   }
 
-  if (!/[<>]/.test(rest)) {
+  if (!/[<>]/.test(rest) && !hasUnrecoverableEntity(rest)) {
     return [{ text: unescapeText(rest), marks, ...(href !== undefined ? { href } : {}) }];
   }
-  return [{ text: unescapeText(innerHtml.replace(/<[^>]+>/g, "")), marks: [] }];
+  // Blunt fallback: strip tags only, do NOT attempt entity-unescaping on text that can't be
+  // safely round-tripped through unescapeText's narrow lt/gt/amp table — see
+  // `hasUnrecoverableEntity` above and `escapeText`'s entity-reference passthrough.
+  return [{ text: innerHtml.replace(/<[^>]+>/g, ""), marks: [] }];
 }
 
 export async function resolveTextRuns(projectRoot, edit) {

--- a/server/text-run-edit.mjs
+++ b/server/text-run-edit.mjs
@@ -11,7 +11,7 @@ import { join, normalize } from "node:path";
 import { parse } from "@astrojs/compiler";
 import { fileVersion } from "./file-version.mjs";
 import { buildTemplateNodeIndex } from "./component-node-index.mjs";
-import { resolveAllSpans, SpanResolutionError, escapeAttr } from "./component-structure-edit.mjs";
+import { resolveAllSpans, SpanResolutionError, escapeAttr, scanTagOpen } from "./component-structure-edit.mjs";
 
 function refuse(reason, detail) {
   return { refused: true, reason, detail };
@@ -39,24 +39,55 @@ function serializeRuns(runs) {
     .join("");
 }
 
-/** Reverses serializeRuns for exactly the shapes it produces — one run per top-level mark
- *  combination, used only to reconstruct the inverse from a node's ORIGINAL rendered content,
- *  not a general HTML-to-runs parser. Out of scope: nested/mixed structures a human hand-edit
- *  could introduce outside the editor — those fall back to a single unmarked run of the raw
- *  inner text (a safe, if blunt, inverse: applying it always yields valid honest markup, just
- *  not a byte-identical restoration of hand-authored HTML). */
+function unescapeText(s) {
+  return s.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+}
+
+// Inverts escapeAttr (component-structure-edit.mjs): that escapes "&" first, then '"', so
+// undoing it runs in the opposite order — unescape "&quot;" back to '"' first, THEN "&amp;"
+// back to "&" — otherwise a literal "&quot;" that was itself escaped from a source "&amp;quot;"
+// would double-unescape.
+function unescapeAttr(s) {
+  return s.replace(/&quot;/g, '"').replace(/&amp;/g, "&");
+}
+
+/** Reverses serializeRuns for exactly the shapes it produces — one run whose marks/href nest in
+ *  serializeRuns' own fixed order (a outermost, then strong, then em, then code innermost, each
+ *  independently optional) — used only to reconstruct the inverse from a node's ORIGINAL
+ *  rendered content, not a general HTML-to-runs parser. Peels each wrapper only when the
+ *  *entire* remaining string is exactly `<tag>...</tag>` (a plain prefix/suffix check, safe
+ *  because `escapeText`/`escapeAttr` always turn any literal "<"/">" in real run content into
+ *  entities, so a raw "<" can only appear here as serializeRuns' own structural markup — never
+ *  as user text). Out of scope: multi-run content (the normal shape after a first edit) and any
+ *  other nested/mixed structure a human hand-edit could introduce outside the editor — after
+ *  peeling every wrapper this function recognizes, anything with tag delimiters STILL left over
+ *  falls back to a single unmarked run of the fully-stripped text (a safe, if blunt, inverse:
+ *  applying it always yields valid honest markup, just not a byte-identical restoration). */
 function parseRunsBestEffort(innerHtml) {
-  const m = innerHtml.match(/^(?:<a href="([^"]*)">)?(?:<strong>)?(?:<em>)?(?:<code>)?([\s\S]*?)(?:<\/code>)?(?:<\/em>)?(?:<\/strong>)?(?:<\/a>)?$/);
-  if (m && m[0] === innerHtml) {
-    const marks = [];
-    if (innerHtml.includes("<strong>")) marks.push("strong");
-    if (innerHtml.includes("<em>")) marks.push("em");
-    if (innerHtml.includes("<code>")) marks.push("code");
-    const text = m[2].replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
-    return [{ text, marks, ...(m[1] !== undefined ? { href: m[1] } : {}) }];
+  let rest = innerHtml;
+  let href;
+  if (rest.startsWith('<a href="') && rest.endsWith("</a>")) {
+    const closeQuote = rest.indexOf('">', 9);
+    if (closeQuote !== -1) {
+      href = unescapeAttr(rest.slice(9, closeQuote));
+      rest = rest.slice(closeQuote + 2, rest.length - 4);
+    }
   }
-  const text = innerHtml.replace(/<[^>]+>/g, "").replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
-  return [{ text, marks: [] }];
+
+  const marks = [];
+  for (const mark of ["strong", "em", "code"]) {
+    const open = `<${mark}>`;
+    const close = `</${mark}>`;
+    if (rest.startsWith(open) && rest.endsWith(close) && rest.length >= open.length + close.length) {
+      marks.push(mark);
+      rest = rest.slice(open.length, rest.length - close.length);
+    }
+  }
+
+  if (!/[<>]/.test(rest)) {
+    return [{ text: unescapeText(rest), marks, ...(href !== undefined ? { href } : {}) }];
+  }
+  return [{ text: unescapeText(innerHtml.replace(/<[^>]+>/g, "")), marks: [] }];
 }
 
 export async function resolveTextRuns(projectRoot, edit) {
@@ -87,7 +118,13 @@ export async function resolveTextRuns(projectRoot, edit) {
   }
   const { byId, rootId } = buildTemplateNodeIndex(ast, source);
   const node = byId.get(textNodeId);
-  if (!node || node.kind !== "element") return refuse("no-match", "editText requires an element node id from get_page_model");
+  // Tag-shaped kinds only — same set `set-attr` (component-structure-edit.mjs) treats
+  // uniformly, since the open/close-tag boundary scan below doesn't depend on which of these
+  // three it is. A block editor's blocks are frequently component instances (e.g.
+  // `<Badge>New</Badge>`), so excluding "component"/"slot" would refuse a common real case.
+  if (!node || !["element", "component", "slot"].includes(node.kind)) {
+    return refuse("no-match", "editText requires an element/component/slot node id from get_page_model");
+  }
 
   let spans;
   try {
@@ -102,9 +139,21 @@ export async function resolveTextRuns(projectRoot, edit) {
   // Inner-content boundary: the open tag's end through the matching close tag's start. Both
   // are re-derived from the source text at the already-verified `outer` span rather than
   // trusted from the AST — same discipline as every other resolver in this module set.
-  const openEnd = source.indexOf(">", outer[0]) + 1;
+  //
+  // The open tag's end is found via `scanTagOpen` (component-structure-edit.mjs) rather than a
+  // naive `indexOf(">", ...)` — a stray literal ">" inside a quoted attribute value (e.g.
+  // `<p title="a>b">`) would otherwise fool a naive forward scan into landing INSIDE the
+  // attribute list, corrupting the splice. `scanTagOpen` skips quoted values and brace-delimited
+  // attribute expressions the same way `resolveAllSpans` already does when it first resolved
+  // `outer` itself.
+  const tagInfo = scanTagOpen(source, outer[0]);
+  if (!tagInfo) return refuse("no-match", "could not resolve the element's opening tag");
+  const openEnd = tagInfo.end;
   const closeStart = source.lastIndexOf("<", outer[1] - 1);
-  if (openEnd <= outer[0] || closeStart < openEnd) return refuse("no-match", "could not resolve the element's inner-content boundary");
+  // Also refuses cleanly for a self-closing/void element (e.g. `<img ... />`, `<br>`) — there's
+  // no real close tag to search for, so `closeStart` lands back at (or before) `outer[0]`,
+  // which is always < `openEnd`.
+  if (closeStart < openEnd) return refuse("no-match", "could not resolve the element's inner-content boundary");
 
   const originalInner = source.slice(openEnd, closeStart);
   const inverse = { op: "editText", component: { path: relPath, textNodeId, runs: parseRunsBestEffort(originalInner) } };

--- a/tests/apply-edit-dispatcher-component-structure.test.ts
+++ b/tests/apply-edit-dispatcher-component-structure.test.ts
@@ -70,6 +70,24 @@ describe("applyEdit — component-structure ops", () => {
     expect(body.reason).toBe("stale");
   });
 
+  it("stamps inverse.component.baseVersion with the post-write content hash", async () => {
+    const baseVersion = fileVersion(CARD);
+    const { byId, rootId } = await nodeIndex(CARD);
+    const article = byId.get(byId.get(rootId).childIds[0]);
+
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/components/Card.astro",
+      op: "setProp",
+      component: { path: "src/components/Card.astro", baseVersion, nodeId: article.id, name: "title", value: "new" },
+    });
+    expect(response.isError).toBeFalsy();
+    const body = parseContent(response);
+    const onDisk = readFileSync(join(tmpDir, "src", "components", "Card.astro"), "utf-8");
+    expect(body.inverse).toBeDefined();
+    expect(body.inverse.component.baseVersion).toBe(fileVersion(onDisk));
+  });
+
   it("re-checks staleness after the resolver's async gap, refusing a concurrent write race", async () => {
     const baseVersion = fileVersion(CARD);
     const { byId, rootId } = await nodeIndex(CARD);

--- a/tests/apply-edit-dispatcher-design-token.test.ts
+++ b/tests/apply-edit-dispatcher-design-token.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { applyEdit } from "../server/apply-edit-dispatcher.mjs";
+import { fileVersion } from "../server/file-version.mjs";
+
+const GLOBAL_CSS = `:root {\n  --color-primary: #2563eb;\n}\n`;
+
+function parseContent(response) {
+  return JSON.parse(response.content[0].text);
+}
+
+describe("applyEdit — setDesignToken", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-aed-dt-"));
+    mkdirSync(join(tmpDir, "src", "styles"), { recursive: true });
+    writeFileSync(join(tmpDir, "src", "styles", "global.css"), GLOBAL_CSS);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("applies setDesignToken end to end and stamps the inverse's post-write baseVersion", async () => {
+    const baseVersion = fileVersion(GLOBAL_CSS);
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/styles/global.css",
+      op: "setDesignToken",
+      component: { path: "src/styles/global.css", baseVersion, token: "--color-primary", tokenValue: "#111111" },
+    });
+    expect(response.isError).toBeFalsy();
+    const body = parseContent(response);
+    expect(body.type).toBe("anglesite:edit-applied");
+    const onDisk = readFileSync(join(tmpDir, "src", "styles", "global.css"), "utf-8");
+    expect(onDisk).toContain("--color-primary: #111111;");
+    expect(body.inverse.component.tokenValue).toBe("#2563eb");
+    expect(body.inverse.component.baseVersion).toBe(fileVersion(onDisk));
+  });
+
+  it("surfaces stale as a failed reply for a wrong baseVersion", async () => {
+    const response = await applyEdit(tmpDir, {
+      id: "1",
+      path: "src/styles/global.css",
+      op: "setDesignToken",
+      component: { path: "src/styles/global.css", baseVersion: "sha256:000000000000", token: "--color-primary", tokenValue: "#111111" },
+    });
+    expect(response.isError).toBe(true);
+    const body = parseContent(response);
+    expect(body.reason).toBe("stale");
+  });
+
+  // Regression for the dispatcher-level TOCTOU gap: setDesignToken is deliberately NOT a member
+  // of COMPONENT_OPS (it doesn't target an Astro component — no payload-presence/model-refetch
+  // semantics apply), but applyEdit still does a second, independent `readFileSync` after the
+  // resolver returns and splices against THAT read. Without re-validating baseVersion against
+  // this second read for every op that carries `component.baseVersion` (not just COMPONENT_OPS
+  // members), a concurrent external write landing in the microtask gap between the resolver's
+  // read and this second read would silently splice stale byte offsets into the new content.
+  it("re-checks staleness against a write that lands in the async gap, refusing instead of corrupting the file", async () => {
+    const baseVersion = fileVersion(GLOBAL_CSS);
+
+    const editPromise = applyEdit(tmpDir, {
+      id: "1",
+      path: "src/styles/global.css",
+      op: "setDesignToken",
+      component: { path: "src/styles/global.css", baseVersion, token: "--color-primary", tokenValue: "#111111" },
+    });
+
+    // Simulate a second write landing while this call is suspended at
+    // `await resolveEdit(...)` in apply-edit-dispatcher.mjs — mirrors the equivalent
+    // component-structure race test in apply-edit-dispatcher-component-structure.test.ts.
+    const externallyWritten = `:root {\n  --color-primary: #2563eb;\n  --spacing-unit: 1rem;\n}\n`;
+    writeFileSync(join(tmpDir, "src", "styles", "global.css"), externallyWritten);
+
+    const response = await editPromise;
+    expect(response.isError).toBe(true);
+    const body = parseContent(response);
+    expect(body.reason).toBe("stale");
+
+    const onDisk = readFileSync(join(tmpDir, "src", "styles", "global.css"), "utf-8");
+    expect(onDisk).toBe(externallyWritten); // untouched — no corrupted splice
+  });
+});

--- a/tests/block-manifest.test.ts
+++ b/tests/block-manifest.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { blockManifestSchema } from "../server/block-manifest-schema.mjs";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadBlockManifest, indexManifestByPath, indexManifestByName, BlockManifestError } from "../server/block-manifest.mjs";
+
+describe("blockManifestSchema", () => {
+  it("accepts a minimal valid manifest", () => {
+    const result = blockManifestSchema.safeParse({
+      schemaVersion: "anglesite-block-manifest/1",
+      modules: [
+        {
+          path: "src/components/Hcard.astro",
+          export: "Hcard",
+          kind: "astro",
+          name: "Business Card",
+          description: "Name, photo, and contact details as an h-card.",
+          icon: null,
+          propEditors: [{ prop: "name", editor: "text" }],
+          slots: [],
+          placement: { allowedParents: null },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unknown propEditor kind", () => {
+    const result = blockManifestSchema.safeParse({
+      schemaVersion: "anglesite-block-manifest/1",
+      modules: [
+        {
+          path: "src/components/Hcard.astro",
+          export: "Hcard",
+          name: "Business Card",
+          propEditors: [{ prop: "name", editor: "not-a-real-editor" }],
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("loadBlockManifest", () => {
+  it("returns an empty manifest when blocks.manifest.json is absent", () => {
+    const dir = mkdtempSync(join(tmpdir(), "anglesite-manifest-"));
+    try {
+      const manifest = loadBlockManifest(dir);
+      expect(manifest.modules).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads, validates, and indexes a real manifest file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "anglesite-manifest-"));
+    try {
+      writeFileSync(
+        join(dir, "blocks.manifest.json"),
+        JSON.stringify({
+          schemaVersion: "anglesite-block-manifest/1",
+          modules: [{ path: "src/components/Hcard.astro", export: "Hcard", name: "Business Card" }],
+        }),
+      );
+      const manifest = loadBlockManifest(dir);
+      expect(indexManifestByPath(manifest).get("src/components/Hcard.astro")?.name).toBe("Business Card");
+      expect(indexManifestByName(manifest).get("Business Card")?.path).toBe("src/components/Hcard.astro");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws BlockManifestError with reason invalid-manifest on schema violation", () => {
+    const dir = mkdtempSync(join(tmpdir(), "anglesite-manifest-"));
+    try {
+      writeFileSync(join(dir, "blocks.manifest.json"), JSON.stringify({ schemaVersion: "wrong", modules: [] }));
+      expect(() => loadBlockManifest(dir)).toThrow(BlockManifestError);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/component-structure-edit.test.ts
+++ b/tests/component-structure-edit.test.ts
@@ -857,6 +857,32 @@ describe("resolveComponentStructure — invertible ops (insertBlock/moveBlock/de
     expect(result.inverse.component.newIndex).toBe(0);
   });
 
+  // The fragment root has no lexical span (resolveAllSpans never spans it), so
+  // computeMoveInverse's root-parent branch takes a special path (reusing the fresh re-parse's
+  // deterministic "n0" root id directly instead of offset-matching) — every other moveBlock test
+  // above moves a node whose original parent is a real, spanned element, so this exercises the
+  // root special-case explicitly (reviewer-flagged coverage gap).
+  it("moveBlock's inverse resolves newParentId to the fresh root id when the original parent is the fragment root", async () => {
+    const source = `---\n---\n<h1>Top</h1>\n<p id="m">x</p><footer id="f"></footer>\n`;
+    writePage(source);
+    const { byId, rootId } = await indexSource(source);
+    const rootChildren = byId.get(rootId).childIds.map((id) => byId.get(id));
+    const p = rootChildren.find((n) => n.tag === "p");
+    const footer = rootChildren.find((n) => n.tag === "footer");
+    expect(p.parentId).toBe(rootId); // genuinely top-level: a direct child of the fragment root
+
+    const result = await resolveComponentStructure(projectRoot, {
+      op: "moveBlock",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), nodeId: p.id, newParentId: footer.id, newIndex: 0 },
+    });
+    expect(result.refused).toBeFalsy();
+    expect(result.inverse.op).toBe("moveBlock");
+
+    const { rootId: newRootId } = await indexSource(result.replacement);
+    expect(result.inverse.component.newParentId).toBe(newRootId);
+    expect(result.inverse.component.newIndex).toBe(1); // p was root's 2nd child: [h1, p, footer]
+  });
+
   it("insertBlock resolves manifestBlock to the registered component's tag/path", async () => {
     writeFileSync(join(projectRoot, "blocks.manifest.json"), JSON.stringify({
       schemaVersion: "anglesite-block-manifest/1",

--- a/tests/component-structure-edit.test.ts
+++ b/tests/component-structure-edit.test.ts
@@ -20,6 +20,15 @@ async function nodeIndex(source) {
   return buildTemplateNodeIndex(ast, source);
 }
 
+// Shared by the inverse-op tests below: parses `source` directly into a byId/rootId index
+// without touching disk — the tests that need this only care about node identity/shape, not
+// about resolveComponentStructure's own file-loading path (that's covered separately by the
+// baseVersion/stale/read-failed tests elsewhere in this file).
+async function indexSource(source) {
+  const { ast } = await parse(source, { position: true });
+  return buildTemplateNodeIndex(ast, source);
+}
+
 describe("resolveComponentStructure — set-attr", () => {
   let tmpDir;
 
@@ -748,5 +757,122 @@ describe("resolveComponentStructure — move-node", () => {
 
     const { ast } = await parse(next, { position: true });
     expect(ast).toBeDefined();
+  });
+});
+
+describe("resolveComponentStructure — invertible ops (insertBlock/moveBlock/deleteBlock/setProp)", () => {
+  let tmpDir;
+  let projectRoot;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-cse6-"));
+    projectRoot = tmpDir;
+    mkdirSync(join(projectRoot, "src", "pages"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writePage(source) {
+    writeFileSync(join(projectRoot, "src", "pages", "index.astro"), source);
+  }
+
+  it("setProp's inverse restores the previous attribute value", async () => {
+    const source = `---\n---\n<div id="a" title="old">x</div>\n`;
+    writePage(source);
+    const { byId } = await indexSource(source);
+    const divId = [...byId.values()].find((n) => n.tag === "div").id;
+    const result = await resolveComponentStructure(projectRoot, {
+      op: "setProp",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), nodeId: divId, name: "title", value: "new" },
+    });
+    expect(result.inverse).toEqual({
+      op: "setProp",
+      component: { path: "src/pages/index.astro", nodeId: divId, name: "title", value: "old" },
+    });
+  });
+
+  it("setProp's inverse removes an attribute that didn't exist before", async () => {
+    const source = `---\n---\n<div id="a">x</div>\n`;
+    writePage(source);
+    const { byId } = await indexSource(source);
+    const divId = [...byId.values()].find((n) => n.tag === "div").id;
+    const result = await resolveComponentStructure(projectRoot, {
+      op: "setProp",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), nodeId: divId, name: "title", value: "new" },
+    });
+    expect(result.inverse.component.value).toBeNull();
+  });
+
+  it("deleteBlock's inverse is a raw insertBlock reconstructing the exact removed markup", async () => {
+    const source = `---\n---\n<main><p id="keep">a</p><p id="gone">b</p></main>\n`;
+    writePage(source);
+    const { byId } = await indexSource(source);
+    const main = [...byId.values()].find((n) => n.tag === "main");
+    const gone = [...byId.values()].find((n) => n.tag === "p" && n.attrs.some((a) => a.name === "id" && a.value === "gone"));
+    const goneIndex = main.childIds.indexOf(gone.id);
+    const result = await resolveComponentStructure(projectRoot, {
+      op: "deleteBlock",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), nodeId: gone.id },
+    });
+    expect(result.inverse.op).toBe("insertBlock");
+    expect(result.inverse.component.parentId).toBe(main.id);
+    expect(result.inverse.component.index).toBe(goneIndex);
+    expect(result.inverse.component.node).toEqual({ kind: "raw", markup: `<p id="gone">b</p>` });
+  });
+
+  it("insertBlock's inverse is a deleteBlock targeting the newly created node's post-edit id", async () => {
+    const source = `---\n---\n<main></main>\n`;
+    writePage(source);
+    const { byId } = await indexSource(source);
+    const main = [...byId.values()].find((n) => n.tag === "main");
+    const result = await resolveComponentStructure(projectRoot, {
+      op: "insertBlock",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), parentId: main.id, index: 0, node: { kind: "element", tag: "p" } },
+    });
+    expect(result.inverse.op).toBe("deleteBlock");
+    // Re-parse the RESULT and confirm the inverse's nodeId actually resolves to the inserted <p>.
+    const rewritten = result.replacement; // whole-file replacement per the {start:0,end:len} range
+    const { byId: newById } = await indexSource(rewritten);
+    const target = newById.get(result.inverse.component.nodeId);
+    expect(target?.tag).toBe("p");
+  });
+
+  it("moveBlock's inverse moves the node back to its original parent/index", async () => {
+    const source = `---\n---\n<main><section id="from"><p id="m">x</p></section><section id="to"></section></main>\n`;
+    writePage(source);
+    const { byId } = await indexSource(source);
+    const p = [...byId.values()].find((n) => n.attrs.some((a) => a.name === "id" && a.value === "m"));
+    const to = [...byId.values()].find((n) => n.attrs.some((a) => a.name === "id" && a.value === "to"));
+    const result = await resolveComponentStructure(projectRoot, {
+      op: "moveBlock",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), nodeId: p.id, newParentId: to.id, newIndex: 0 },
+    });
+    const { byId: newById } = await indexSource(result.replacement);
+    const movedBack = newById.get(result.inverse.component.nodeId);
+    expect(movedBack?.attrs.some((a) => a.name === "id" && a.value === "m")).toBe(true);
+    const newFromParent = [...newById.values()].find((n) => n.attrs.some((a) => a.name === "id" && a.value === "from"));
+    expect(result.inverse.component.newParentId).toBe(newFromParent.id);
+    expect(result.inverse.component.newIndex).toBe(0);
+  });
+
+  it("insertBlock resolves manifestBlock to the registered component's tag/path", async () => {
+    writeFileSync(join(projectRoot, "blocks.manifest.json"), JSON.stringify({
+      schemaVersion: "anglesite-block-manifest/1",
+      modules: [{ path: "src/components/Testimonial.astro", export: "Testimonial", name: "Testimonial" }],
+    }));
+    mkdirSync(join(projectRoot, "src", "components"), { recursive: true });
+    writeFileSync(join(projectRoot, "src", "components", "Testimonial.astro"), `---\n---\n<blockquote>Great!</blockquote>\n`);
+    const source = `---\n---\n<main></main>\n`;
+    writePage(source);
+    const { byId } = await indexSource(source);
+    const main = [...byId.values()].find((n) => n.tag === "main");
+    const result = await resolveComponentStructure(projectRoot, {
+      op: "insertBlock",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), parentId: main.id, index: 0, manifestBlock: "Testimonial" },
+    });
+    expect(result.replacement).toContain("<Testimonial");
+    expect(result.replacement).toContain(`import Testimonial from`);
   });
 });

--- a/tests/component-structure-edit.test.ts
+++ b/tests/component-structure-edit.test.ts
@@ -901,4 +901,65 @@ describe("resolveComponentStructure — invertible ops (insertBlock/moveBlock/de
     expect(result.replacement).toContain("<Testimonial");
     expect(result.replacement).toContain(`import Testimonial from`);
   });
+
+  // Final review — Important: insertBlock's `node.kind: "raw"` accepts arbitrary caller-supplied
+  // markup with zero validation beyond `typeof === "string"` (componentEditSchema). Malformed
+  // markup used to get spliced into the file anyway (a success response with no inverse),
+  // producing an unparseable file with no way to undo it. Reuses computeInsertInverse's own
+  // re-parse-and-locate check: when it can't find a single well-formed node starting exactly at
+  // the insertion offset, refuse the WHOLE op rather than writing broken markup.
+  it("refuses a raw insertBlock whose markup doesn't parse as a single well-formed node", async () => {
+    const source = `---\n---\n<main></main>\n`;
+    writePage(source);
+    const { byId } = await indexSource(source);
+    const main = [...byId.values()].find((n) => n.tag === "main");
+    const before = readFileSync(join(projectRoot, "src/pages/index.astro"), "utf-8");
+    const result = await resolveComponentStructure(projectRoot, {
+      op: "insertBlock",
+      component: {
+        path: "src/pages/index.astro", baseVersion: fileVersion(source), parentId: main.id, index: 0,
+        node: { kind: "raw", markup: "</div><script>x()</script>" },
+      },
+    });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+    // Refusing at resolve time means nothing was ever written to disk.
+    expect(readFileSync(join(projectRoot, "src/pages/index.astro"), "utf-8")).toBe(before);
+  });
+
+  // Well-formed raw markup must still succeed with a real computed inverse — the fix above must
+  // not broaden the refusal beyond genuinely malformed markup.
+  it("still accepts well-formed raw insertBlock markup with a computed inverse", async () => {
+    const source = `---\n---\n<main></main>\n`;
+    writePage(source);
+    const { byId } = await indexSource(source);
+    const main = [...byId.values()].find((n) => n.tag === "main");
+    const result = await resolveComponentStructure(projectRoot, {
+      op: "insertBlock",
+      component: {
+        path: "src/pages/index.astro", baseVersion: fileVersion(source), parentId: main.id, index: 0,
+        node: { kind: "raw", markup: `<p id="gone">b</p>` },
+      },
+    });
+    expect(result.refused).toBeFalsy();
+    expect(result.inverse.op).toBe("deleteBlock");
+  });
+
+  // Final review — Important: an invalid blocks.manifest.json used to propagate as an untyped
+  // BlockManifestError exception straight out of resolveComponentStructure instead of a normal
+  // refusal — the module's own established pattern (every other resolver here returns
+  // `refuse(reason, detail)`, never throws for a data-shaped problem).
+  it("refuses cleanly (rather than throwing) when insertBlock's manifestBlock resolves against a malformed manifest", async () => {
+    writeFileSync(join(projectRoot, "blocks.manifest.json"), "{ not valid json");
+    const source = `---\n---\n<main></main>\n`;
+    writePage(source);
+    const { byId } = await indexSource(source);
+    const main = [...byId.values()].find((n) => n.tag === "main");
+    const result = await resolveComponentStructure(projectRoot, {
+      op: "insertBlock",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), parentId: main.id, index: 0, manifestBlock: "Testimonial" },
+    });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("parse-failed");
+  });
 });

--- a/tests/design-token-edit.test.ts
+++ b/tests/design-token-edit.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileVersion } from "../server/file-version.mjs";
+import { resolveDesignToken } from "../server/design-token-edit.mjs";
+
+const GLOBAL_CSS = `:root {\n  --color-primary: #2563eb;\n  --spacing-unit: 0.25rem;\n}\n\n@media (prefers-color-scheme: dark) {\n  :root {\n    --color-primary: #60a5fa;\n  }\n}\n`;
+
+let projectRoot: string;
+beforeEach(() => {
+  projectRoot = mkdtempSync(join(tmpdir(), "anglesite-token-"));
+  mkdirSync(join(projectRoot, "src", "styles"), { recursive: true });
+  writeFileSync(join(projectRoot, "src", "styles", "global.css"), GLOBAL_CSS);
+});
+afterEach(() => rmSync(projectRoot, { recursive: true, force: true }));
+
+describe("resolveDesignToken", () => {
+  it("replaces the light :root declaration's value and leaves the dark block untouched", async () => {
+    const result = await resolveDesignToken(projectRoot, {
+      op: "setDesignToken",
+      component: { path: "src/styles/global.css", baseVersion: fileVersion(GLOBAL_CSS), token: "--color-primary", tokenValue: "#111111" },
+    });
+    const next = GLOBAL_CSS.slice(0, result.range.start) + result.replacement + GLOBAL_CSS.slice(result.range.end);
+    expect(next).toContain("--color-primary: #111111;");
+    expect(next).toContain("--color-primary: #60a5fa;"); // dark block unchanged
+  });
+
+  it("computes an inverse restoring the previous value", async () => {
+    const result = await resolveDesignToken(projectRoot, {
+      op: "setDesignToken",
+      component: { path: "src/styles/global.css", baseVersion: fileVersion(GLOBAL_CSS), token: "--color-primary", tokenValue: "#111111" },
+    });
+    expect(result.inverse).toEqual({
+      op: "setDesignToken",
+      component: { path: "src/styles/global.css", token: "--color-primary", tokenValue: "#2563eb" },
+    });
+  });
+
+  it("refuses an unknown token rather than inventing a declaration", async () => {
+    const result = await resolveDesignToken(projectRoot, {
+      op: "setDesignToken",
+      component: { path: "src/styles/global.css", baseVersion: fileVersion(GLOBAL_CSS), token: "--does-not-exist", tokenValue: "red" },
+    });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("no-match");
+  });
+});

--- a/tests/design-token-edit.test.ts
+++ b/tests/design-token-edit.test.ts
@@ -45,4 +45,31 @@ describe("resolveDesignToken", () => {
     expect(result.refused).toBe(true);
     expect(result.reason).toBe("no-match");
   });
+
+  it("refuses a path other than src/styles/global.css rather than inferring one", async () => {
+    const result = await resolveDesignToken(projectRoot, {
+      op: "setDesignToken",
+      component: { path: "src/styles/other.css", baseVersion: fileVersion(GLOBAL_CSS), token: "--color-primary", tokenValue: "#111111" },
+    });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+
+  it("refuses a token that doesn't look like a CSS custom-property name", async () => {
+    const result = await resolveDesignToken(projectRoot, {
+      op: "setDesignToken",
+      component: { path: "src/styles/global.css", baseVersion: fileVersion(GLOBAL_CSS), token: "color-primary", tokenValue: "#111111" },
+    });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("invalid-input");
+  });
+
+  it("refuses a stale baseVersion rather than resolving against a changed file", async () => {
+    const result = await resolveDesignToken(projectRoot, {
+      op: "setDesignToken",
+      component: { path: "src/styles/global.css", baseVersion: "sha256:000000000000", token: "--color-primary", tokenValue: "#111111" },
+    });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("stale");
+  });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -832,4 +832,92 @@ describe("MCP annotation server", () => {
       proc.kill();
     }
   });
+
+  // Final review — Important: the golden round-trip suite (tests/page-ops-roundtrip.test.ts)
+  // calls resolvers directly and hand-rebuilds the inverse edit's baseVersion rather than
+  // exercising the REAL apply_edit dispatcher-stamped `inverse` object end to end. This is the
+  // one test that takes an edit-applied response's `inverse` VERBATIM — no rebuilding — and
+  // sends it straight back through apply_edit as a real MCP tool call, proving the promise in
+  // createEditAppliedContent's doc comment ("ready to send straight back through apply_edit
+  // unmodified for undo") actually holds for insertBlock, the most structurally complex op.
+  it("insertBlock's stamped inverse, sent back through apply_edit verbatim, restores the exact original bytes", async () => {
+    mkdirSync(join(tmpDir, "src", "pages"), { recursive: true });
+    const source = `---\n---\n<main><p id="keep">a</p></main>\n`;
+    writeFileSync(join(tmpDir, "src", "pages", "index.astro"), source);
+    const proc = startServer(tmpDir);
+    try {
+      await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      });
+      sendNotification(proc, { jsonrpc: "2.0", method: "notifications/initialized" });
+
+      const modelResponse = await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "get_page_model", arguments: { path: "src/pages/index.astro" } },
+      });
+      const modelResult = modelResponse.result as { content: { text: string }[]; isError?: boolean };
+      expect(modelResult.isError).toBeFalsy();
+      const model = JSON.parse(modelResult.content[0].text);
+      const main = model.tree.children.find((n: { tag?: string }) => n.tag === "main");
+
+      const insertResponse = await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: {
+          name: "apply_edit",
+          arguments: {
+            id: "insert-1",
+            path: "src/pages/index.astro",
+            op: "insertBlock",
+            component: {
+              path: "src/pages/index.astro",
+              baseVersion: model.version,
+              parentId: main.id,
+              index: 1,
+              node: { kind: "element", tag: "footer" },
+            },
+          },
+        },
+      });
+      const insertResult = insertResponse.result as { content: { text: string }[]; isError?: boolean };
+      expect(insertResult.isError).toBeFalsy();
+      const insertBody = JSON.parse(insertResult.content[0].text);
+      expect(insertBody.inverse.op).toBe("deleteBlock");
+      const afterInsert = readFileSync(join(tmpDir, "src", "pages", "index.astro"), "utf-8");
+      expect(afterInsert).toContain("<footer>");
+      expect(afterInsert).not.toBe(source);
+
+      // Send the dispatcher-stamped inverse straight back — VERBATIM, no rebuilding.
+      const undoResponse = await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 4,
+        method: "tools/call",
+        params: {
+          name: "apply_edit",
+          arguments: {
+            id: "undo-1",
+            path: "src/pages/index.astro",
+            op: insertBody.inverse.op,
+            component: insertBody.inverse.component,
+          },
+        },
+      });
+      const undoResult = undoResponse.result as { content: { text: string }[]; isError?: boolean };
+      expect(undoResult.isError).toBeFalsy();
+      const restored = readFileSync(join(tmpDir, "src", "pages", "index.astro"), "utf-8");
+      expect(restored).toBe(source);
+    } finally {
+      proc.kill();
+    }
+  });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "nod
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { spawn } from "node:child_process";
+import { fileVersion as fileVersionOf } from "../server/file-version.mjs";
 
 const SERVER_PATH = resolve(__dirname, "..", "server", "index.mjs");
 
@@ -779,6 +780,54 @@ describe("MCP annotation server", () => {
       expect(body.inverse.op).toBe("editText");
       const written = readFileSync(join(tmpDir, "src", "pages", "index.astro"), "utf-8");
       expect(written).toContain("<strong>Bye</strong>");
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("setDesignToken patches global.css's :root and returns a stamped inverse over stdio", async () => {
+    mkdirSync(join(tmpDir, "src", "styles"), { recursive: true });
+    const css = `:root {\n  --color-primary: #2563eb;\n}\n`;
+    writeFileSync(join(tmpDir, "src", "styles", "global.css"), css);
+    const proc = startServer(tmpDir);
+    try {
+      await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      });
+      sendNotification(proc, { jsonrpc: "2.0", method: "notifications/initialized" });
+
+      const editResponse = await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: "apply_edit",
+          arguments: {
+            id: "1",
+            path: "src/styles/global.css",
+            op: "setDesignToken",
+            component: {
+              path: "src/styles/global.css",
+              baseVersion: fileVersionOf(css),
+              token: "--color-primary",
+              tokenValue: "#111111",
+            },
+          },
+        },
+      });
+      const editResult = editResponse.result as { content: { text: string }[]; isError?: boolean };
+      expect(editResult.isError).toBeFalsy();
+      const payload = JSON.parse(editResult.content[0].text);
+      expect(payload.inverse.component.tokenValue).toBe("#2563eb");
+      const written = readFileSync(join(tmpDir, "src", "styles", "global.css"), "utf-8");
+      expect(written).toContain("--color-primary: #111111");
     } finally {
       proc.kill();
     }

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -185,6 +185,7 @@ describe("MCP annotation server", () => {
         "create_page",
         "create_post",
         "get_component_model",
+        "get_page_model",
         "list_annotations",
         "list_content",
         "resolve_annotation",
@@ -545,6 +546,50 @@ describe("MCP annotation server", () => {
       const failResult = failure.result as { content: { text: string }[]; isError?: boolean };
       expect(failResult.isError).toBe(true);
       expect(JSON.parse(failResult.content[0].text).reason).toBe("read-failed");
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("get_page_model returns a block-annotated tree over stdio", async () => {
+    mkdirSync(join(tmpDir, "src", "pages"), { recursive: true });
+    mkdirSync(join(tmpDir, "src", "components"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "blocks.manifest.json"),
+      JSON.stringify({
+        schemaVersion: "anglesite-block-manifest/1",
+        modules: [{ path: "src/components/Hcard.astro", export: "Hcard", name: "Business Card" }],
+      }),
+    );
+    writeFileSync(join(tmpDir, "src", "components", "Hcard.astro"), `---\n---\n<div>card</div>\n`);
+    writeFileSync(
+      join(tmpDir, "src", "pages", "index.astro"),
+      `---\nimport Hcard from "../components/Hcard.astro";\n---\n<Hcard />\n`,
+    );
+    const proc = startServer(tmpDir);
+    try {
+      await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      });
+      sendNotification(proc, { jsonrpc: "2.0", method: "notifications/initialized" });
+
+      const response = await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "get_page_model", arguments: { path: "src/pages/index.astro" } },
+      });
+      const result = response.result as { content: { text: string }[]; isError?: boolean };
+      expect(result.isError).toBeFalsy();
+      const model = JSON.parse(result.content[0].text);
+      expect(model.tree.children[0].block.name).toBe("Business Card");
     } finally {
       proc.kill();
     }

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -724,4 +724,63 @@ describe("MCP annotation server", () => {
       proc.kill();
     }
   });
+
+  it("editText replaces an element's inner content with re-serialized runs over stdio", async () => {
+    mkdirSync(join(tmpDir, "src", "pages"), { recursive: true });
+    const source = `---\n---\n<p id="t">Hello world</p>\n`;
+    writeFileSync(join(tmpDir, "src", "pages", "index.astro"), source);
+    const proc = startServer(tmpDir);
+    try {
+      await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      });
+      sendNotification(proc, { jsonrpc: "2.0", method: "notifications/initialized" });
+
+      const modelResponse = await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "get_page_model", arguments: { path: "src/pages/index.astro" } },
+      });
+      const modelResult = modelResponse.result as { content: { text: string }[]; isError?: boolean };
+      expect(modelResult.isError).toBeFalsy();
+      const model = JSON.parse(modelResult.content[0].text);
+      const p = model.tree.children.find((n: { tag?: string }) => n.tag === "p");
+
+      const editResponse = await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: {
+          name: "apply_edit",
+          arguments: {
+            id: "1",
+            path: "src/pages/index.astro",
+            op: "editText",
+            component: {
+              path: "src/pages/index.astro",
+              baseVersion: model.version,
+              textNodeId: p.id,
+              runs: [{ text: "Bye", marks: ["strong"] }],
+            },
+          },
+        },
+      });
+      const editResult = editResponse.result as { content: { text: string }[]; isError?: boolean };
+      expect(editResult.isError).toBeFalsy();
+      const body = JSON.parse(editResult.content[0].text);
+      expect(body.inverse.op).toBe("editText");
+      const written = readFileSync(join(tmpDir, "src", "pages", "index.astro"), "utf-8");
+      expect(written).toContain("<strong>Bye</strong>");
+    } finally {
+      proc.kill();
+    }
+  });
 });

--- a/tests/page-model.test.ts
+++ b/tests/page-model.test.ts
@@ -61,4 +61,22 @@ describe("buildPageModel", () => {
   it("throws PageModelError(invalid-input) for a non-.astro path", async () => {
     await expect(buildPageModel(dir, "src/pages/index.md")).rejects.toBeInstanceOf(PageModelError);
   });
+
+  // Final review — Important: an invalid blocks.manifest.json used to throw an untyped
+  // BlockManifestError straight out of buildPageModel, which the get_page_model tool handler
+  // (index-tools.mjs) can only report as reason "internal-error" since it isn't a PageModelError
+  // — losing the real parse-failed/invalid-manifest reason. Fix wraps loadBlockManifest and
+  // rethrows as a PageModelError carrying BlockManifestError's own reason/message through.
+  it("surfaces a malformed manifest's real reason as a PageModelError instead of an untyped throw", async () => {
+    writeFileSync(join(dir, "blocks.manifest.json"), "{ not valid json");
+    writeFileSync(join(dir, "src", "pages", "index.astro"), `---\n---\n<main></main>\n`);
+    let error: unknown;
+    try {
+      await buildPageModel(dir, "src/pages/index.astro");
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toBeInstanceOf(PageModelError);
+    expect((error as InstanceType<typeof PageModelError>).reason).toBe("parse-failed");
+  });
 });

--- a/tests/page-model.test.ts
+++ b/tests/page-model.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildPageModel, PageModelError } from "../server/page-model.mjs";
+
+const HCARD = `---\ninterface Props { name: string; }\nconst { name } = Astro.props;\n---\n<div class="h-card">{name}</div>\n`;
+
+const MANIFEST = JSON.stringify({
+  schemaVersion: "anglesite-block-manifest/1",
+  modules: [
+    { path: "src/components/Hcard.astro", export: "Hcard", name: "Business Card", description: "An h-card.", propEditors: [{ prop: "name", editor: "text" }] },
+  ],
+});
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "anglesite-page-model-"));
+  mkdirSync(join(dir, "src", "pages"), { recursive: true });
+  mkdirSync(join(dir, "src", "components"), { recursive: true });
+  writeFileSync(join(dir, "blocks.manifest.json"), MANIFEST);
+  writeFileSync(join(dir, "src", "components", "Hcard.astro"), HCARD);
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("buildPageModel", () => {
+  it("annotates a manifest-registered component instance with its block descriptor", async () => {
+    writeFileSync(
+      join(dir, "src", "pages", "index.astro"),
+      `---\nimport Hcard from "../components/Hcard.astro";\n---\n<main><Hcard name="Ana" /></main>\n`,
+    );
+    const model = await buildPageModel(dir, "src/pages/index.astro");
+    expect(model.path).toBe("src/pages/index.astro");
+    expect(model.version).toMatch(/^sha256:/);
+    const main = model.tree.children.find((n) => n.tag === "main")!;
+    const hcard = main.children.find((n) => n.tag === "Hcard")!;
+    expect(hcard.block).toEqual({
+      manifestPath: "src/components/Hcard.astro",
+      name: "Business Card",
+      description: "An h-card.",
+      icon: null,
+      propEditors: [{ prop: "name", editor: "text" }],
+      slots: [],
+    });
+  });
+
+  it("leaves an unregistered component's block field null", async () => {
+    writeFileSync(
+      join(dir, "src", "pages", "index.astro"),
+      `---\n---\n<main><Untracked /></main>\n`,
+    );
+    const model = await buildPageModel(dir, "src/pages/index.astro");
+    const untracked = model.tree.children.find((n) => n.tag === "main")!.children[0];
+    expect(untracked.block).toBeNull();
+  });
+
+  it("throws PageModelError(invalid-input) for a non-.astro path", async () => {
+    await expect(buildPageModel(dir, "src/pages/index.md")).rejects.toBeInstanceOf(PageModelError);
+  });
+});

--- a/tests/page-ops-roundtrip.test.ts
+++ b/tests/page-ops-roundtrip.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileVersion } from "../server/file-version.mjs";
+import { resolveComponentStructure } from "../server/component-structure-edit.mjs";
+import { resolveTextRuns } from "../server/text-run-edit.mjs";
+import { resolveDesignToken } from "../server/design-token-edit.mjs";
+
+let projectRoot: string;
+beforeEach(() => {
+  projectRoot = mkdtempSync(join(tmpdir(), "anglesite-roundtrip-"));
+  mkdirSync(join(projectRoot, "src", "pages"), { recursive: true });
+  mkdirSync(join(projectRoot, "src", "styles"), { recursive: true });
+});
+afterEach(() => rmSync(projectRoot, { recursive: true, force: true }));
+
+/** Applies `resolver`'s result to `original`, then applies the computed inverse to that
+ *  result, and asserts the round trip lands back on `original` byte-for-byte — the exact
+ *  "op → source diff → re-parsed model" golden shape the spec requires (§10), proven directly
+ *  against the resolver rather than through a live subprocess for speed and clarity. */
+async function assertRoundTrips(resolver, original, edit) {
+  const forward = await resolver(projectRoot, edit);
+  expect(forward.refused).toBeFalsy();
+  const afterForward = original.slice(0, forward.range.start) + forward.replacement + original.slice(forward.range.end);
+  expect(forward.inverse).toBeTruthy();
+  // Resolvers read the file fresh from disk (baseVersion is checked against on-disk content, not
+  // against anything held in memory here) — persist the forward result before resolving the
+  // inverse, or the backward call sees stale (pre-forward) content and refuses as stale.
+  writeFileSync(join(projectRoot, edit.component.path), afterForward);
+  const inverseEdit = { op: forward.inverse.op, component: { ...forward.inverse.component, baseVersion: fileVersion(afterForward) } };
+  const backward = await resolver(projectRoot, inverseEdit);
+  expect(backward.refused).toBeFalsy();
+  const afterBackward = afterForward.slice(0, backward.range.start) + backward.replacement + afterForward.slice(backward.range.end);
+  expect(afterBackward).toBe(original);
+  return { forward, backward };
+}
+
+describe("op round trips", () => {
+  it("setProp round-trips a changed attribute back to its original value", async () => {
+    const source = `---\n---\n<div id="a" title="old">x</div>\n`;
+    writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+    const { buildTemplateNodeIndex } = await import("../server/component-node-index.mjs");
+    const { parse } = await import("@astrojs/compiler");
+    const { ast } = await parse(source, { position: true });
+    const { byId } = buildTemplateNodeIndex(ast, source);
+    const divId = [...byId.values()].find((n: any) => n.tag === "div")!.id;
+    await assertRoundTrips(resolveComponentStructure, source, {
+      op: "setProp",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), nodeId: divId, name: "title", value: "new" },
+    });
+  });
+
+  it("editText round-trips a rewritten paragraph back to its original runs", async () => {
+    const source = `---\n---\n<p id="t">Hello world</p>\n`;
+    writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+    const { buildTemplateNodeIndex } = await import("../server/component-node-index.mjs");
+    const { parse } = await import("@astrojs/compiler");
+    const { ast } = await parse(source, { position: true });
+    const { byId } = buildTemplateNodeIndex(ast, source);
+    const p = [...byId.values()].find((n: any) => n.tag === "p")!;
+    await assertRoundTrips(resolveTextRuns, source, {
+      op: "editText",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), textNodeId: p.id, runs: [{ text: "Bye", marks: ["strong"] }] },
+    });
+  });
+
+  it("setDesignToken round-trips a changed token back to its original value", async () => {
+    const source = `:root {\n  --color-primary: #2563eb;\n}\n`;
+    writeFileSync(join(projectRoot, "src/styles/global.css"), source);
+    await assertRoundTrips(resolveDesignToken, source, {
+      op: "setDesignToken",
+      component: { path: "src/styles/global.css", baseVersion: fileVersion(source), token: "--color-primary", tokenValue: "#111111" },
+    });
+  });
+
+  // Documents Task 4 Step 8's known gap rather than leaving it silently uncovered (per this
+  // repo's "no silent caps" testing discipline): deleteBlock's raw-markup inverse does not
+  // restore a pruned import when the removed subtree was the import's only usage, so a
+  // deleteBlock → insertBlock round trip on such a subtree currently reconstructs the markup
+  // but NOT the import line. Fix (re-detect + re-add the import from the raw markup's tag
+  // name on reinsertion) is out of scope for this slice.
+  it.todo("deleteBlock/insertBlock round-trips import pruning when the block was the import's sole use");
+
+  // The three ops below (insertBlock/deleteBlock/moveBlock) use single-line, condensed markup —
+  // no newlines/indentation between the target node and its siblings — deliberately mirroring
+  // the fixtures already proven in tests/component-structure-edit.test.ts's "invertible ops"
+  // suite. Those inverses restore the correct NODE/PARENT/INDEX but do NOT restore surrounding
+  // whitespace on multi-line, indented markup (see the "KNOWN WHITESPACE-FIDELITY GAP" comments
+  // in server/component-structure-edit.mjs at the trim/reinsert sites) — condensed fixtures keep
+  // these assertions about real invertibility rather than about that documented, out-of-scope gap.
+
+  it("insertBlock round-trips a newly inserted node back out of the tree", async () => {
+    const source = `---\n---\n<main></main>\n`;
+    writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+    const { buildTemplateNodeIndex } = await import("../server/component-node-index.mjs");
+    const { parse } = await import("@astrojs/compiler");
+    const { ast } = await parse(source, { position: true });
+    const { byId } = buildTemplateNodeIndex(ast, source);
+    const main = [...byId.values()].find((n: any) => n.tag === "main")!;
+    await assertRoundTrips(resolveComponentStructure, source, {
+      op: "insertBlock",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), parentId: main.id, index: 0, node: { kind: "element", tag: "p" } },
+    });
+  });
+
+  it("deleteBlock round-trips a removed node back into the tree", async () => {
+    const source = `---\n---\n<main><p id="keep">a</p><p id="gone">b</p></main>\n`;
+    writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+    const { buildTemplateNodeIndex } = await import("../server/component-node-index.mjs");
+    const { parse } = await import("@astrojs/compiler");
+    const { ast } = await parse(source, { position: true });
+    const { byId } = buildTemplateNodeIndex(ast, source);
+    const gone = [...byId.values()].find((n: any) => n.tag === "p" && n.attrs.some((a: any) => a.name === "id" && a.value === "gone"))!;
+    await assertRoundTrips(resolveComponentStructure, source, {
+      op: "deleteBlock",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), nodeId: gone.id },
+    });
+  });
+
+  it("moveBlock round-trips a moved node back to its original parent/index", async () => {
+    const source = `---\n---\n<main><section id="from"><p id="m">x</p></section><section id="to"></section></main>\n`;
+    writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+    const { buildTemplateNodeIndex } = await import("../server/component-node-index.mjs");
+    const { parse } = await import("@astrojs/compiler");
+    const { ast } = await parse(source, { position: true });
+    const { byId } = buildTemplateNodeIndex(ast, source);
+    const p = [...byId.values()].find((n: any) => n.attrs.some((a: any) => a.name === "id" && a.value === "m"))!;
+    const to = [...byId.values()].find((n: any) => n.attrs.some((a: any) => a.name === "id" && a.value === "to"))!;
+    await assertRoundTrips(resolveComponentStructure, source, {
+      op: "moveBlock",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), nodeId: p.id, newParentId: to.id, newIndex: 0 },
+    });
+  });
+});

--- a/tests/text-run-edit.test.ts
+++ b/tests/text-run-edit.test.ts
@@ -131,6 +131,39 @@ describe("resolveTextRuns", () => {
     expect(result.inverse.component.runs).toEqual([{ text: "New", marks: [] }]);
   });
 
+  // Final review — Critical: the original inner HTML can carry ANY HTML entity, not just the
+  // three unescapeText reverses (&lt;/&gt;/&amp;) — e.g. &nbsp;/&mdash; from a site author's own
+  // markup or a prior hand-edit. unescapeText left them untouched (as literal text carrying a
+  // real "&" character), which escapeText then re-escaped into &amp;nbsp;/&amp;mdash; on
+  // write-back — silent, user-visible corruption on the undo path. Confirms the computed inverse
+  // holds the raw entity text (not mangled) AND that actually applying it as a real editText op
+  // restores the exact original bytes.
+  it("preserves HTML entities other than lt/gt/amp exactly through the computed inverse", async () => {
+    const source = `---\n---\n<p id="t">Cafe&nbsp;Bar &mdash; open</p>\n`;
+    const filePath = join(projectRoot, "src/pages/index.astro");
+    writeFileSync(filePath, source);
+    const { byId } = await indexSource(source);
+    const p = [...byId.values()].find((n) => n.tag === "p")!;
+    const result = await resolveTextRuns(projectRoot, {
+      op: "editText",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), textNodeId: p.id, runs: [{ text: "New text", marks: [] }] },
+    });
+    expect(result.refused).toBeFalsy();
+    // The reconstructed inverse must NOT have turned the entities into "&amp;nbsp;"/"&amp;mdash;".
+    expect(result.inverse.component.runs).toEqual([{ text: "Cafe&nbsp;Bar &mdash; open", marks: [] }]);
+
+    const edited = source.slice(0, result.range.start) + result.replacement + source.slice(result.range.end);
+    writeFileSync(filePath, edited);
+
+    const undo = await resolveTextRuns(projectRoot, {
+      op: "editText",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(edited), textNodeId: p.id, runs: result.inverse.component.runs },
+    });
+    expect(undo.refused).toBeFalsy();
+    const restored = edited.slice(0, undo.range.start) + undo.replacement + edited.slice(undo.range.end);
+    expect(restored).toBe(source);
+  });
+
   // Minor: a void/self-closing element has no inner-content region at all — refuse cleanly
   // rather than guess.
   it("refuses cleanly for a self-closing element with no inner content region", async () => {

--- a/tests/text-run-edit.test.ts
+++ b/tests/text-run-edit.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFileSync, mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parse } from "@astrojs/compiler";
+import { buildTemplateNodeIndex } from "../server/component-node-index.mjs";
+import { fileVersion } from "../server/file-version.mjs";
+import { resolveTextRuns } from "../server/text-run-edit.mjs";
+
+let projectRoot: string;
+beforeEach(() => {
+  projectRoot = mkdtempSync(join(tmpdir(), "anglesite-text-run-"));
+  mkdirSync(join(projectRoot, "src", "pages"), { recursive: true });
+});
+afterEach(() => rmSync(projectRoot, { recursive: true, force: true }));
+
+async function indexSource(source: string) {
+  const { ast } = await parse(source, { position: true });
+  return buildTemplateNodeIndex(ast, source);
+}
+
+describe("resolveTextRuns", () => {
+  it("re-serializes runs as honest inline HTML, replacing the element's inner content", async () => {
+    const source = `---\n---\n<p id="t">Hello world</p>\n`;
+    writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+    const { byId } = await indexSource(source);
+    const p = [...byId.values()].find((n) => n.tag === "p")!;
+    const result = await resolveTextRuns(projectRoot, {
+      op: "editText",
+      component: {
+        path: "src/pages/index.astro", baseVersion: fileVersion(source), textNodeId: p.id,
+        runs: [{ text: "Hello ", marks: [] }, { text: "world", marks: ["strong"] }],
+      },
+    });
+    expect(result.replacement).toBe("Hello <strong>world</strong>");
+  });
+
+  it("escapes text content so a run's text can never break out as markup", async () => {
+    const source = `---\n---\n<p id="t">old</p>\n`;
+    writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+    const { byId } = await indexSource(source);
+    const p = [...byId.values()].find((n) => n.tag === "p")!;
+    const result = await resolveTextRuns(projectRoot, {
+      op: "editText",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), textNodeId: p.id, runs: [{ text: "<b>x</b> & y", marks: [] }] },
+    });
+    expect(result.replacement).toBe("&lt;b&gt;x&lt;/b&gt; &amp; y");
+  });
+
+  it("computes an inverse editText restoring the original runs", async () => {
+    const source = `---\n---\n<p id="t">Hello world</p>\n`;
+    writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+    const { byId } = await indexSource(source);
+    const p = [...byId.values()].find((n) => n.tag === "p")!;
+    const result = await resolveTextRuns(projectRoot, {
+      op: "editText",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), textNodeId: p.id, runs: [{ text: "Bye", marks: [] }] },
+    });
+    expect(result.inverse).toEqual({
+      op: "editText",
+      component: { path: "src/pages/index.astro", textNodeId: p.id, runs: [{ text: "Hello world", marks: [] }] },
+    });
+  });
+});

--- a/tests/text-run-edit.test.ts
+++ b/tests/text-run-edit.test.ts
@@ -61,4 +61,88 @@ describe("resolveTextRuns", () => {
       component: { path: "src/pages/index.astro", textNodeId: p.id, runs: [{ text: "Hello world", marks: [] }] },
     });
   });
+
+  // Fix round 1 — Critical: a literal ">" inside a quoted attribute value used to fool a naive
+  // `indexOf(">", ...)` forward scan into landing inside the attribute list instead of past the
+  // opening tag's real end, corrupting the splice. Reproduces the reviewer's exact repro case.
+  it("resolves the inner-content boundary correctly when an attribute value contains a literal '>'", async () => {
+    const source = `---\n---\n<p title="a>b">text</p>\n`;
+    writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+    const { byId } = await indexSource(source);
+    const p = [...byId.values()].find((n) => n.tag === "p")!;
+    const result = await resolveTextRuns(projectRoot, {
+      op: "editText",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), textNodeId: p.id, runs: [{ text: "Bye", marks: ["strong"] }] },
+    });
+    expect(result.refused).toBeFalsy();
+    // The attribute survives untouched, and the splice lands strictly inside the real
+    // "text" content — not inside the attribute value (which would corrupt the tag).
+    const spliced = source.slice(0, result.range.start) + result.replacement + source.slice(result.range.end);
+    expect(spliced).toBe(`---\n---\n<p title="a>b"><strong>Bye</strong></p>\n`);
+    expect(result.inverse.component.runs).toEqual([{ text: "text", marks: [] }]);
+  });
+
+  // Fix round 1 — Important 1: original content shaped like MULTIPLE runs (e.g. the normal shape
+  // after a first edit) must fall back to the documented safe blunt inverse — one unmarked run of
+  // the stripped text — rather than a garbled reconstruction that leaks literal tag text into the
+  // run's `text` field.
+  it("falls back to a single unmarked run when the original content has more than one run", async () => {
+    const source = `---\n---\n<p id="t">Hello <strong>world</strong></p>\n`;
+    writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+    const { byId } = await indexSource(source);
+    const p = [...byId.values()].find((n) => n.tag === "p")!;
+    const result = await resolveTextRuns(projectRoot, {
+      op: "editText",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), textNodeId: p.id, runs: [{ text: "Bye", marks: [] }] },
+    });
+    expect(result.inverse.component.runs).toEqual([{ text: "Hello world", marks: [] }]);
+  });
+
+  // Fix round 1 — Important 1 (positive case): a genuinely single-run, fully-marked original
+  // (exactly the shape serializeRuns produces) still round-trips its marks precisely, so the
+  // stricter fallback check isn't overly conservative.
+  it("still recovers marks/text precisely for a genuine single marked run", async () => {
+    const source = `---\n---\n<p id="t"><strong>Bye</strong></p>\n`;
+    writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+    const { byId } = await indexSource(source);
+    const p = [...byId.values()].find((n) => n.tag === "p")!;
+    const result = await resolveTextRuns(projectRoot, {
+      op: "editText",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), textNodeId: p.id, runs: [{ text: "Hi", marks: [] }] },
+    });
+    expect(result.inverse.component.runs).toEqual([{ text: "Bye", marks: ["strong"] }]);
+  });
+
+  // Fix round 1 — Important 2: a component-kind node (an Astro component instance, e.g. a WYSIWYG
+  // block) must be editable too, not just plain HTML elements — matches set-attr's uniform
+  // element/component/slot treatment in component-structure-edit.mjs.
+  it("edits a component-kind node's inner content", async () => {
+    const source = `---\nimport Badge from "../components/Badge.astro";\n---\n<Badge>New</Badge>\n`;
+    writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+    const { byId } = await indexSource(source);
+    const badge = [...byId.values()].find((n) => n.tag === "Badge")!;
+    expect(badge.kind).toBe("component");
+    const result = await resolveTextRuns(projectRoot, {
+      op: "editText",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), textNodeId: badge.id, runs: [{ text: "Sale", marks: [] }] },
+    });
+    expect(result.refused).toBeFalsy();
+    expect(result.replacement).toBe("Sale");
+    expect(result.inverse.component.runs).toEqual([{ text: "New", marks: [] }]);
+  });
+
+  // Minor: a void/self-closing element has no inner-content region at all — refuse cleanly
+  // rather than guess.
+  it("refuses cleanly for a self-closing element with no inner content region", async () => {
+    const source = `---\n---\n<img id="t" src="x.jpg" />\n`;
+    writeFileSync(join(projectRoot, "src/pages/index.astro"), source);
+    const { byId } = await indexSource(source);
+    const img = [...byId.values()].find((n) => n.tag === "img")!;
+    const result = await resolveTextRuns(projectRoot, {
+      op: "editText",
+      component: { path: "src/pages/index.astro", baseVersion: fileVersion(source), textNodeId: img.id, runs: [{ text: "x", marks: [] }] },
+    });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("no-match");
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `get_page_model` — a page-level, block-annotated template tree read service (mirrors `get_component_model`'s shape) joined against a new theme `blocks.manifest.json` (a Custom Elements Manifest superset), so a page's component instances carry owner-facing name/description/icon/propEditors/slots when the theme registers them as blocks.
- Extends `apply_edit` with six ops for the upcoming WYSIWYG block editor (Anglesite-app epic #1221, slice 1: Anglesite-app#1222): `insertBlock`/`moveBlock`/`deleteBlock`/`setProp` (protocol-facing names dispatched through the existing `insert-node`/`move-node`/`remove-node`/`set-attr` resolvers), plus two new resolvers, `editText` (rich-text run editing on `.astro` template elements) and `setDesignToken` (global CSS custom-property editing in `global.css`'s light `:root` block).
- **Every op now returns a computed `inverse` op**, stamped by the dispatcher with the post-write content hash — the design spec's hard "no op ships without its inverse" requirement (substrate for the app's `NSUndoManager` undo, per `docs/superpowers/specs/2026-08-03-modern-wysiwyg-editor-design.md` §3.2).
- Implemented via 9-task subagent-driven development with per-task and whole-branch adversarial review; full plan at `docs/superpowers/plans/2026-08-10-page-block-model-ops-protocol.md`.

Two known, deliberately-documented v1 gaps (not fixed here, called out in code comments and the golden test suite): `deleteBlock`'s inverse doesn't restore a pruned component import when the removed subtree was its sole usage; `insertBlock`/`moveBlock`/`deleteBlock` inverses restore correct node/parent/index but not exact whitespace/indentation on multi-line markup.

## Paired PR check

- [ ] This change is **self-contained** to the plugin (skills / hooks / template / docs / MCP server with no consumer-visible contract change).
- [x] This change **needs a paired PR** in [`Anglesite/Anglesite-app`](https://github.com/Anglesite/Anglesite-app) (MCP message schema, template fields the app reads, hook surface, anything the native app embeds or shells out to). Link it here: _pending — this PR is the sidecar half of Anglesite-app#1222 (currently labeled `Blocked: human` pending routing); the app-side consumer PR has not been started yet._

> Cross-cutting changes land as paired PRs: the plugin ships first in a tagged release, then the app bumps its bundled-plugin pointer. The plugin is the source of truth for skills, hooks, and the MCP message schema. See `Anglesite-app/CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `npm test` — 156 test files, 3133 tests passing, 1 documented `.todo` (the import-pruning gap above)
- [ ] If touching the template: `scripts/scaffold.sh` produces a buildable site — N/A, this PR doesn't touch `template/`
- [ ] If touching the MCP server: paired app PR exercises the new/changed messages — **not yet done**, see Paired PR check above; the version bump/tag for this release is intentionally deferred to whoever merges (running `bin/release.ts` on an unmerged feature branch was judged premature — see Task 9 in the linked plan)

🤖 Generated with [Claude Code](https://claude.ai/code)