### PR TITLE
fix(server): give resolveAstro a structural fallback for tag+nthChild selectors

### DIFF
--- a/server/patcher.mjs
+++ b/server/patcher.mjs
@@ -1,6 +1,8 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative, extname, basename, dirname } from "node:path";
+import { parse } from "@astrojs/compiler";
 import { rewriteAstroStyle } from "./style-edit.mjs";
+import { buildTemplateNodeIndex } from "./component-node-index.mjs";
 import { resolveComponentStyle } from "./component-style-edit.mjs";
 import { resolveComponentStructure } from "./component-structure-edit.mjs";
 import { resolveComponentFrontmatter } from "./component-frontmatter-edit.mjs";
@@ -39,9 +41,11 @@ import {
  * `@astrojs/compiler`, which is itself async. `resolveDesignToken`
  * (design-token-edit.mjs) is also declared `async` for signature consistency
  * with those siblings, but its own CSS parse (css-tree, via `walkCssRules`)
- * is synchronous — no real yield point there. Every other resolver here is
- * synchronous; awaiting their (non-Promise) return values is a no-op, so this
- * doesn't change their behavior.
+ * is synchronous — no real yield point there. `resolveAstro` is async too:
+ * its structural fallback (locating an element by tag + nthChild when
+ * selector.textContent is absent) also parses with `@astrojs/compiler`.
+ * `resolveMdoc` and `resolveKeystatic` remain synchronous; awaiting their
+ * (non-Promise) return values in the `resolvers` loop below is a no-op.
  *
  * @param {string} projectRoot
  * @param {{ path: string, selector: object, op: string, value?: unknown, component?: object }} edit
@@ -73,7 +77,7 @@ export async function resolve(projectRoot, edit) {
   let bestRefusal = /** @type {ResolveRefusal | null} */ (null);
 
   for (const resolver of resolvers) {
-    const result = resolver(projectRoot, edit);
+    const result = await resolver(projectRoot, edit);
     if (!result.refused) return result;
     if (!bestRefusal || refusalPriority(result.reason) > refusalPriority(bestRefusal.reason)) {
       bestRefusal = result;
@@ -511,7 +515,92 @@ function resolveStyle(projectRoot, edit) {
   return { file, range: { start: 0, end: source.length }, replacement: r.next };
 }
 
-function resolveAstro(projectRoot, edit) {
+/**
+ * Structural fallback for when selector.textContent is absent: locate the
+ * Nth <tag> element in the template — "Nth" meaning position among ALL
+ * sibling elements/components, matching the CSS :nth-child semantics that
+ * selector.mjs's buildSelector encodes nthChild with — and derive the
+ * element's current text or attribute value to use as the search needle
+ * the rest of resolveAstro already knows how to work with.
+ *
+ * Only resolves when the value is statically known and unique:
+ *  - replace-text: the element's sole child must be a plain text node.
+ *    Mixed, nested, or dynamic-expression content can't be safely
+ *    reconstructed as a single contiguous source needle.
+ *  - replace-attr / replace-image-src: the named attribute must be a
+ *    literal quoted string, not a dynamic expression.
+ * Returns the derived needle string, or null if no safe unique match exists
+ * (caller falls through to the existing "nothing to search for" refusal).
+ */
+async function deriveStructuralNeedle(source, selector, op, attrName) {
+  const tag = selector.tag?.toLowerCase();
+  if (!tag || !Number.isInteger(selector.nthChild)) return null;
+
+  const templateStart = findAstroTemplateStart(source);
+  const template = source.slice(templateStart);
+
+  let ast;
+  try {
+    ({ ast } = await parse(template, { position: true }));
+  } catch {
+    return null;
+  }
+  const { byId } = buildTemplateNodeIndex(ast, template);
+
+  const candidates = [];
+  for (const node of byId.values()) {
+    if (node.kind !== "element" && node.kind !== "component") continue;
+    if (node.tag?.toLowerCase() !== tag) continue;
+    if (nthChildIndex(byId, node) !== selector.nthChild) continue;
+    candidates.push(node);
+  }
+  if (candidates.length !== 1) return null;
+  const [target] = candidates;
+
+  if (op === "replace-attr" || op === "replace-image-src") {
+    const attr = target.attrs.find((a) => a.name === attrName && a.kind === "quoted");
+    return attr ? attr.value : null;
+  }
+
+  if (target.childIds.length !== 1) return null;
+  const onlyChild = byId.get(target.childIds[0]);
+  if (onlyChild.kind !== "text") return null;
+  const [start, end] = onlyChild.span;
+  if (start == null || end == null) return null;
+  return template.slice(start, end).trim();
+}
+
+/** Position of `node` among its parent's element/component children, 1-indexed —
+ *  mirrors CSS :nth-child, which counts sibling elements regardless of tag. */
+function nthChildIndex(byId, node) {
+  const parent = byId.get(node.parentId);
+  if (!parent) return null;
+  let idx = 0;
+  for (const cid of parent.childIds) {
+    const c = byId.get(cid);
+    if (c.kind !== "element" && c.kind !== "component") continue;
+    idx++;
+    if (cid === node.id) return idx;
+  }
+  return null;
+}
+
+/** Try each candidate file's structural fallback in turn; use the first hit. */
+async function deriveStructuralNeedleFromCandidates(candidates, selector, op, attrName) {
+  for (const file of candidates) {
+    let source;
+    try {
+      source = readFileSync(file, "utf-8");
+    } catch {
+      continue;
+    }
+    const needle = await deriveStructuralNeedle(source, selector, op, attrName);
+    if (needle) return needle;
+  }
+  return null;
+}
+
+async function resolveAstro(projectRoot, edit) {
   const { path: pagePath, selector, op, value } = edit;
   const candidates = pathToAstroCandidates(projectRoot, pagePath);
 
@@ -520,7 +609,10 @@ function resolveAstro(projectRoot, edit) {
   }
 
   if (op === "replace-image-src") {
-    const currentSrc = selector.textContent;
+    let currentSrc = selector.textContent;
+    if (!currentSrc) {
+      currentSrc = await deriveStructuralNeedleFromCandidates(candidates, selector, op, "src");
+    }
     if (!currentSrc) {
       return refuse("no-match", "no current src to find in .astro files");
     }
@@ -552,7 +644,11 @@ function resolveAstro(projectRoot, edit) {
   }
 
   const textContent = selector.textContent;
-  const needle = op === "replace-text" ? textContent : getAttrSearchValue(op, selector, value);
+  let needle = op === "replace-text" ? textContent : getAttrSearchValue(op, selector, value);
+  if (!needle && (op === "replace-text" || op === "replace-attr")) {
+    const attrName = op === "replace-attr" && value && typeof value === "object" ? value.name : null;
+    needle = await deriveStructuralNeedleFromCandidates(candidates, selector, op, attrName);
+  }
   if (!needle) {
     return refuse("no-match", "nothing to search for in .astro files");
   }

--- a/tests/patcher-astro-structural-fallback.test.ts
+++ b/tests/patcher-astro-structural-fallback.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolve } from "../server/patcher.mjs";
+
+let root: string;
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "ang-astro-structural-"));
+  mkdirSync(join(root, "src/pages"), { recursive: true });
+});
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+function writePage(source: string) {
+  writeFileSync(join(root, "src/pages/about.astro"), source);
+}
+
+describe("resolveAstro structural fallback (selector.textContent absent)", () => {
+  it("locates a lone element by tag + nthChild for replace-text", async () => {
+    writePage("---\n---\n<h1>Welcome</h1>\n");
+    const r = await resolve(root, {
+      path: "/about/",
+      selector: { tag: "h1", classes: [], nthChild: 1 },
+      op: "replace-text",
+      value: "Hello",
+    });
+    expect(r.refused).toBeFalsy();
+    expect(r.replacement).toBe("Hello");
+  });
+
+  it("counts nthChild among all element/component siblings, not just same-tag ones", async () => {
+    writePage("---\n---\n<div><h1>A</h1><p>B</p><h1>C</h1></div>\n");
+    const r = await resolve(root, {
+      path: "/about/",
+      selector: { tag: "h1", classes: [], nthChild: 3 },
+      op: "replace-text",
+      value: "Z",
+    });
+    expect(r.refused).toBeFalsy();
+    // Must resolve to the SECOND <h1> ("C"), not the first ("A").
+    expect(r.replacement).toBe("Z");
+    const file = join(root, "src/pages/about.astro");
+    const source = readFileSync(file, "utf-8");
+    expect(source.slice(r.range.start, r.range.end)).toBe("C");
+  });
+
+  it("counts Astro components as siblings when computing nthChild", async () => {
+    writePage("---\n---\n<div><Header /><h1>Title</h1></div>\n");
+    const r = await resolve(root, {
+      path: "/about/",
+      selector: { tag: "h1", classes: [], nthChild: 2 },
+      op: "replace-text",
+      value: "New Title",
+    });
+    expect(r.refused).toBeFalsy();
+    expect(r.replacement).toBe("New Title");
+  });
+
+  it("derives the current attribute value for replace-attr", async () => {
+    writePage('---\n---\n<img src="/a.jpg" alt="Old Alt" />\n');
+    const r = await resolve(root, {
+      path: "/about/",
+      selector: { tag: "img", classes: [], nthChild: 1 },
+      op: "replace-attr",
+      value: { name: "alt", value: "New Alt" },
+    });
+    expect(r.refused).toBeFalsy();
+    expect(r.replacement).toBe("New Alt");
+    const file = join(root, "src/pages/about.astro");
+    const source = readFileSync(file, "utf-8");
+    expect(source.slice(r.range.start, r.range.end)).toBe("Old Alt");
+  });
+
+  it("derives the current src for replace-image-src", async () => {
+    writePage('---\n---\n<img src="/old.jpg" alt="x" />\n');
+    const r = await resolve(root, {
+      path: "/about/",
+      selector: { tag: "img", classes: [], nthChild: 1 },
+      op: "replace-image-src",
+      value: { src: "/new.jpg", srcset: "" },
+    });
+    expect(r.refused).toBeFalsy();
+    expect(r.replacement).toContain('src="/new.jpg"');
+  });
+
+  it("refuses (no-match) when the element mixes text with nested markup", async () => {
+    writePage("---\n---\n<h1>Hello <b>World</b></h1>\n");
+    const r = await resolve(root, {
+      path: "/about/",
+      selector: { tag: "h1", classes: [], nthChild: 1 },
+      op: "replace-text",
+      value: "Hi",
+    });
+    expect(r.refused).toBe(true);
+  });
+
+  it("refuses (no-match) when tag + nthChild match multiple elements structurally", async () => {
+    writePage("---\n---\n<div><h1>A</h1></div><div><h1>B</h1></div>\n");
+    const r = await resolve(root, {
+      path: "/about/",
+      selector: { tag: "h1", classes: [], nthChild: 1 },
+      op: "replace-text",
+      value: "Z",
+    });
+    expect(r.refused).toBe(true);
+    expect(r.reason).toBe("no-match");
+  });
+
+  it("still refuses when neither textContent nor a resolvable nthChild match is present", async () => {
+    writePage("---\n---\n<h1>Welcome</h1>\n");
+    const r = await resolve(root, {
+      path: "/about/",
+      selector: { tag: "h1", classes: [], nthChild: 5 },
+      op: "replace-text",
+      value: "Hello",
+    });
+    expect(r.refused).toBe(true);
+    expect(r.reason).toBe("no-match");
+  });
+});


### PR DESCRIPTION
## Summary

- `resolveAstro` (`server/patcher.mjs`) previously refused every `apply-edit` request whose selector lacked `textContent`, even when `tag` + `nthChild` alone were enough to deterministically locate the element — the case the app hits when nothing is selected in the live preview overlay.
- Added a structural fallback: parse the `.astro` template with `@astrojs/compiler`, locate the Nth element by tag (counting position among all sibling elements/components, matching the CSS `:nth-child` semantics `selector.mjs` already encodes `nthChild` with), and derive the current text/attribute value as the search needle — self-resolving, no client-side guess needed. Only resolves when the match is unique and the value is statically known (a lone text child; a literal quoted attribute) — otherwise falls through to the existing refusal.
- `resolveAstro` is now async (the compiler parse is async), which also surfaced and fixed a latent bug: the `resolvers` loop in `resolve()` called each resolver without `await`.

## Paired PR check

- [x] This change is **self-contained** to the plugin (MCP server, no consumer-visible contract change). `selector.tag`/`nthChild` already ship in the wire format today — the app already omits `textContent` when it doesn't have one, and will simply start succeeding instead of hitting the app-side refusal added in Anglesite/Anglesite-app#1411.
- [ ] This change needs a paired PR in `Anglesite/Anglesite-app`

## Test plan

- [x] `npx vitest run` — 3148 passed (1 pre-existing, unrelated failure: missing `tsx` binary in `node_modules/.bin`, confirmed present on `main` before this change too)
- [x] New tests in `tests/patcher-astro-structural-fallback.test.ts` cover: lone-element resolution, CSS-nth-child sibling counting across mixed tags, Astro components counted as siblings, `replace-attr`, `replace-image-src`, and the safety refusals (mixed text+markup content, multi-parent ambiguity, out-of-range `nthChild`)

Closes #437

Relates: Anglesite/Anglesite#1410, Anglesite/Anglesite#1411