### PR TITLE
fix(#1421): resolve replace-image-src against md/mdx frontmatter

### DIFF
--- a/server/patcher.mjs
+++ b/server/patcher.mjs
@@ -30,9 +30,10 @@ import {
  *
  * Tries resolvers in priority order: edit-style → component-style ops →
  * component-structure ops → component-frontmatter ops → component-extract op →
- * editText → setDesignToken → .mdoc → Keystatic YAML/JSON → .astro. Returns
- * the first non-refusal. If all refuse, returns the most informative refusal
- * (from the highest-priority resolver that had an opinion).
+ * editText → setDesignToken → content-frontmatter image → .mdoc → Keystatic
+ * YAML/JSON → .astro. Returns the first non-refusal. If all refuse, returns
+ * the most informative refusal (from the highest-priority resolver that had
+ * an opinion).
  *
  * Async because `resolveComponentStyle` (component-style-edit.mjs),
  * `resolveComponentStructure` (component-structure-edit.mjs),
@@ -45,8 +46,9 @@ import {
  * is synchronous — no real yield point there. `resolveAstro` is async too:
  * its structural fallback (locating an element by tag + nthChild when
  * selector.textContent is absent) also parses with `@astrojs/compiler`.
- * `resolveMdoc` and `resolveKeystatic` remain synchronous; awaiting their
- * (non-Promise) return values in the `resolvers` loop below is a no-op.
+ * `resolveFrontmatterImage`, `resolveMdoc`, and `resolveKeystatic` remain
+ * synchronous; awaiting their (non-Promise) return values in the `resolvers`
+ * loop below is a no-op.
  *
  * @param {string} projectRoot
  * @param {{ path: string, selector: object, op: string, value?: unknown, component?: object }} edit
@@ -77,7 +79,7 @@ export async function resolve(projectRoot, edit) {
   if (DESIGN_TOKEN_OPS.has(edit.op)) {
     return resolveDesignToken(projectRoot, edit);
   }
-  const resolvers = [resolveMdoc, resolveKeystatic, resolveAstro];
+  const resolvers = [resolveFrontmatterImage, resolveMdoc, resolveKeystatic, resolveAstro];
   let bestRefusal = /** @type {ResolveRefusal | null} */ (null);
 
   for (const resolver of resolvers) {
@@ -255,6 +257,90 @@ export function pathToAstroCandidates(projectRoot, pagePath) {
 function extractSlug(pagePath) {
   const segments = pagePath.replace(/^\/|\/$/g, "").split("/");
   return segments[segments.length - 1] || "";
+}
+
+// ── Content-frontmatter image resolver ──────────────────────────────
+
+/**
+ * Resolve replace-image-src edits against Markdown/MDX content-collection
+ * frontmatter, e.g. `image: "/images/hello.svg"`. Covers the case the other
+ * resolvers can't reach: a layout that renders a frontmatter field through a
+ * dynamic expression (`<img src={d.image} />`), so there's no literal `<img
+ * src="…">` tag for `resolveAstro` to find and no `.mdoc` body text for
+ * `resolveMdoc` to match. Matches on the field's *value*, not its name —
+ * different collections may store an image path under different keys.
+ */
+function resolveFrontmatterImage(projectRoot, edit) {
+  if (edit.op !== "replace-image-src") {
+    return refuse("no-match", "frontmatter image resolver only handles replace-image-src");
+  }
+  const { selector, value } = edit;
+  const currentSrc = getAttrSearchValue(edit.op, selector, value);
+  if (!currentSrc) {
+    return refuse("no-match", "no current src to find in content frontmatter");
+  }
+
+  const contentDir = join(projectRoot, "src", "content");
+  const mdFiles = walkFiles(contentDir, (name) => extname(name) === ".md" || extname(name) === ".mdx");
+  if (mdFiles.length === 0) {
+    return refuse("no-match", "no .md/.mdx content files found");
+  }
+
+  const allMatches = [];
+  for (const file of mdFiles) {
+    let source;
+    try {
+      source = readFileSync(file, "utf-8");
+    } catch {
+      continue;
+    }
+    const frontmatterEnd = findFrontmatterEnd(source);
+    if (frontmatterEnd === 0) continue;
+    const range = findFrontmatterFieldValue(source.slice(0, frontmatterEnd), currentSrc);
+    if (range) {
+      allMatches.push({ file: relative(projectRoot, file), range });
+    }
+  }
+
+  if (allMatches.length === 0) {
+    return refuse("no-match", `no frontmatter field matches src="${currentSrc}"`);
+  }
+  if (allMatches.length > 1) {
+    return refuse("ambiguous", `${allMatches.length} content files have a frontmatter field matching src="${currentSrc}"`);
+  }
+
+  return {
+    file: allMatches[0].file,
+    range: allMatches[0].range,
+    replacement: value && typeof value === "object" ? String(value.src ?? "") : "",
+  };
+}
+
+/**
+ * Find the value range of a top-level YAML frontmatter field whose value is
+ * exactly `needle` — quoted (`image: "/x.svg"` or `image: '/x.svg'`) or a
+ * plain scalar (`image: /x.svg`). Returns the range of the value only (quotes
+ * excluded, mirroring resolveKeystatic's findValueInDataFile), or null.
+ */
+function findFrontmatterFieldValue(frontmatter, needle) {
+  const quotedRe = /^([ \t]*[\w-]+:[ \t]*)(["'])((?:(?!\2).)*)\2[ \t]*$/gm;
+  let m;
+  while ((m = quotedRe.exec(frontmatter)) !== null) {
+    if (m[3] === needle) {
+      const valueStart = m.index + m[1].length + 1;
+      return { start: valueStart, end: valueStart + m[3].length };
+    }
+  }
+
+  const plainRe = /^([ \t]*[\w-]+:[ \t]+)(\S+)[ \t]*$/gm;
+  while ((m = plainRe.exec(frontmatter)) !== null) {
+    if (m[2] === needle) {
+      const valueStart = m.index + m[1].length;
+      return { start: valueStart, end: valueStart + m[2].length };
+    }
+  }
+
+  return null;
 }
 
 // ── .mdoc resolver ────────────────────────────────────────────────

--- a/test/fixtures/patcher/src/content/photos/duplicate-photo-2.md
+++ b/test/fixtures/patcher/src/content/photos/duplicate-photo-2.md
@@ -1,0 +1,4 @@
+---
+image: "/images/shared.jpg"
+caption: "Same image path as another fixture, for the ambiguous case."
+---

--- a/test/fixtures/patcher/src/content/photos/duplicate-photo.md
+++ b/test/fixtures/patcher/src/content/photos/duplicate-photo.md
@@ -1,0 +1,4 @@
+---
+image: "/images/shared.jpg"
+caption: "Same image path as another fixture, for the ambiguous case."
+---

--- a/test/fixtures/patcher/src/content/photos/hello-photo.md
+++ b/test/fixtures/patcher/src/content/photos/hello-photo.md
@@ -1,0 +1,6 @@
+---
+image: "/images/hello.svg"
+caption: "An example photo."
+publishDate: 2026-06-26T12:00:00.000Z
+tags: ["hello"]
+---

--- a/test/fixtures/patcher/src/content/photos/unquoted-photo.md
+++ b/test/fixtures/patcher/src/content/photos/unquoted-photo.md
@@ -1,0 +1,4 @@
+---
+image: /images/unquoted.png
+caption: "A photo with an unquoted frontmatter image path."
+---

--- a/test/patcher.test.js
+++ b/test/patcher.test.js
@@ -24,6 +24,63 @@ function makeEdit(overrides = {}) {
   };
 }
 
+// ── Content-frontmatter image resolver ────────────────────────────
+
+describe("frontmatter image resolver", () => {
+  it("quoted frontmatter value → returns correct {file, range, replacement}", async () => {
+    const result = await resolve(FIXTURE_ROOT, {
+      path: "/photos/hello-photo/",
+      selector: { tag: "IMG", classes: [], nthChild: 1, textContent: "/images/hello.svg" },
+      op: "replace-image-src",
+      value: { src: "/images/hello.webp", srcset: "" },
+    });
+    expect(result.refused).toBeUndefined();
+    expect(result.file).toBe("src/content/photos/hello-photo.md");
+    expect(result.replacement).toBe("/images/hello.webp");
+
+    const source = readFileSync(resolvePath(FIXTURE_ROOT, result.file), "utf-8");
+    const matched = source.slice(result.range.start, result.range.end);
+    expect(matched).toBe("/images/hello.svg");
+  });
+
+  it("unquoted plain-scalar frontmatter value → returns correct {file, range, replacement}", async () => {
+    const result = await resolve(FIXTURE_ROOT, {
+      path: "/photos/unquoted-photo/",
+      selector: { tag: "IMG", classes: [], nthChild: 1, textContent: "/images/unquoted.png" },
+      op: "replace-image-src",
+      value: { src: "/images/unquoted.webp", srcset: "" },
+    });
+    expect(result.refused).toBeUndefined();
+    expect(result.file).toBe("src/content/photos/unquoted-photo.md");
+
+    const source = readFileSync(resolvePath(FIXTURE_ROOT, result.file), "utf-8");
+    const matched = source.slice(result.range.start, result.range.end);
+    expect(matched).toBe("/images/unquoted.png");
+  });
+
+  it("no match in any content frontmatter → refuses with reason: no-match", async () => {
+    const result = await resolve(FIXTURE_ROOT, {
+      path: "/photos/hello-photo/",
+      selector: { tag: "IMG", classes: [], nthChild: 1, textContent: "/images/does-not-exist.svg" },
+      op: "replace-image-src",
+      value: { src: "/images/whatever.webp", srcset: "" },
+    });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("no-match");
+  });
+
+  it("value shared by two content files → refuses with reason: ambiguous", async () => {
+    const result = await resolve(FIXTURE_ROOT, {
+      path: "/photos/duplicate-photo/",
+      selector: { tag: "IMG", classes: [], nthChild: 1, textContent: "/images/shared.jpg" },
+      op: "replace-image-src",
+      value: { src: "/images/whatever.webp", srcset: "" },
+    });
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("ambiguous");
+  });
+});
+
 // ── .mdoc resolver ────────────────────────────────────────────────
 
 describe("mdoc resolver", () => {


### PR DESCRIPTION
## Summary

- \`apply_edit\`'s \`replace-image-src\` op always refused with \`no-match\` / "no .mdoc files found" against the stock template's example photo page, because none of the existing resolvers (\`.mdoc\`, Keystatic, \`.astro\`) can patch an image whose \`src\` comes from Markdown/MDX **frontmatter** rendered through a dynamic expression (e.g. \`<img src={d.image} />\` in \`Hentry.astro\`).
- Adds \`resolveFrontmatterImage\` to \`server/patcher.mjs\`'s resolver chain: for \`replace-image-src\` edits, it scans \`.md\`/\`.mdx\` files under \`src/content\` for a top-level frontmatter field (quoted or plain-scalar) whose *value* matches the drop target's current \`src\`, and patches just that value in place. Matches on value, not field name, since different content collections use different keys.
- No MCP schema change — reuses the existing \`replace-image-src\` op and payload shape.

## Paired PR check

- [x] This change is **self-contained** to the plugin (skills / hooks / template / docs / MCP server with no consumer-visible contract change).
- [ ] This change **needs a paired PR** in `Anglesite/Anglesite-app`.

## Test plan

- [x] Plugin self-checks pass (`npm test` — 3158 passed, 1 pre-existing unrelated failure in `test/optimize-images-packaging.test.js` due to a missing `tsx` binary in this fresh worktree, not touched by this change)
- [x] Added `test/fixtures/patcher/src/content/photos/*.md` fixtures and `describe("frontmatter image resolver", …)` in `test/patcher.test.js` covering: quoted value match, unquoted plain-scalar match, no-match refusal, and ambiguous refusal (two files sharing the same image value)
- [ ] If touching the MCP server: paired app PR exercises the new/changed messages — N/A, no schema/op change

Closes Anglesite/Anglesite#1421