### PR TITLE
feat: add insert-image apply_edit op

### DIFF
--- a/server/apply-edit-dispatcher.mjs
+++ b/server/apply-edit-dispatcher.mjs
@@ -35,7 +35,7 @@ import {
 import { join, dirname, basename, extname } from "node:path";
 import { Buffer } from "node:buffer";
 import { randomBytes } from "node:crypto";
-import { resolve as resolveEdit } from "./patcher.mjs";
+import { resolve as resolveEdit, pathToAstroCandidates } from "./patcher.mjs";
 import { optimizeImage } from "./optimize-images.mjs";
 import {
   createEditAppliedContent,
@@ -126,7 +126,7 @@ async function processImageDrop(projectRoot, edit) {
     throw new Error("image drop missing dataURL");
   }
 
-  const currentSrc = selector.textContent ?? "";
+  const currentSrc = selector?.textContent ?? "";
   let stem;
   const localMatch = currentSrc.match(/\/images\/([^/?#]+?)(?:\.[a-z0-9]+)?$/i);
   if (localMatch) {
@@ -307,7 +307,15 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
   let effectiveEdit = edit;
   let imageResult;
 
-  if (edit.op === "replace-image-src") {
+  // insert-image has no selector to match against, so unlike replace-image-src there's nothing
+  // stopping processImageDrop from writing+optimizing bytes to public/images/ even when the
+  // target page doesn't exist. Check the page resolves to exactly one .astro candidate first —
+  // resolveInsertImage would refuse the same way, but only after the (wasted) disk write.
+  if (edit.op === "insert-image" && pathToAstroCandidates(projectRoot, edit.path).length === 0) {
+    return failed(edit.id, "no-match", `no .astro file found for path ${edit.path}`);
+  }
+
+  if (edit.op === "replace-image-src" || edit.op === "insert-image") {
     try {
       imageResult = await processImageDrop(projectRoot, edit);
     } catch (err) {
@@ -315,7 +323,7 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
     }
     effectiveEdit = {
       ...edit,
-      value: { src: imageResult.src, srcset: imageResult.srcset },
+      value: { src: imageResult.src, srcset: imageResult.srcset, alt: edit.value?.alt },
     };
   }
 

--- a/server/apply-edit-dispatcher.mjs
+++ b/server/apply-edit-dispatcher.mjs
@@ -295,7 +295,7 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
 
   // dry_run is read-only. Image edits can't be previewed without writing optimized
   // bytes to disk, so refuse rather than violate the no-write invariant.
-  if (edit.dry_run && edit.op === "replace-image-src") {
+  if (edit.dry_run && (edit.op === "replace-image-src" || edit.op === "insert-image")) {
     return failed(edit.id, "not-implemented", "dry-run preview is not supported for image edits");
   }
   // Same reasoning for extract-component: its two-file write doesn't fit the single-window

--- a/server/apply-edit-schema.mjs
+++ b/server/apply-edit-schema.mjs
@@ -46,6 +46,7 @@ export const editOps = [
   "replace-text",
   "replace-attr",
   "replace-image-src",
+  "insert-image",
   "edit-style",
   "apply-instruction",
   "set-style-property",
@@ -221,13 +222,13 @@ export const applyEditInputShape = {
   op: z
     .enum(editOps)
     .describe(
-      "Edit operation: replace-text (innerText), replace-attr (value is {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>), apply-instruction (reserved: sent only by the Anglesite-app Foundation Models chat path; always returns edit-failed/needs-agent — do not use from external callers), set-style-property/remove-style-property/add-style-rule/set-rule-selector (component-style ops), insert-node/move-node/remove-node/set-attr (component-structure ops), set-props-interface/set-script-zone (component-frontmatter ops), extract-component (nodeId + newName — writes a new src/components/<newName>.astro from the selected subtree, hoists obvious literal props, and replaces the selection in the source file with an instance + import — see componentEditSchema), and the WYSIWYG block-editor ops (same component-structure/text/style-token machinery, protocol-facing vocabulary, each returning a computed `inverse` for host-side undo): insertBlock (component.node or component.manifestBlock + parentId/index — insert a new element/component/slot/raw-markup node, or a blocks.manifest.json-registered block, as a child), moveBlock (component.nodeId + newParentId/newIndex — reparent/reorder an existing node), deleteBlock (component.nodeId — remove a node and its subtree), setProp (component.nodeId/name/value — set or, with value null, remove an attribute), editText (component.textNodeId/runs — replace an element/component/slot's inner content with re-serialized rich-text runs), setDesignToken (component.token/tokenValue — edit a global CSS custom property)",
+      "Edit operation: replace-text (innerText), replace-attr (value is {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), insert-image (value is {filename, mimeType, dataURL, alt?}; inserts a brand-new <img> into the page identified by path — no selector, no existing image required), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>), apply-instruction (reserved: sent only by the Anglesite-app Foundation Models chat path; always returns edit-failed/needs-agent — do not use from external callers), set-style-property/remove-style-property/add-style-rule/set-rule-selector (component-style ops), insert-node/move-node/remove-node/set-attr (component-structure ops), set-props-interface/set-script-zone (component-frontmatter ops), extract-component (nodeId + newName — writes a new src/components/<newName>.astro from the selected subtree, hoists obvious literal props, and replaces the selection in the source file with an instance + import — see componentEditSchema), and the WYSIWYG block-editor ops (same component-structure/text/style-token machinery, protocol-facing vocabulary, each returning a computed `inverse` for host-side undo): insertBlock (component.node or component.manifestBlock + parentId/index — insert a new element/component/slot/raw-markup node, or a blocks.manifest.json-registered block, as a child), moveBlock (component.nodeId + newParentId/newIndex — reparent/reorder an existing node), deleteBlock (component.nodeId — remove a node and its subtree), setProp (component.nodeId/name/value — set or, with value null, remove an attribute), editText (component.textNodeId/runs — replace an element/component/slot's inner content with re-serialized rich-text runs), setDesignToken (component.token/tokenValue — edit a global CSS custom property)",
     ),
   value: z
     .unknown()
     .optional()
     .describe(
-      "Operation payload; varies by op (string for replace-text, {name, value} for replace-attr, {filename, mimeType, dataURL} for replace-image-src, {property, value} for edit-style, string for apply-instruction — the NL instruction text). Omitted for the component ops, whose payload is `component`.",
+      "Operation payload; varies by op (string for replace-text, {name, value} for replace-attr, {filename, mimeType, dataURL} for replace-image-src, {filename, mimeType, dataURL, alt?} for insert-image, {property, value} for edit-style, string for apply-instruction — the NL instruction text). Omitted for the component ops, whose payload is `component`.",
     ),
   dry_run: z
     .boolean()

--- a/server/component-structure-edit.mjs
+++ b/server/component-structure-edit.mjs
@@ -633,7 +633,7 @@ function childlessInsertionPoint(parent, rootId, spans, source) {
 //     is resolvable at all, falls back to the childless-parent case.
 //
 // Returns null when no insertion point could be resolved.
-function resolveInsertionOffset(byId, rootId, spans, source, parent, index, excludeChildId) {
+export function resolveInsertionOffset(byId, rootId, spans, source, parent, index, excludeChildId) {
   const children = parent.childIds.filter((id) => id !== excludeChildId).map((id) => byId.get(id));
   if (children.length === 0) {
     return childlessInsertionPoint(parent, rootId, spans, source);

--- a/server/insert-image-edit.mjs
+++ b/server/insert-image-edit.mjs
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import { relative } from "node:path";
+import { parse } from "@astrojs/compiler";
+import { buildTemplateNodeIndex } from "./component-node-index.mjs";
+import { resolveAllSpans, resolveInsertionOffset, escapeAttr } from "./component-structure-edit.mjs";
+import { pathToAstroCandidates } from "./patcher.mjs";
+
+function refuse(reason, detail) {
+  return { refused: true, reason, detail };
+}
+
+/**
+ * Picks where a brand-new image should land inside a page's template: as the last child of the
+ * page's sole wrapping Layout component when there is exactly one (every template page wraps its
+ * content in one Layout, e.g. `<BaseLayout>...</BaseLayout>` — appending at the literal AST
+ * fragment root would insert the <img> as a SIBLING of that wrapper, outside the rendered page
+ * content), falling back to the fragment root itself for anything else (zero or multiple
+ * top-level nodes, or a single non-component top-level node).
+ */
+function resolveImageParent(byId, rootId) {
+  const root = byId.get(rootId);
+  if (root.childIds.length === 1) {
+    const only = byId.get(root.childIds[0]);
+    if (only && only.kind === "component") return only;
+  }
+  return root;
+}
+
+/**
+ * Resolves `insert-image` to a single-file patch that appends a new `<img>` inside the target
+ * page's content. Unlike `insert-node`/`resolveComponentStructure`, this is NOT a component-payload
+ * op — it addresses its target via `edit.path` (a URL page path, like `replace-image-src`), has no
+ * `baseVersion` staleness guard (there is no prior `get_component_model` fetch to go stale against
+ * — the file is always read fresh here), and takes no `component.parentId`/`index` — the insertion
+ * point is always "append inside this page's content," resolved fresh from the current file.
+ *
+ * @param {string} projectRoot
+ * @param {{ path: string, value: { src: string, srcset?: string, alt?: string } }} edit
+ */
+export async function resolveInsertImage(projectRoot, edit) {
+  const candidates = pathToAstroCandidates(projectRoot, edit.path);
+  if (candidates.length === 0) {
+    return refuse("no-match", `no .astro file found for path ${edit.path}`);
+  }
+  if (candidates.length > 1) {
+    return refuse("ambiguous", `${candidates.length} .astro files match path ${edit.path}`);
+  }
+  const absPath = candidates[0];
+
+  let source;
+  try {
+    source = readFileSync(absPath, "utf-8");
+  } catch (err) {
+    return refuse("write-failed", `read ${edit.path}: ${err.message}`);
+  }
+
+  let ast;
+  try {
+    ({ ast } = await parse(source, { position: true }));
+  } catch (err) {
+    return refuse("parse-failed", `parse ${edit.path}: ${err.message}`);
+  }
+
+  const { byId, rootId } = buildTemplateNodeIndex(ast, source);
+  const parent = resolveImageParent(byId, rootId);
+
+  let spans;
+  try {
+    spans = resolveAllSpans(byId, rootId, source);
+  } catch {
+    return refuse(
+      "no-match",
+      "could not lexically re-locate the page's structure without trusting compiler offsets — refusing rather than risking corruption",
+    );
+  }
+
+  const insertAt = resolveInsertionOffset(byId, rootId, spans, source, parent, parent.childIds.length, undefined);
+  if (insertAt == null) {
+    return refuse("no-match", "could not resolve an insertion point in the page");
+  }
+
+  const { src, srcset, alt } = edit.value;
+  const attrs = [`src="${escapeAttr(src)}"`];
+  if (srcset) attrs.push(`srcset="${escapeAttr(srcset)}"`);
+  attrs.push(`alt="${escapeAttr(alt ?? "")}"`);
+  const markup = `\n  <img ${attrs.join(" ")} />`;
+  const replacement = source.slice(0, insertAt) + markup + source.slice(insertAt);
+
+  return { file: relative(projectRoot, absPath), range: { start: 0, end: source.length }, replacement };
+}

--- a/server/insert-image-edit.mjs
+++ b/server/insert-image-edit.mjs
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { relative } from "node:path";
 import { parse } from "@astrojs/compiler";
 import { buildTemplateNodeIndex } from "./component-node-index.mjs";
-import { resolveAllSpans, resolveInsertionOffset, escapeAttr } from "./component-structure-edit.mjs";
+import { resolveAllSpans, resolveInsertionOffset, escapeAttr, SpanResolutionError } from "./component-structure-edit.mjs";
 import { pathToAstroCandidates } from "./patcher.mjs";
 
 function refuse(reason, detail) {
@@ -67,7 +67,8 @@ export async function resolveInsertImage(projectRoot, edit) {
   let spans;
   try {
     spans = resolveAllSpans(byId, rootId, source);
-  } catch {
+  } catch (err) {
+    if (!(err instanceof SpanResolutionError)) throw err;
     return refuse(
       "no-match",
       "could not lexically re-locate the page's structure without trusting compiler offsets — refusing rather than risking corruption",

--- a/server/patcher.mjs
+++ b/server/patcher.mjs
@@ -5,6 +5,7 @@ import { resolveComponentStyle } from "./component-style-edit.mjs";
 import { resolveComponentStructure } from "./component-structure-edit.mjs";
 import { resolveComponentFrontmatter } from "./component-frontmatter-edit.mjs";
 import { resolveComponentExtract } from "./component-extract-edit.mjs";
+import { resolveInsertImage } from "./insert-image-edit.mjs";
 import { resolveTextRuns } from "./text-run-edit.mjs";
 import { resolveDesignToken } from "./design-token-edit.mjs";
 import {
@@ -62,6 +63,9 @@ export async function resolve(projectRoot, edit) {
   }
   if (COMPONENT_EXTRACT_OPS.has(edit.op)) {
     return resolveComponentExtract(projectRoot, edit);
+  }
+  if (edit.op === "insert-image") {
+    return resolveInsertImage(projectRoot, edit);
   }
   if (COMPONENT_TEXT_OPS.has(edit.op)) {
     return resolveTextRuns(projectRoot, edit);

--- a/server/patcher.mjs
+++ b/server/patcher.mjs
@@ -218,7 +218,7 @@ function findImgTagBySrc(source, srcNeedle) {
  * Map a page path to candidate .astro files in src/pages/.
  * /about/ → [src/pages/about.astro, src/pages/about/index.astro]
  */
-function pathToAstroCandidates(projectRoot, pagePath) {
+export function pathToAstroCandidates(projectRoot, pagePath) {
   const normalized = pagePath.replace(/^\/|\/$/g, "") || "index";
   const pagesDir = join(projectRoot, "src", "pages");
   const candidates = [];

--- a/test/apply-edit-dispatcher.test.js
+++ b/test/apply-edit-dispatcher.test.js
@@ -386,4 +386,28 @@ describe("insert-image", () => {
     const reply = JSON.parse(result.content[0].text);
     expect(reply.reason).toBe("image-optimize-failed");
   });
+
+  it("refuses dry_run with not-implemented and writes nothing to public/images/", async () => {
+    writeFileSync(
+      join(projectRoot, "src/pages/index.astro"),
+      `---\nimport BaseLayout from "../layouts/BaseLayout.astro";\n---\n\n<BaseLayout title="Home">\n  <h1>Welcome</h1>\n</BaseLayout>\n`,
+    );
+    const dropped = await sharp({ create: { width: 800, height: 600, channels: 3, background: { r: 0, g: 0, b: 0 } } })
+      .jpeg()
+      .toBuffer();
+    const dataURL = `data:image/jpeg;base64,${dropped.toString("base64")}`;
+
+    const result = await applyEdit(projectRoot, {
+      id: "e-5",
+      path: "/",
+      op: "insert-image",
+      dry_run: true,
+      value: { filename: "preview.jpg", mimeType: "image/jpeg", dataURL },
+    });
+
+    expect(result.isError).toBe(true);
+    const reply = JSON.parse(result.content[0].text);
+    expect(reply.reason).toBe("not-implemented");
+    expect(existsSync(join(projectRoot, "public/images"))).toBe(false);
+  });
 });

--- a/test/apply-edit-dispatcher.test.js
+++ b/test/apply-edit-dispatcher.test.js
@@ -280,3 +280,110 @@ describe("replace-image-src", () => {
     expect(reply.reason).toBe("image-optimize-failed");
   });
 });
+
+describe("insert-image", () => {
+  let projectRoot;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), "anglesite-img-insert-"));
+    mkdirSync(join(projectRoot, "src/pages"), { recursive: true });
+    mkdirSync(join(projectRoot, "src/layouts"), { recursive: true });
+    writeFileSync(
+      join(projectRoot, "src/layouts/BaseLayout.astro"),
+      `---\ninterface Props { title: string }\nconst { title } = Astro.props;\n---\n<html><head><title>{title}</title></head><body><slot /></body></html>\n`,
+    );
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it("writes bytes, optimizes, inserts a new <img> inside the page's Layout, and returns result.src+srcset", async () => {
+    writeFileSync(
+      join(projectRoot, "src/pages/index.astro"),
+      `---\nimport BaseLayout from "../layouts/BaseLayout.astro";\n---\n\n<BaseLayout title="Home">\n  <h1>Welcome</h1>\n</BaseLayout>\n`,
+    );
+
+    const dropped = await sharp({ create: { width: 2000, height: 1500, channels: 3, background: { r: 10, g: 200, b: 10 } } })
+      .jpeg()
+      .toBuffer();
+    const dataURL = `data:image/jpeg;base64,${dropped.toString("base64")}`;
+
+    const result = await applyEdit(projectRoot, {
+      id: "e-1",
+      path: "/",
+      op: "insert-image",
+      value: { filename: "garden.jpg", mimeType: "image/jpeg", dataURL },
+    });
+
+    expect(result.isError).toBeUndefined();
+    const reply = JSON.parse(result.content[0].text);
+    expect(reply.type).toBe("anglesite:edit-applied");
+    expect(reply.result.src).toBe("/images/garden.webp");
+    expect(reply.result.srcset).toContain("480w");
+
+    const astro = readFileSync(join(projectRoot, "src/pages/index.astro"), "utf-8");
+    expect(astro).toContain('<img src="/images/garden.webp"');
+    // Lands inside BaseLayout, after the existing <h1>, not after </BaseLayout>.
+    const h1End = astro.indexOf("</h1>");
+    const imgStart = astro.indexOf("<img");
+    const layoutEnd = astro.indexOf("</BaseLayout>");
+    expect(imgStart).toBeGreaterThan(h1End);
+    expect(imgStart).toBeLessThan(layoutEnd);
+
+    expect(existsSync(join(projectRoot, "public/images/garden.webp"))).toBe(true);
+  });
+
+  it("uses the dropped filename's stem — there is no existing image to derive one from", async () => {
+    writeFileSync(
+      join(projectRoot, "src/pages/index.astro"),
+      `---\nimport BaseLayout from "../layouts/BaseLayout.astro";\n---\n\n<BaseLayout title="Home">\n  <h1>Welcome</h1>\n</BaseLayout>\n`,
+    );
+    const dropped = await sharp({ create: { width: 800, height: 600, channels: 3, background: { r: 0, g: 0, b: 0 } } })
+      .png()
+      .toBuffer();
+    const dataURL = `data:image/png;base64,${dropped.toString("base64")}`;
+
+    const result = await applyEdit(projectRoot, {
+      id: "e-2",
+      path: "/",
+      op: "insert-image",
+      value: { filename: "team-photo.png", mimeType: "image/png", dataURL },
+    });
+
+    const reply = JSON.parse(result.content[0].text);
+    expect(reply.result.src).toBe("/images/team-photo.webp");
+  });
+
+  it("refuses with no-match when no .astro file exists for the path", async () => {
+    const result = await applyEdit(projectRoot, {
+      id: "e-3",
+      path: "/nowhere/",
+      op: "insert-image",
+      value: { filename: "x.jpg", mimeType: "image/jpeg", dataURL: "data:image/jpeg;base64,AA==" },
+    });
+
+    expect(result.isError).toBe(true);
+    const reply = JSON.parse(result.content[0].text);
+    expect(reply.type).toBe("anglesite:edit-failed");
+    expect(reply.reason).toBe("no-match");
+  });
+
+  it("returns image-optimize-failed when the dataURL bytes are corrupt", async () => {
+    writeFileSync(
+      join(projectRoot, "src/pages/index.astro"),
+      `---\nimport BaseLayout from "../layouts/BaseLayout.astro";\n---\n\n<BaseLayout title="Home">\n  <h1>Welcome</h1>\n</BaseLayout>\n`,
+    );
+
+    const result = await applyEdit(projectRoot, {
+      id: "e-4",
+      path: "/",
+      op: "insert-image",
+      value: { filename: "x.jpg", mimeType: "image/jpeg", dataURL: "data:image/jpeg;base64,not-valid-base64!!!" },
+    });
+
+    expect(result.isError).toBe(true);
+    const reply = JSON.parse(result.content[0].text);
+    expect(reply.reason).toBe("image-optimize-failed");
+  });
+});

--- a/test/apply-edit-schema.test.js
+++ b/test/apply-edit-schema.test.js
@@ -73,6 +73,16 @@ describe("applyEditInputShape", () => {
       expect(applyEditSchema.safeParse({ ...validPayload, op }).success).toBe(true);
     }
   });
+
+  it("accepts insert-image as a valid op", () => {
+    const result = applyEditSchema.safeParse({
+      id: "e-1",
+      path: "/",
+      op: "insert-image",
+      value: { filename: "photo.jpg", mimeType: "image/jpeg", dataURL: "data:image/jpeg;base64,AA==" },
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 describe("elementInfoSchema", () => {


### PR DESCRIPTION
## Summary

- Adds a new `insert-image` op to the `apply_edit` MCP tool: writes a brand-new optimized image asset (reusing the existing `replace-image-src` write/optimize pipeline) and inserts a new `<img>` into a page's content, for pages that have no existing image to replace.
- Descends into the page's sole wrapping Layout component (e.g. `<BaseLayout>`) when appending, rather than the literal AST fragment root, so the inserted image lands inside the rendered page content instead of as a sibling of the Layout wrapper.
- No `selector`/container targeting for v1 — always appends at the page's content root, matching both planned app-side entry points (drag-drop on an image-less page, and a new `Insert ▸ Image` menu command).

## Paired PR check

- [ ] This change is **self-contained** to the plugin (skills / hooks / template / docs / MCP server with no consumer-visible contract change).
- [x] This change **needs a paired PR** in [`Anglesite/Anglesite-app`](https://github.com/Anglesite/Anglesite-app) (MCP message schema — new `apply_edit` op the app must send). Link it here: Anglesite/Anglesite#1413

> Cross-cutting changes land as paired PRs: the plugin ships first in a tagged release, then the app bumps its bundled-plugin pointer. The plugin is the source of truth for skills, hooks, and the MCP message schema. See `Anglesite-app/CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] Plugin self-checks pass — `npm test` (full suite, 3146 passed, 1 pre-existing unrelated failure in `test/optimize-images-packaging.test.js`, confirmed present before this branch's work started)
- [ ] If touching the template: `scripts/scaffold.sh` produces a buildable site — N/A, no template changes
- [ ] If touching the MCP server: paired app PR exercises the new/changed messages — Anglesite/Anglesite#1413 (draft, pending this PR merging)

Related: Anglesite/Anglesite-app#1408

🤖 Generated with [Claude Code](https://claude.com/claude-code)